### PR TITLE
fix: update read_int32 to handle negative integers correctly

### DIFF
--- a/lib/src/lib/reader.mbt
+++ b/lib/src/lib/reader.mbt
@@ -86,7 +86,8 @@ fn[T : Reader] read_varint64(reader : T) -> UInt64 raise ReaderError {
 
 ///|
 pub fn[T : Reader] read_int32(reader : T) -> Int raise ReaderError {
-  reader |> read_varint32() |> UInt::reinterpret_as_int
+  // if integer is negative, varint32 is encoded as 10 bytes
+  reader |> read_varint64() |> UInt64::to_int() 
 }
 
 ///|

--- a/lib/src/lib/reader_test.mbt
+++ b/lib/src/lib/reader_test.mbt
@@ -37,11 +37,11 @@ test "integer/2" {
   assert_eq(r |> @lib.is_eof(), true)
 }
 
-test "panic integer" {
+test "integer/3" {
   let r = @lib.BytesReader::from_bytes(b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01")
     as &@lib.Reader
   assert_eq(r |> @lib.read_varint32() |> UInt::reinterpret_as_int, -1)
-  assert_eq(r |> @lib.is_eof(), true)
+  assert_eq(r |> @lib.is_eof(), false)
 }
 
 ///|

--- a/lib/src/lib/reader_test.mbt
+++ b/lib/src/lib/reader_test.mbt
@@ -37,6 +37,13 @@ test "integer/2" {
   assert_eq(r |> @lib.is_eof(), true)
 }
 
+test "panic integer" {
+  let r = @lib.BytesReader::from_bytes(b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01")
+    as &@lib.Reader
+  assert_eq(r |> @lib.read_varint32() |> UInt::reinterpret_as_int, -1)
+  assert_eq(r |> @lib.is_eof(), true)
+}
+
 ///|
 test "signed integer" {
   let r = @lib.BytesReader::from_bytes(b"\x00") as &@lib.Reader

--- a/lib/src/lib/reader_test.mbt
+++ b/lib/src/lib/reader_test.mbt
@@ -28,6 +28,15 @@ test "integer" {
   assert_eq(r |> @lib.read_int64(), -2)
 }
 
+test "integer/2" {
+  let r = @lib.BytesReader::from_bytes(
+      b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01",
+    )
+    as &@lib.Reader
+  assert_eq(r |> @lib.read_int32(), -1)
+  assert_eq(r |> @lib.is_eof(), true)
+}
+
 ///|
 test "signed integer" {
   let r = @lib.BytesReader::from_bytes(b"\x00") as &@lib.Reader


### PR DESCRIPTION
https://protobuf.dev/programming-guides/encoding/#signed-ints

> The intN types encode negative numbers as two’s complement, which means that, as unsigned, 64-bit integers, they have their highest bit set. As a result, this means that all ten bytes must be used. For example, -2 is converted by protoscope into
 >   ```
 >   11111110 11111111 11111111 11111111 11111111
 >   11111111 11111111 11111111 11111111 00000001
 >   ```