### PR TITLE
feat: generator support sync/async

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You can pass project parameters using `--mbt_opt`, separated by commas:
 | Name          | Type    | Description                                   | Default Value         |
 |---------------|---------|-----------------------------------------------|----------------------|
 | json          | bool    | Generate additional `JSON` serialization code   | true            |
+| async         | bool    | Generate async read/write code                 | true                 |
 | username      | string  | Username to be used in `moon.mod.json`        | username    |
 | project_name  | string  | Project name to be used in `moon.mod.json` & `moon.pkg.json`     | protoc-gen-mbt    |
 

--- a/cli/src/generator.mbt
+++ b/cli/src/generator.mbt
@@ -41,6 +41,11 @@ fn CodeGenerator::support_json(self : CodeGenerator) -> Bool {
 }
 
 ///|
+fn CodeGenerator::support_async(self : CodeGenerator) -> Bool {
+  self.parameter.get_or_default("async", "true") == "true"
+}
+
+///|
 fn CodeGenerator::find_enum(self : CodeGenerator, type_name : String) -> Enum? {
   for name, pkg in self.package_dictionary {
     let name = name.trim_start(".")

--- a/cli/src/main.mbt
+++ b/cli/src/main.mbt
@@ -75,7 +75,7 @@ async fn parse_request(
   loop_ : @uv.Loop,
 ) -> @compiler.CodeGeneratorResponse noraise {
   let reader = Stdin::{ loop_, file: @uv.stdin() }
-  let request = @compiler.CodeGeneratorRequest::read(reader) catch {
+  let request = @compiler.CodeGeneratorRequest::async_read(reader) catch {
     err => {
       let response = @compiler.CodeGeneratorResponse::default()
       response.supported_features = Some(1)
@@ -103,5 +103,5 @@ async fn output_response(
   loop_ : @uv.Loop,
 ) -> Unit raise {
   let stdout = Stdout::{ loop_, file: @uv.stdout() }
-  response.write(stdout)
+  response.async_write(stdout)
 }

--- a/cli/src/template.mbt
+++ b/cli/src/template.mbt
@@ -185,7 +185,7 @@ fn CodeGenerator::get_moonbit_type(
         }
         return message_path.path() |> to_camel_case
       }
-      "UNDEFINED_MESSAGE"
+      raise UnsupportedType("Message \{message_name} not found")
     }
     FieldType::TYPE_BYTES => "Bytes"
     FieldType::TYPE_UINT32 => "UInt"
@@ -198,7 +198,7 @@ fn CodeGenerator::get_moonbit_type(
         }
         return path.path() |> to_camel_case
       }
-      "UNDEFINED_ENUM"
+      raise UnsupportedType("Enum \{enum_name} not found")
     }
     FieldType::TYPE_SFIXED32 => "Int"
     FieldType::TYPE_SFIXED64 => "Int64"

--- a/cli/src/template.mbt
+++ b/cli/src/template.mbt
@@ -275,8 +275,8 @@ fn CodeGenerator::gen_message(
     self.gen_message_json(message, file)
   }
   if self.support_async() {
-    self.gen_message_reader(message, file, async_="async")
-    self.gen_message_writer(message, file, async_="async")
+    self.gen_message_reader(message, file, is_async=true)
+    self.gen_message_writer(message, file, is_async=true)
   }
 }
 
@@ -839,18 +839,20 @@ fn gen_message_reader(
   self : CodeGenerator,
   message : Message,
   content : StringBuilder,
-  async_~ : String = "",
+  is_async~ : Bool = false,
 ) -> Unit raise {
   let message_name = message.import_path.path() |> to_camel_case
-  let async_snake = async_ |> pascal_to_snake
+  let async_keyword = if is_async { "async" } else { "" }
+  let async_keyword_to_snake = async_keyword |> pascal_to_snake
+  let async_keyword_to_title = async_keyword |> title
   if message.fields.is_empty() {
     content.write_string(
       (
-        $|pub \{async_} fn[R] \{message_name}::\{async_snake}read(reader : R) -> \{message_name} noraise {
+        $|pub \{async_keyword} fn[R] \{message_name}::\{async_keyword_to_snake}read(reader : R) -> \{message_name} noraise {
         #|  let reader = @protobuf.LimitedReader::new(reader)
-        $|  \{message_name}::\{async_snake}read_with_limit(reader)
+        $|  \{message_name}::\{async_keyword_to_snake}read_with_limit(reader)
         #|}
-        $|pub \{async_} fn[R] \{message_name}::\{async_snake}read_with_limit(_ : @protobuf.LimitedReader[R], _limit ?: Int) -> \{message_name} noraise {
+        $|pub \{async_keyword} fn[R] \{message_name}::\{async_keyword_to_snake}read_with_limit(_ : @protobuf.LimitedReader[R], _limit ?: Int) -> \{message_name} noraise {
         $|  \{message_name}::default()
         #|}
         #|
@@ -860,11 +862,11 @@ fn gen_message_reader(
   }
   content.write_string(
     (
-      $|pub \{async_} fn[R: @protobuf.\{async_ |> title}Reader] \{message_name}::\{async_snake}read(reader : R) -> \{message_name} raise {
+      $|pub \{async_keyword} fn[R: @protobuf.\{async_keyword_to_title}Reader] \{message_name}::\{async_keyword_to_snake}read(reader : R) -> \{message_name} raise {
       #|  let reader = @protobuf.LimitedReader::new(reader)
-      $|  \{message_name}::\{async_snake}read_with_limit(reader)
+      $|  \{message_name}::\{async_keyword_to_snake}read_with_limit(reader)
       #|}
-      $|pub \{async_} fn[R: @protobuf.\{async_ |> title}Reader] \{message_name}::\{async_snake}read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> \{message_name} raise {
+      $|pub \{async_keyword} fn[R: @protobuf.\{async_keyword_to_title}Reader] \{message_name}::\{async_keyword_to_snake}read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> \{message_name} raise {
       #|  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
       #|    if l < limit { raise @protobuf.EndOfStream }
       #|    Some(l - limit)
@@ -878,14 +880,19 @@ fn gen_message_reader(
     (
       #|  try {
       #|    for {
-      $|      match (reader |> @protobuf.\{async_ |> pascal_to_snake}read_tag()) {\n
+      $|      match (reader |> @protobuf.\{async_keyword_to_snake}read_tag()) {\n
     ),
   )
   for field in message.fields {
     if field.is_list() {
-      self.gen_repeated_field_read(field, message.import_path, content, async_~)
+      self.gen_repeated_field_read(
+        field,
+        message.import_path,
+        content,
+        is_async~,
+      )
     } else {
-      self.gen_field_read(field, message.import_path, content, async_~)
+      self.gen_field_read(field, message.import_path, content, is_async~)
     }
   }
   for oneof in message.oneofs {
@@ -899,13 +906,13 @@ fn gen_message_reader(
         parent_path=message.import_path,
       )
       content.write_string(
-        "        (\{field_number}, _) => msg.\{oneof_field_name} = \{gen_kind_read(field.type_.unwrap(), type_name, async_=async_)} |> \{oneof_name}::\{field_name}\n",
+        "        (\{field_number}, _) => msg.\{oneof_field_name} = \{gen_kind_read(field.type_.unwrap(), type_name, is_async~)} |> \{oneof_name}::\{field_name}\n",
       )
     }
   }
   content.write_string(
     (
-      $|       (_, wire) => reader |> @protobuf.\{async_ |> pascal_to_snake}read_unknown(wire)
+      $|       (_, wire) => reader |> @protobuf.\{async_keyword |> pascal_to_snake}read_unknown(wire)
       #|      }
       #|    }
       #|  } catch {
@@ -926,10 +933,11 @@ fn gen_repeated_field_read(
   field : Field,
   parent_path : ImportPath,
   content : StringBuilder,
-  async_~ : String = "",
+  is_async~ : Bool = false,
 ) -> Unit raise {
   let kind = field.type_.unwrap()
-  let async_snake = async_ |> pascal_to_snake
+  let async_keyword = if is_async { "async" } else { "" }
+  let async_keyword_to_snake = async_keyword |> pascal_to_snake
   let field_number = field.number.unwrap()
   let field_name = field.import_path.name() |> pascal_to_snake
   let mut name = ""
@@ -946,7 +954,7 @@ fn gen_repeated_field_read(
       | FieldType::TYPE_SINT32
       | FieldType::TYPE_SINT64 =>
         content.write_string(
-          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.\{async_snake}read_packed(\{kind_read_func(kind, async_=async_)}, None)).iter()) }\n",
+          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.\{async_keyword_to_snake}read_packed(\{kind_read_func(kind, is_async~)}, None)).iter()) }\n",
         )
 
       // I64
@@ -954,7 +962,7 @@ fn gen_repeated_field_read(
       | FieldType::TYPE_FIXED64
       | FieldType::TYPE_DOUBLE =>
         content.write_string(
-          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.\{async_snake}read_packed(\{kind_read_func(kind, async_=async_)}, Some(8))).iter()) }\n",
+          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.\{async_keyword_to_snake}read_packed(\{kind_read_func(kind, is_async~)}, Some(8))).iter()) }\n",
         )
 
       // I32
@@ -962,17 +970,17 @@ fn gen_repeated_field_read(
       | FieldType::TYPE_FIXED32
       | FieldType::TYPE_FLOAT =>
         content.write_string(
-          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.\{async_snake}read_packed(\{kind_read_func(kind, async_=async_)}, Some(4))).iter()) }\n",
+          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.\{async_keyword_to_snake}read_packed(\{kind_read_func(kind, is_async~)}, Some(4))).iter()) }\n",
         )
       _ => raise UnexpectedType("Packed field type: \{kind}")
     }
   } else if field.map_key_value() is Some(_) {
     content.write_string(
-      "      (\{field_number}, _) => { let {key, value} = \{gen_kind_read(kind, name, async_=async_)}; msg.\{field_name}[key] = value }\n",
+      "      (\{field_number}, _) => { let {key, value} = \{gen_kind_read(kind, name, is_async~)}; msg.\{field_name}[key] = value }\n",
     )
   } else {
     content.write_string(
-      "      (\{field_number}, _) => msg.\{field_name}.push(\{gen_kind_read(kind, name, async_=async_)})\n",
+      "      (\{field_number}, _) => msg.\{field_name}.push(\{gen_kind_read(kind, name, is_async~)})\n",
     )
   }
 }
@@ -983,7 +991,7 @@ fn gen_field_read(
   field : Field,
   parent_path : ImportPath,
   content : StringBuilder,
-  async_~ : String = "",
+  is_async~ : Bool = false,
 ) -> Unit raise {
   let field_name = field.import_path.name() |> pascal_to_snake
   let field_number = field.number.unwrap()
@@ -995,29 +1003,29 @@ fn gen_field_read(
     ""
   }
   content.write_string(
-    "      (\{field_number}, _) => msg.\{field_name} = \{gen_kind_read(kind, type_name, async_=async_)}\{optional_constructor}\n",
+    "      (\{field_number}, _) => msg.\{field_name} = \{gen_kind_read(kind, type_name, is_async~)}\{optional_constructor}\n",
   )
 }
 
 ///|
-fn kind_read_func(kind : FieldType, async_~ : String = "") -> String raise {
-  let async_ = async_ |> pascal_to_snake
+fn kind_read_func(kind : FieldType, is_async~ : Bool = false) -> String raise {
+  let async_keyword = if is_async { "async_" } else { "" }
   match kind {
-    FieldType::TYPE_BOOL => "@protobuf.\{async_}read_bool"
-    FieldType::TYPE_INT32 => "@protobuf.\{async_}read_int32"
-    FieldType::TYPE_INT64 => "@protobuf.\{async_}read_int64"
-    FieldType::TYPE_SINT32 => "@protobuf.\{async_}read_sint32"
-    FieldType::TYPE_SINT64 => "@protobuf.\{async_}read_sint64"
-    FieldType::TYPE_UINT32 => "@protobuf.\{async_}read_uint32"
-    FieldType::TYPE_UINT64 => "@protobuf.\{async_}read_uint64"
-    FieldType::TYPE_FIXED32 => "@protobuf.\{async_}read_fixed32"
-    FieldType::TYPE_FIXED64 => "@protobuf.\{async_}read_fixed64"
-    FieldType::TYPE_SFIXED32 => "@protobuf.\{async_}read_sfixed32"
-    FieldType::TYPE_SFIXED64 => "@protobuf.\{async_}read_sfixed64"
-    FieldType::TYPE_FLOAT => "@protobuf.\{async_}read_float"
-    FieldType::TYPE_DOUBLE => "@protobuf.\{async_}read_double"
-    FieldType::TYPE_STRING => "@protobuf.\{async_}read_string"
-    FieldType::TYPE_BYTES => "@protobuf.\{async_}read_bytes"
+    FieldType::TYPE_BOOL => "@protobuf.\{async_keyword}read_bool"
+    FieldType::TYPE_INT32 => "@protobuf.\{async_keyword}read_int32"
+    FieldType::TYPE_INT64 => "@protobuf.\{async_keyword}read_int64"
+    FieldType::TYPE_SINT32 => "@protobuf.\{async_keyword}read_sint32"
+    FieldType::TYPE_SINT64 => "@protobuf.\{async_keyword}read_sint64"
+    FieldType::TYPE_UINT32 => "@protobuf.\{async_keyword}read_uint32"
+    FieldType::TYPE_UINT64 => "@protobuf.\{async_keyword}read_uint64"
+    FieldType::TYPE_FIXED32 => "@protobuf.\{async_keyword}read_fixed32"
+    FieldType::TYPE_FIXED64 => "@protobuf.\{async_keyword}read_fixed64"
+    FieldType::TYPE_SFIXED32 => "@protobuf.\{async_keyword}read_sfixed32"
+    FieldType::TYPE_SFIXED64 => "@protobuf.\{async_keyword}read_sfixed64"
+    FieldType::TYPE_FLOAT => "@protobuf.\{async_keyword}read_float"
+    FieldType::TYPE_DOUBLE => "@protobuf.\{async_keyword}read_double"
+    FieldType::TYPE_STRING => "@protobuf.\{async_keyword}read_string"
+    FieldType::TYPE_BYTES => "@protobuf.\{async_keyword}read_bytes"
     FieldType::TYPE_ENUM => raise UnsupportedType("Enum type: \{kind}")
     FieldType::TYPE_MESSAGE => raise UnexpectedType("Message type: \{kind}")
     FieldType::TYPE_GROUP => raise UnsupportedType("Group")
@@ -1028,9 +1036,9 @@ fn kind_read_func(kind : FieldType, async_~ : String = "") -> String raise {
 fn gen_kind_read(
   field_type : FieldType,
   type_name : String,
-  async_~ : String = "",
+  is_async~ : Bool = false,
 ) -> String raise {
-  let async_ = async_ |> pascal_to_snake
+  let async_keyword = if is_async { "async_" } else { "" }
   match field_type {
     FieldType::TYPE_BOOL
     | FieldType::TYPE_INT32
@@ -1045,19 +1053,19 @@ fn gen_kind_read(
     | FieldType::TYPE_DOUBLE
     | FieldType::TYPE_STRING
     | FieldType::TYPE_BYTES =>
-      "reader |> \{kind_read_func(field_type, async_~)}()"
+      "reader |> \{kind_read_func(field_type, is_async~)}()"
     FieldType::TYPE_SINT32 | FieldType::TYPE_SINT64 =>
-      "(reader |> \{kind_read_func(field_type, async_~)}()).inner()"
+      "(reader |> \{kind_read_func(field_type, is_async~)}()).inner()"
     FieldType::TYPE_ENUM =>
-      "reader |> @protobuf.\{async_}read_enum() |> \{type_name}::from_enum"
+      "reader |> @protobuf.\{async_keyword}read_enum() |> \{type_name}::from_enum"
     FieldType::TYPE_MESSAGE =>
       (
         #|  {
-        $|    let len = reader |> @protobuf.\{async_}read_int32()
+        $|    let len = reader |> @protobuf.\{async_keyword}read_int32()
         #|    if len == 0 {
         $|      \{type_name}::default()
         #|    } else {
-        $|      \{type_name}::\{async_}read_with_limit(reader, limit=len)
+        $|      \{type_name}::\{async_keyword}read_with_limit(reader, limit=len)
         $|    }
         #|  }
       )
@@ -1070,14 +1078,17 @@ fn gen_message_writer(
   self : CodeGenerator,
   message : Message,
   content : StringBuilder,
-  async_~ : String = "",
+  is_async~ : Bool = false,
 ) -> Unit raise {
   let message_name = message.import_path.path() |> to_camel_case
-  let async_snake = async_ |> pascal_to_snake
+  // let async_snake = is_async |> pascal_to_snake
+  let async_keyword = if is_async { "async" } else { "" }
+  let async_keyword_to_snake = async_keyword |> pascal_to_snake
+  let async_keyword_to_title = async_keyword |> title
   if message.fields.is_empty() {
     content.write_string(
       (
-        $|pub \{async_} fn[W: @protobuf.\{async_ |> title}Writer] \{message_name}::\{async_snake}write(_: Self, _ : W) -> Unit noraise {
+        $|pub \{async_keyword} fn[W: @protobuf.\{async_keyword_to_title}Writer] \{message_name}::\{async_keyword_to_snake}write(_: Self, _ : W) -> Unit noraise {
         $|}
         $|
       ),
@@ -1085,7 +1096,7 @@ fn gen_message_writer(
     return
   }
   content.write_string(
-    "pub \{async_} fn[W: @protobuf.\{async_ |> title}Writer] \{message_name}::\{async_snake}write(self:Self, writer : W) -> Unit raise {\n",
+    "pub \{async_keyword} fn[W: @protobuf.\{async_keyword_to_title}Writer] \{message_name}::\{async_keyword_to_snake}write(self:Self, writer : W) -> Unit raise {\n",
   )
   for field in message.fields {
     let field_name = field.import_path.name() |> pascal_to_snake
@@ -1093,7 +1104,7 @@ fn gen_message_writer(
     if field.is_pack() {
       let tag_val = tag(field.type_.unwrap(), field_number, true)
       content.write_string(
-        "  writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL)\n",
+        "  writer |> @protobuf.\{async_keyword_to_snake}write_varint(\{tag_val}UL)\n",
       )
       match field.type_.unwrap() {
         FieldType::TYPE_FIXED32
@@ -1125,14 +1136,10 @@ fn gen_message_writer(
           )
         _ => raise UnexpectedType("packed field type: \{field.type_}")
       }
-      let field_write_type = self.gen_kind_write(
-        field,
-        "item",
-        async_=async_snake,
-      )
+      let field_write_type = self.gen_kind_write(field, "item", is_async~)
       content.write_string(
         (
-          $|  writer |> @protobuf.\{async_snake}write_uint32(size)
+          $|  writer |> @protobuf.\{async_keyword_to_snake}write_uint32(size)
           $|  for item in self.\{field_name} {
           $|      \{field_write_type}
           $|  }
@@ -1149,7 +1156,7 @@ fn gen_message_writer(
           #|  for i in 0..<keys.length() {
           #|    let k = keys[i]
           $|    let v = self.\{field_name}.get(k).unwrap()
-          $|    writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL)
+          $|    writer |> @protobuf.\{async_keyword_to_snake}write_varint(\{tag_val}UL)
           $|
         ),
       )
@@ -1223,22 +1230,14 @@ fn gen_message_writer(
       }
       let key_tag_val = tag(key_field.type_.unwrap(), 1, false)
       let value_tag_val = tag(value_field.type_.unwrap(), 2, false)
-      let field_write_type_k = self.gen_kind_write(
-        key_field,
-        "k",
-        async_=async_snake,
-      )
-      let field_write_type_v = self.gen_kind_write(
-        value_field,
-        "v",
-        async_=async_snake,
-      )
+      let field_write_type_k = self.gen_kind_write(key_field, "k", is_async~)
+      let field_write_type_v = self.gen_kind_write(value_field, "v", is_async~)
       content.write_string(
         (
-          $|    writer |> @protobuf.\{async_snake}write_uint32(key_size + value_size)
-          $|    writer |> @protobuf.\{async_snake}write_varint(\{key_tag_val}UL)
+          $|    writer |> @protobuf.\{async_keyword_to_snake}write_uint32(key_size + value_size)
+          $|    writer |> @protobuf.\{async_keyword_to_snake}write_varint(\{key_tag_val}UL)
           $|    \{field_write_type_k}
-          $|    writer |> @protobuf.\{async_snake}write_varint(\{value_tag_val}UL);
+          $|    writer |> @protobuf.\{async_keyword_to_snake}write_varint(\{value_tag_val}UL);
           $|    \{field_write_type_v}
           $|  }
           $| 
@@ -1246,28 +1245,24 @@ fn gen_message_writer(
       )
     } else if field.is_list() {
       let tag_val = tag(field.type_.unwrap(), field_number, false)
-      let field_write_type = self.gen_kind_write(
-        field,
-        "item",
-        async_=async_snake,
-      )
+      let field_write_type = self.gen_kind_write(field, "item", is_async~)
       content.write_string(
         (
           $|  for item in self.\{field_name} {
-          $|    writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL)
+          $|    writer |> @protobuf.\{async_keyword_to_snake}write_varint(\{tag_val}UL)
           $|    \{field_write_type}
           $|  }
           $|
         ),
       )
     } else if field.is_optional() {
-      let field_write_type = self.gen_kind_write(field, "v", async_=async_snake)
+      let field_write_type = self.gen_kind_write(field, "v", is_async~)
       let tag_val = tag(field.type_.unwrap(), field_number, false)
       content.write_string(
         (
           $|  match self.\{field_name} {
           $|    Some(v) => {
-          $|      writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL);
+          $|      writer |> @protobuf.\{async_keyword_to_snake}write_varint(\{tag_val}UL);
           $|      \{field_write_type}
           $|    }
           $|    None => ()
@@ -1279,12 +1274,12 @@ fn gen_message_writer(
       let field_write_type = self.gen_kind_write(
         field,
         "self.\{field_name}",
-        async_=async_snake,
+        is_async~,
       )
       let tag_val = tag(field.type_.unwrap(), field_number, false)
       content.write_string(
         (
-          $|  writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL);
+          $|  writer |> @protobuf.\{async_keyword_to_snake}write_varint(\{tag_val}UL);
           $|  \{field_write_type}
         ),
       )
@@ -1298,11 +1293,11 @@ fn gen_message_writer(
       let field_name = field.import_path.name() |> to_camel_case
       let field_number = field.number.unwrap()
       let tag_val = tag(field.type_.unwrap(), field_number, false)
-      let field_write_type = self.gen_kind_write(field, "v", async_=async_snake)
+      let field_write_type = self.gen_kind_write(field, "v", is_async~)
       content.write_string(
         (
           $|    \{oneof_name}::\{field_name}(v) => {
-          $|      writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL)
+          $|      writer |> @protobuf.\{async_keyword_to_snake}write_varint(\{tag_val}UL)
           $|      \{field_write_type}
           $|     }
           $|
@@ -1325,46 +1320,47 @@ fn CodeGenerator::gen_kind_write(
   _ : CodeGenerator,
   field : Field,
   variable : String,
-  async_~ : String = "",
+  is_async~ : Bool = false,
 ) -> String raise {
   guard field.type_ is Some(field_type) else {
     raise UnexpectedType("Field type is not set: \{field.import_path.name()}")
   }
+  let async_keyword = if is_async { "async_" } else { "" }
   match field_type {
     FieldType::TYPE_STRING =>
-      "writer |> @protobuf.\{async_}write_string(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_string(\{variable})\n"
     FieldType::TYPE_BYTES =>
-      "writer |> @protobuf.\{async_}write_bytes(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_bytes(\{variable})\n"
     FieldType::TYPE_MESSAGE =>
-      "writer |> @protobuf.\{async_}write_uint32(@protobuf.size_of(\{variable})); \{variable}.\{async_}write(writer)\n"
+      "writer |> @protobuf.\{async_keyword}write_uint32(@protobuf.size_of(\{variable})); \{variable}.\{async_keyword}write(writer)\n"
     FieldType::TYPE_FIXED32 =>
-      "writer |> @protobuf.\{async_}write_fixed32(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_fixed32(\{variable})\n"
     FieldType::TYPE_SFIXED32 =>
-      "writer |> @protobuf.\{async_}write_sfixed32(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_sfixed32(\{variable})\n"
     FieldType::TYPE_FLOAT =>
-      "writer |> @protobuf.\{async_}write_float(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_float(\{variable})\n"
     FieldType::TYPE_FIXED64 =>
-      "writer |> @protobuf.\{async_}write_fixed64(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_fixed64(\{variable})\n"
     FieldType::TYPE_SFIXED64 =>
-      "writer |> @protobuf.\{async_}write_sfixed64(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_sfixed64(\{variable})\n"
     FieldType::TYPE_DOUBLE =>
-      "writer |> @protobuf.\{async_}write_double(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_double(\{variable})\n"
     FieldType::TYPE_BOOL =>
-      "writer |> @protobuf.\{async_}write_bool(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_bool(\{variable})\n"
     FieldType::TYPE_INT32 =>
-      "writer |> @protobuf.\{async_}write_int32(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_int32(\{variable})\n"
     FieldType::TYPE_INT64 =>
-      "writer |> @protobuf.\{async_}write_int64(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_int64(\{variable})\n"
     FieldType::TYPE_SINT32 =>
-      "writer |> @protobuf.\{async_}write_sint32(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_sint32(\{variable})\n"
     FieldType::TYPE_SINT64 =>
-      "writer |> @protobuf.\{async_}write_sint64(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_sint64(\{variable})\n"
     FieldType::TYPE_UINT32 =>
-      "writer |> @protobuf.\{async_}write_uint32(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_uint32(\{variable})\n"
     FieldType::TYPE_UINT64 =>
-      "writer |> @protobuf.\{async_}write_uint64(\{variable})\n"
+      "writer |> @protobuf.\{async_keyword}write_uint64(\{variable})\n"
     FieldType::TYPE_ENUM =>
-      "writer |> @protobuf.\{async_}write_enum(\{variable}.to_enum())\n"
+      "writer |> @protobuf.\{async_keyword}write_enum(\{variable}.to_enum())\n"
     _ =>
       raise UnexpectedType(
         "Unsupported field type: \{field_type} for field \{field.import_path.name()}",

--- a/cli/src/template.mbt
+++ b/cli/src/template.mbt
@@ -274,6 +274,10 @@ fn CodeGenerator::gen_message(
   if self.support_json() {
     self.gen_message_json(message, file)
   }
+  if self.support_async() {
+    self.gen_message_reader(message, file, async_="async")
+    self.gen_message_writer(message, file, async_="async")
+  }
 }
 
 ///|
@@ -835,16 +839,18 @@ fn gen_message_reader(
   self : CodeGenerator,
   message : Message,
   content : StringBuilder,
+  async_~ : String = "",
 ) -> Unit raise {
   let message_name = message.import_path.path() |> to_camel_case
+  let async_snake = async_ |> pascal_to_snake
   if message.fields.is_empty() {
     content.write_string(
       (
-        $|pub async fn[R] \{message_name}::read(reader : R) -> \{message_name} noraise {
+        $|pub \{async_} fn[R] \{message_name}::\{async_snake}read(reader : R) -> \{message_name} noraise {
         #|  let reader = @protobuf.LimitedReader::new(reader)
-        $|  \{message_name}::read_with_limit(reader)
+        $|  \{message_name}::\{async_snake}read_with_limit(reader)
         #|}
-        $|pub async fn[R] \{message_name}::read_with_limit(_ : @protobuf.LimitedReader[R], _limit ?: Int) -> \{message_name} noraise {
+        $|pub \{async_} fn[R] \{message_name}::\{async_snake}read_with_limit(_ : @protobuf.LimitedReader[R], _limit ?: Int) -> \{message_name} noraise {
         $|  \{message_name}::default()
         #|}
         #|
@@ -854,11 +860,11 @@ fn gen_message_reader(
   }
   content.write_string(
     (
-      $|pub async fn[R: @protobuf.AsyncReader] \{message_name}::read(reader : R) -> \{message_name} raise {
+      $|pub \{async_} fn[R: @protobuf.\{async_ |> title}Reader] \{message_name}::\{async_snake}read(reader : R) -> \{message_name} raise {
       #|  let reader = @protobuf.LimitedReader::new(reader)
-      $|  \{message_name}::read_with_limit(reader)
+      $|  \{message_name}::\{async_snake}read_with_limit(reader)
       #|}
-      $|pub async fn[R: @protobuf.AsyncReader] \{message_name}::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> \{message_name} raise {
+      $|pub \{async_} fn[R: @protobuf.\{async_ |> title}Reader] \{message_name}::\{async_snake}read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> \{message_name} raise {
       #|  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
       #|    if l < limit { raise @protobuf.EndOfStream }
       #|    Some(l - limit)
@@ -872,14 +878,14 @@ fn gen_message_reader(
     (
       #|  try {
       #|    for {
-      $|      match (reader |> @protobuf.async_read_tag()) {\n
+      $|      match (reader |> @protobuf.\{async_ |> pascal_to_snake}read_tag()) {\n
     ),
   )
   for field in message.fields {
     if field.is_list() {
-      self.gen_repeated_field_read(field, message.import_path, content)
+      self.gen_repeated_field_read(field, message.import_path, content, async_~)
     } else {
-      self.gen_field_read(field, message.import_path, content)
+      self.gen_field_read(field, message.import_path, content, async_~)
     }
   }
   for oneof in message.oneofs {
@@ -893,13 +899,13 @@ fn gen_message_reader(
         parent_path=message.import_path,
       )
       content.write_string(
-        "        (\{field_number}, _) => msg.\{oneof_field_name} = \{gen_kind_read(field.type_.unwrap(), type_name)} |> \{oneof_name}::\{field_name}\n",
+        "        (\{field_number}, _) => msg.\{oneof_field_name} = \{gen_kind_read(field.type_.unwrap(), type_name, async_=async_)} |> \{oneof_name}::\{field_name}\n",
       )
     }
   }
   content.write_string(
     (
-      #|       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      $|       (_, wire) => reader |> @protobuf.\{async_ |> pascal_to_snake}read_unknown(wire)
       #|      }
       #|    }
       #|  } catch {
@@ -920,8 +926,10 @@ fn gen_repeated_field_read(
   field : Field,
   parent_path : ImportPath,
   content : StringBuilder,
+  async_~ : String = "",
 ) -> Unit raise {
   let kind = field.type_.unwrap()
+  let async_snake = async_ |> pascal_to_snake
   let field_number = field.number.unwrap()
   let field_name = field.import_path.name() |> pascal_to_snake
   let mut name = ""
@@ -938,7 +946,7 @@ fn gen_repeated_field_read(
       | FieldType::TYPE_SINT32
       | FieldType::TYPE_SINT64 =>
         content.write_string(
-          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.async_read_packed(\{kind_read_func(kind)}, None)).iter()) }\n",
+          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.\{async_snake}read_packed(\{kind_read_func(kind, async_=async_)}, None)).iter()) }\n",
         )
 
       // I64
@@ -946,7 +954,7 @@ fn gen_repeated_field_read(
       | FieldType::TYPE_FIXED64
       | FieldType::TYPE_DOUBLE =>
         content.write_string(
-          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.async_read_packed(\{kind_read_func(kind)}, Some(8))).iter()) }\n",
+          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.\{async_snake}read_packed(\{kind_read_func(kind, async_=async_)}, Some(8))).iter()) }\n",
         )
 
       // I32
@@ -954,17 +962,17 @@ fn gen_repeated_field_read(
       | FieldType::TYPE_FIXED32
       | FieldType::TYPE_FLOAT =>
         content.write_string(
-          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.async_read_packed(\{kind_read_func(kind)}, Some(4))).iter()) }\n",
+          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @protobuf.\{async_snake}read_packed(\{kind_read_func(kind, async_=async_)}, Some(4))).iter()) }\n",
         )
       _ => raise UnexpectedType("Packed field type: \{kind}")
     }
   } else if field.map_key_value() is Some(_) {
     content.write_string(
-      "      (\{field_number}, _) => { let {key, value} = \{gen_kind_read(kind, name)}; msg.\{field_name}[key] = value }\n",
+      "      (\{field_number}, _) => { let {key, value} = \{gen_kind_read(kind, name, async_=async_)}; msg.\{field_name}[key] = value }\n",
     )
   } else {
     content.write_string(
-      "      (\{field_number}, _) => msg.\{field_name}.push(\{gen_kind_read(kind, name)})\n",
+      "      (\{field_number}, _) => msg.\{field_name}.push(\{gen_kind_read(kind, name, async_=async_)})\n",
     )
   }
 }
@@ -975,6 +983,7 @@ fn gen_field_read(
   field : Field,
   parent_path : ImportPath,
   content : StringBuilder,
+  async_~ : String = "",
 ) -> Unit raise {
   let field_name = field.import_path.name() |> pascal_to_snake
   let field_number = field.number.unwrap()
@@ -986,36 +995,42 @@ fn gen_field_read(
     ""
   }
   content.write_string(
-    "      (\{field_number}, _) => msg.\{field_name} = \{gen_kind_read(kind, type_name)}\{optional_constructor}\n",
+    "      (\{field_number}, _) => msg.\{field_name} = \{gen_kind_read(kind, type_name, async_=async_)}\{optional_constructor}\n",
   )
 }
 
 ///|
-fn kind_read_func(kind : FieldType) -> String raise {
+fn kind_read_func(kind : FieldType, async_~ : String = "") -> String raise {
+  let async_ = async_ |> pascal_to_snake
   match kind {
-    FieldType::TYPE_BOOL => "@protobuf.async_read_bool"
-    FieldType::TYPE_INT32 => "@protobuf.async_read_int32"
-    FieldType::TYPE_INT64 => "@protobuf.async_read_int64"
-    FieldType::TYPE_SINT32 => "@protobuf.async_read_sint32"
-    FieldType::TYPE_SINT64 => "@protobuf.async_read_sint64"
-    FieldType::TYPE_UINT32 => "@protobuf.async_read_uint32"
-    FieldType::TYPE_UINT64 => "@protobuf.async_read_uint64"
-    FieldType::TYPE_FIXED32 => "@protobuf.async_read_fixed32"
-    FieldType::TYPE_FIXED64 => "@protobuf.async_read_fixed64"
-    FieldType::TYPE_SFIXED32 => "@protobuf.async_read_sfixed32"
-    FieldType::TYPE_SFIXED64 => "@protobuf.async_read_sfixed64"
-    FieldType::TYPE_FLOAT => "@protobuf.async_read_float"
-    FieldType::TYPE_DOUBLE => "@protobuf.async_read_double"
-    FieldType::TYPE_STRING => "@protobuf.async_read_string"
-    FieldType::TYPE_BYTES => "@protobuf.async_read_bytes"
-    FieldType::TYPE_ENUM => "@protobuf.async_read_enum"
-    FieldType::TYPE_MESSAGE => "@protobuf.AsyncReader::read"
+    FieldType::TYPE_BOOL => "@protobuf.\{async_}read_bool"
+    FieldType::TYPE_INT32 => "@protobuf.\{async_}read_int32"
+    FieldType::TYPE_INT64 => "@protobuf.\{async_}read_int64"
+    FieldType::TYPE_SINT32 => "@protobuf.\{async_}read_sint32"
+    FieldType::TYPE_SINT64 => "@protobuf.\{async_}read_sint64"
+    FieldType::TYPE_UINT32 => "@protobuf.\{async_}read_uint32"
+    FieldType::TYPE_UINT64 => "@protobuf.\{async_}read_uint64"
+    FieldType::TYPE_FIXED32 => "@protobuf.\{async_}read_fixed32"
+    FieldType::TYPE_FIXED64 => "@protobuf.\{async_}read_fixed64"
+    FieldType::TYPE_SFIXED32 => "@protobuf.\{async_}read_sfixed32"
+    FieldType::TYPE_SFIXED64 => "@protobuf.\{async_}read_sfixed64"
+    FieldType::TYPE_FLOAT => "@protobuf.\{async_}read_float"
+    FieldType::TYPE_DOUBLE => "@protobuf.\{async_}read_double"
+    FieldType::TYPE_STRING => "@protobuf.\{async_}read_string"
+    FieldType::TYPE_BYTES => "@protobuf.\{async_}read_bytes"
+    FieldType::TYPE_ENUM => raise UnsupportedType("Enum type: \{kind}")
+    FieldType::TYPE_MESSAGE => raise UnexpectedType("Message type: \{kind}")
     FieldType::TYPE_GROUP => raise UnsupportedType("Group")
   }
 }
 
 ///|
-fn gen_kind_read(field_type : FieldType, type_name : String) -> String raise {
+fn gen_kind_read(
+  field_type : FieldType,
+  type_name : String,
+  async_~ : String = "",
+) -> String raise {
+  let async_ = async_ |> pascal_to_snake
   match field_type {
     FieldType::TYPE_BOOL
     | FieldType::TYPE_INT32
@@ -1029,19 +1044,20 @@ fn gen_kind_read(field_type : FieldType, type_name : String) -> String raise {
     | FieldType::TYPE_FLOAT
     | FieldType::TYPE_DOUBLE
     | FieldType::TYPE_STRING
-    | FieldType::TYPE_BYTES => "reader |> \{kind_read_func(field_type)}()"
+    | FieldType::TYPE_BYTES =>
+      "reader |> \{kind_read_func(field_type, async_~)}()"
     FieldType::TYPE_SINT32 | FieldType::TYPE_SINT64 =>
-      "(reader |> \{kind_read_func(field_type)}()).inner()"
+      "(reader |> \{kind_read_func(field_type, async_~)}()).inner()"
     FieldType::TYPE_ENUM =>
-      "reader |> @protobuf.async_read_enum() |> \{type_name}::from_enum"
+      "reader |> @protobuf.\{async_}read_enum() |> \{type_name}::from_enum"
     FieldType::TYPE_MESSAGE =>
       (
         #|  {
-        #|    let len = reader |> @protobuf.async_read_int32()
+        $|    let len = reader |> @protobuf.\{async_}read_int32()
         #|    if len == 0 {
         $|      \{type_name}::default()
         #|    } else {
-        $|      \{type_name}::read_with_limit(reader, limit=len)
+        $|      \{type_name}::\{async_}read_with_limit(reader, limit=len)
         $|    }
         #|  }
       )
@@ -1054,12 +1070,14 @@ fn gen_message_writer(
   self : CodeGenerator,
   message : Message,
   content : StringBuilder,
+  async_~ : String = "",
 ) -> Unit raise {
   let message_name = message.import_path.path() |> to_camel_case
+  let async_snake = async_ |> pascal_to_snake
   if message.fields.is_empty() {
     content.write_string(
       (
-        $|pub async fn[W] \{message_name}::write(_: Self, _ : W) -> Unit noraise {
+        $|pub \{async_} fn[W: @protobuf.\{async_ |> title}Writer] \{message_name}::\{async_snake}write(_: Self, _ : W) -> Unit noraise {
         $|}
         $|
       ),
@@ -1067,7 +1085,7 @@ fn gen_message_writer(
     return
   }
   content.write_string(
-    "pub async fn[W: @protobuf.AsyncWriter] \{message_name}::write(self:Self, writer : W) -> Unit raise {\n",
+    "pub \{async_} fn[W: @protobuf.\{async_ |> title}Writer] \{message_name}::\{async_snake}write(self:Self, writer : W) -> Unit raise {\n",
   )
   for field in message.fields {
     let field_name = field.import_path.name() |> pascal_to_snake
@@ -1075,7 +1093,7 @@ fn gen_message_writer(
     if field.is_pack() {
       let tag_val = tag(field.type_.unwrap(), field_number, true)
       content.write_string(
-        "  writer |> @protobuf.async_write_varint(\{tag_val}UL)\n",
+        "  writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL)\n",
       )
       match field.type_.unwrap() {
         FieldType::TYPE_FIXED32
@@ -1107,10 +1125,14 @@ fn gen_message_writer(
           )
         _ => raise UnexpectedType("packed field type: \{field.type_}")
       }
-      let field_write_type = self.gen_kind_write(field, "item")
+      let field_write_type = self.gen_kind_write(
+        field,
+        "item",
+        async_=async_snake,
+      )
       content.write_string(
         (
-          #|  writer |> @protobuf.async_write_uint32(size)
+          $|  writer |> @protobuf.\{async_snake}write_uint32(size)
           $|  for item in self.\{field_name} {
           $|      \{field_write_type}
           $|  }
@@ -1127,7 +1149,7 @@ fn gen_message_writer(
           #|  for i in 0..<keys.length() {
           #|    let k = keys[i]
           $|    let v = self.\{field_name}.get(k).unwrap()
-          $|    writer |> @protobuf.async_write_varint(\{tag_val}UL)
+          $|    writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL)
           $|
         ),
       )
@@ -1201,14 +1223,22 @@ fn gen_message_writer(
       }
       let key_tag_val = tag(key_field.type_.unwrap(), 1, false)
       let value_tag_val = tag(value_field.type_.unwrap(), 2, false)
-      let field_write_type_k = self.gen_kind_write(key_field, "k")
-      let field_write_type_v = self.gen_kind_write(value_field, "v")
+      let field_write_type_k = self.gen_kind_write(
+        key_field,
+        "k",
+        async_=async_snake,
+      )
+      let field_write_type_v = self.gen_kind_write(
+        value_field,
+        "v",
+        async_=async_snake,
+      )
       content.write_string(
         (
-          #|    writer |> @protobuf.async_write_uint32(key_size + value_size)
-          $|    writer |> @protobuf.async_write_varint(\{key_tag_val}UL)
+          $|    writer |> @protobuf.\{async_snake}write_uint32(key_size + value_size)
+          $|    writer |> @protobuf.\{async_snake}write_varint(\{key_tag_val}UL)
           $|    \{field_write_type_k}
-          $|    writer |> @protobuf.async_write_varint(\{value_tag_val}UL);
+          $|    writer |> @protobuf.\{async_snake}write_varint(\{value_tag_val}UL);
           $|    \{field_write_type_v}
           $|  }
           $| 
@@ -1216,24 +1246,28 @@ fn gen_message_writer(
       )
     } else if field.is_list() {
       let tag_val = tag(field.type_.unwrap(), field_number, false)
-      let field_write_type = self.gen_kind_write(field, "item")
+      let field_write_type = self.gen_kind_write(
+        field,
+        "item",
+        async_=async_snake,
+      )
       content.write_string(
         (
           $|  for item in self.\{field_name} {
-          $|    writer |> @protobuf.async_write_varint(\{tag_val}UL)
+          $|    writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL)
           $|    \{field_write_type}
           $|  }
           $|
         ),
       )
     } else if field.is_optional() {
-      let field_write_type = self.gen_kind_write(field, "v")
+      let field_write_type = self.gen_kind_write(field, "v", async_=async_snake)
       let tag_val = tag(field.type_.unwrap(), field_number, false)
       content.write_string(
         (
           $|  match self.\{field_name} {
           $|    Some(v) => {
-          $|      writer |> @protobuf.async_write_varint(\{tag_val}UL);
+          $|      writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL);
           $|      \{field_write_type}
           $|    }
           $|    None => ()
@@ -1242,11 +1276,15 @@ fn gen_message_writer(
         ),
       )
     } else {
-      let field_write_type = self.gen_kind_write(field, "self.\{field_name}")
+      let field_write_type = self.gen_kind_write(
+        field,
+        "self.\{field_name}",
+        async_=async_snake,
+      )
       let tag_val = tag(field.type_.unwrap(), field_number, false)
       content.write_string(
         (
-          $|  writer |> @protobuf.async_write_varint(\{tag_val}UL);
+          $|  writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL);
           $|  \{field_write_type}
         ),
       )
@@ -1260,11 +1298,11 @@ fn gen_message_writer(
       let field_name = field.import_path.name() |> to_camel_case
       let field_number = field.number.unwrap()
       let tag_val = tag(field.type_.unwrap(), field_number, false)
-      let field_write_type = self.gen_kind_write(field, "v")
+      let field_write_type = self.gen_kind_write(field, "v", async_=async_snake)
       content.write_string(
         (
           $|    \{oneof_name}::\{field_name}(v) => {
-          $|      writer |> @protobuf.async_write_varint(\{tag_val}UL)
+          $|      writer |> @protobuf.\{async_snake}write_varint(\{tag_val}UL)
           $|      \{field_write_type}
           $|     }
           $|
@@ -1287,45 +1325,46 @@ fn CodeGenerator::gen_kind_write(
   _ : CodeGenerator,
   field : Field,
   variable : String,
+  async_~ : String = "",
 ) -> String raise {
   guard field.type_ is Some(field_type) else {
     raise UnexpectedType("Field type is not set: \{field.import_path.name()}")
   }
   match field_type {
     FieldType::TYPE_STRING =>
-      "writer |> @protobuf.async_write_string(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_string(\{variable})\n"
     FieldType::TYPE_BYTES =>
-      "writer |> @protobuf.async_write_bytes(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_bytes(\{variable})\n"
     FieldType::TYPE_MESSAGE =>
-      "writer |> @protobuf.async_write_uint32(@protobuf.size_of(\{variable})); \{variable}.write(writer)\n"
+      "writer |> @protobuf.\{async_}write_uint32(@protobuf.size_of(\{variable})); \{variable}.\{async_}write(writer)\n"
     FieldType::TYPE_FIXED32 =>
-      "writer |> @protobuf.async_write_fixed32(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_fixed32(\{variable})\n"
     FieldType::TYPE_SFIXED32 =>
-      "writer |> @protobuf.async_write_sfixed32(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_sfixed32(\{variable})\n"
     FieldType::TYPE_FLOAT =>
-      "writer |> @protobuf.async_write_float(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_float(\{variable})\n"
     FieldType::TYPE_FIXED64 =>
-      "writer |> @protobuf.async_write_fixed64(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_fixed64(\{variable})\n"
     FieldType::TYPE_SFIXED64 =>
-      "writer |> @protobuf.async_write_sfixed64(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_sfixed64(\{variable})\n"
     FieldType::TYPE_DOUBLE =>
-      "writer |> @protobuf.async_write_double(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_double(\{variable})\n"
     FieldType::TYPE_BOOL =>
-      "writer |> @protobuf.async_write_bool(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_bool(\{variable})\n"
     FieldType::TYPE_INT32 =>
-      "writer |> @protobuf.async_write_int32(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_int32(\{variable})\n"
     FieldType::TYPE_INT64 =>
-      "writer |> @protobuf.async_write_int64(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_int64(\{variable})\n"
     FieldType::TYPE_SINT32 =>
-      "writer |> @protobuf.async_write_sint32(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_sint32(\{variable})\n"
     FieldType::TYPE_SINT64 =>
-      "writer |> @protobuf.async_write_sint64(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_sint64(\{variable})\n"
     FieldType::TYPE_UINT32 =>
-      "writer |> @protobuf.async_write_uint32(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_uint32(\{variable})\n"
     FieldType::TYPE_UINT64 =>
-      "writer |> @protobuf.async_write_uint64(\{variable})\n"
+      "writer |> @protobuf.\{async_}write_uint64(\{variable})\n"
     FieldType::TYPE_ENUM =>
-      "writer |> @protobuf.async_write_enum(\{variable}.to_enum())\n"
+      "writer |> @protobuf.\{async_}write_enum(\{variable}.to_enum())\n"
     _ =>
       raise UnexpectedType(
         "Unsupported field type: \{field_type} for field \{field.import_path.name()}",

--- a/cli/src/utils.mbt
+++ b/cli/src/utils.mbt
@@ -17,6 +17,47 @@ fn convert_args(args : String) -> Map[String, String] {
 }
 
 ///|
+fn title(s : String) -> String {
+  let sb = StringBuilder::new()
+  let mut is_word_start = true
+  for c in s {
+    if c == ' ' {
+      sb.write_char(' ')
+      is_word_start = true
+    } else if is_word_start {
+      sb.write_char(c.to_ascii_uppercase())
+      is_word_start = false
+    } else {
+      sb.write_char(c)
+    }
+  }
+  sb.to_string()
+}
+
+///|
+test "title" {
+  inspect(title("hello world"), content="Hello World")
+  inspect(title("the quick brown fox"), content="The Quick Brown Fox")
+  inspect(title("a b c"), content="A B C")
+}
+
+///|
+test "title/edge_cases" {
+  inspect(title(""), content="")
+  inspect(title(" "), content=" ")
+  inspect(title("  "), content="  ")
+  inspect(title("hello"), content="Hello")
+}
+
+///|
+test "title/special_characters" {
+  inspect(title("hello  world UK"), content="Hello  World UK")
+  inspect(title(" hello world"), content=" Hello World")
+  inspect(title("hello world "), content="Hello World ")
+  inspect(title("123 abc"), content="123 Abc")
+}
+
+///|
 fn to_camel_case(s : String) -> String {
   let b = StringBuilder::new()
   let chars = s.to_array()

--- a/lib/src/async_reader.mbt
+++ b/lib/src/async_reader.mbt
@@ -223,11 +223,12 @@ pub async fn[T : AsyncReader] async_read_string(reader : T) -> String raise {
 // / fields behaves like an iterator, yielding their tag everytime
 pub async fn[M : Sized, R : AsyncReader] async_read_packed(
   reader : R,
-  async_read_fn : async (R) -> M raise,
+  async_read_fn : async (LimitedReader[R]) -> M raise,
   size : UInt?,
 ) -> Array[M] raise {
   let len = reader |> async_read_varint32()
   let array = []
+  let reader = LimitedReader::new(reader, limit=len.reinterpret_as_int())
   match size {
     Some(size) =>
       for i = 0U; i < len / size; i = i + 1 {

--- a/lib/src/reader.mbt
+++ b/lib/src/reader.mbt
@@ -232,7 +232,7 @@ pub fn[M : Read + Default, R : Reader] read_message(reader : R) -> M raise {
 /// fields behaves like an iterator, yielding their tag everytime
 pub fn[M : Sized, R : Reader] read_packed(
   reader : R,
-  read_fn : (&Reader) -> M raise ReaderError,
+  read_fn : (&Reader) -> M raise,
   size : UInt?,
 ) -> Array[M] raise {
   let len = reader |> read_varint32()

--- a/lib/src/reader.mbt
+++ b/lib/src/reader.mbt
@@ -232,11 +232,12 @@ pub fn[M : Read + Default, R : Reader] read_message(reader : R) -> M raise {
 /// fields behaves like an iterator, yielding their tag everytime
 pub fn[M : Sized, R : Reader] read_packed(
   reader : R,
-  read_fn : (&Reader) -> M raise,
+  read_fn : (LimitedReader[R]) -> M raise,
   size : UInt?,
 ) -> Array[M] raise {
   let len = reader |> read_varint32()
   let array = []
+  let reader = LimitedReader::new(reader, limit=len.reinterpret_as_int())
   match size {
     Some(size) =>
       for i = 0U; i < len / size; i = i + 1 {

--- a/plugin/moon.mod.json
+++ b/plugin/moon.mod.json
@@ -5,8 +5,7 @@
     "moonbit-community/protobuf": {
       "path": "../lib"
     },
-    "tonyfettes/uv": "0.10.1",
-    "moonbitlang/async": "0.2.2"
+    "tonyfettes/uv": "0.10.1"
   },
   "readme": "",
   "repository": "",

--- a/plugin/moon.mod.json
+++ b/plugin/moon.mod.json
@@ -1,16 +1,17 @@
 {
   "name": "moonbit-community/plugin",
   "version": "0.1.0",
+  "deps": {
+    "moonbit-community/protobuf": {
+      "path": "../lib"
+    },
+    "tonyfettes/uv": "0.10.1",
+    "moonbitlang/async": "0.2.2"
+  },
   "readme": "",
   "repository": "",
   "license": "",
   "keywords": [],
   "description": "",
-  "source": "src",
-  "deps": {
-    "moonbit-community/protobuf": {
-      "path": "../lib"
-    },
-    "tonyfettes/uv": "0.10.1"
-  }
+  "source": "src"
 }

--- a/plugin/src/google/protobuf/compiler/compiler.mbti
+++ b/plugin/src/google/protobuf/compiler/compiler.mbti
@@ -7,6 +7,8 @@ import(
 
 // Values
 
+// Errors
+
 // Types and methods
 pub(all) struct CodeGeneratorRequest {
   mut file_to_generate : Array[String]
@@ -15,9 +17,12 @@ pub(all) struct CodeGeneratorRequest {
   mut source_file_descriptors : Array[@moonbit-community/plugin/google/protobuf.FileDescriptorProto]
   mut compiler_version : Version?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorRequest::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] CodeGeneratorRequest::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorRequest::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorRequest::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] CodeGeneratorRequest::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] CodeGeneratorRequest::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] CodeGeneratorRequest::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] CodeGeneratorRequest::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for CodeGeneratorRequest
 impl Default for CodeGeneratorRequest
 impl Eq for CodeGeneratorRequest
@@ -32,9 +37,12 @@ pub(all) struct CodeGeneratorResponse {
   mut maximum_edition : Int?
   mut file : Array[CodeGeneratorResponse_File]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorResponse::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorResponse::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] CodeGeneratorResponse::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorResponse::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorResponse::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] CodeGeneratorResponse::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] CodeGeneratorResponse::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] CodeGeneratorResponse::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] CodeGeneratorResponse::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for CodeGeneratorResponse
 impl Default for CodeGeneratorResponse
 impl Eq for CodeGeneratorResponse
@@ -62,9 +70,12 @@ pub(all) struct CodeGeneratorResponse_File {
   mut content : String?
   mut generated_code_info : @moonbit-community/plugin/google/protobuf.GeneratedCodeInfo?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorResponse_File::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorResponse_File::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] CodeGeneratorResponse_File::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorResponse_File::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] CodeGeneratorResponse_File::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] CodeGeneratorResponse_File::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] CodeGeneratorResponse_File::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] CodeGeneratorResponse_File::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] CodeGeneratorResponse_File::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for CodeGeneratorResponse_File
 impl Default for CodeGeneratorResponse_File
 impl Eq for CodeGeneratorResponse_File
@@ -78,9 +89,12 @@ pub(all) struct Version {
   mut patch : Int?
   mut suffix : String?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] Version::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] Version::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] Version::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] Version::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] Version::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] Version::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] Version::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] Version::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] Version::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for Version
 impl Default for Version
 impl Eq for Version

--- a/plugin/src/google/protobuf/compiler/top.mbt
+++ b/plugin/src/google/protobuf/compiler/top.mbt
@@ -39,15 +39,13 @@ pub impl Default for Version with default() -> Version {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] Version::read(
-  reader : R,
-) -> Version raise {
+pub fn[R : @protobuf.Reader] Version::read(reader : R) -> Version raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Version::read_with_limit(reader)
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] Version::read_with_limit(
+pub fn[R : @protobuf.Reader] Version::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> Version raise {
@@ -63,12 +61,12 @@ pub async fn[R : @protobuf.AsyncReader] Version::read_with_limit(
   let msg = Version::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.major = reader |> @protobuf.async_read_int32() |> Some
-        (2, _) => msg.minor = reader |> @protobuf.async_read_int32() |> Some
-        (3, _) => msg.patch = reader |> @protobuf.async_read_int32() |> Some
-        (4, _) => msg.suffix = reader |> @protobuf.async_read_string() |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.major = reader |> @protobuf.read_int32() |> Some
+        (2, _) => msg.minor = reader |> @protobuf.read_int32() |> Some
+        (3, _) => msg.patch = reader |> @protobuf.read_int32() |> Some
+        (4, _) => msg.suffix = reader |> @protobuf.read_string() |> Some
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -80,35 +78,35 @@ pub async fn[R : @protobuf.AsyncReader] Version::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] Version::write(
+pub fn[W : @protobuf.Writer] Version::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.major {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(8UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.minor {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.patch {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.suffix {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(34UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
@@ -155,6 +153,82 @@ pub impl @json.FromJson for Version with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] Version::async_read(
+  reader : R,
+) -> Version raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Version::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] Version::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> Version raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = Version::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.major = reader |> @protobuf.async_read_int32() |> Some
+        (2, _) => msg.minor = reader |> @protobuf.async_read_int32() |> Some
+        (3, _) => msg.patch = reader |> @protobuf.async_read_int32() |> Some
+        (4, _) => msg.suffix = reader |> @protobuf.async_read_string() |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] Version::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.major {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.minor {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.patch {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.suffix {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -217,7 +291,7 @@ pub impl Default for CodeGeneratorRequest with default() -> CodeGeneratorRequest
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] CodeGeneratorRequest::read(
+pub fn[R : @protobuf.Reader] CodeGeneratorRequest::read(
   reader : R,
 ) -> CodeGeneratorRequest raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -225,7 +299,7 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorRequest::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(
+pub fn[R : @protobuf.Reader] CodeGeneratorRequest::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> CodeGeneratorRequest raise {
@@ -241,15 +315,13 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(
   let msg = CodeGeneratorRequest::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) =>
-          msg.file_to_generate.push(reader |> @protobuf.async_read_string())
-        (2, _) =>
-          msg.parameter = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.file_to_generate.push(reader |> @protobuf.read_string())
+        (2, _) => msg.parameter = reader |> @protobuf.read_string() |> Some
         (15, _) =>
           msg.proto_file.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 @protobuf1.FileDescriptorProto::default()
               } else {
@@ -263,7 +335,7 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(
         (17, _) =>
           msg.source_file_descriptors.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 @protobuf1.FileDescriptorProto::default()
               } else {
@@ -276,7 +348,7 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(
           )
         (3, _) =>
           msg.compiler_version = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 Version::default()
               } else {
@@ -284,7 +356,7 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(
               }
             }
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -296,35 +368,35 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] CodeGeneratorRequest::write(
+pub fn[W : @protobuf.Writer] CodeGeneratorRequest::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   for item in self.file_to_generate {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_string(item)
   }
   match self.parameter {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   for item in self.proto_file {
-    writer |> @protobuf.async_write_varint(122UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(122UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.source_file_descriptors {
-    writer |> @protobuf.async_write_varint(138UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(138UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.compiler_version {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(26UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
@@ -384,6 +456,121 @@ pub impl @json.FromJson for CodeGeneratorRequest with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] CodeGeneratorRequest::async_read(
+  reader : R,
+) -> CodeGeneratorRequest raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  CodeGeneratorRequest::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] CodeGeneratorRequest::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> CodeGeneratorRequest raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = CodeGeneratorRequest::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.file_to_generate.push(reader |> @protobuf.async_read_string())
+        (2, _) =>
+          msg.parameter = reader |> @protobuf.async_read_string() |> Some
+        (15, _) =>
+          msg.proto_file.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                @protobuf1.FileDescriptorProto::default()
+              } else {
+                @protobuf1.FileDescriptorProto::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (17, _) =>
+          msg.source_file_descriptors.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                @protobuf1.FileDescriptorProto::default()
+              } else {
+                @protobuf1.FileDescriptorProto::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (3, _) =>
+          msg.compiler_version = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                Version::default()
+              } else {
+                Version::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] CodeGeneratorRequest::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  for item in self.file_to_generate {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_string(item)
+  }
+  match self.parameter {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  for item in self.proto_file {
+    writer |> @protobuf.async_write_varint(122UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.source_file_descriptors {
+    writer |> @protobuf.async_write_varint(138UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.compiler_version {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -523,7 +710,7 @@ pub impl Default for CodeGeneratorResponse_File with default() -> CodeGeneratorR
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse_File::read(
+pub fn[R : @protobuf.Reader] CodeGeneratorResponse_File::read(
   reader : R,
 ) -> CodeGeneratorResponse_File raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -531,7 +718,7 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse_File::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse_File::read_with_limit(
+pub fn[R : @protobuf.Reader] CodeGeneratorResponse_File::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> CodeGeneratorResponse_File raise {
@@ -547,14 +734,14 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse_File::read_with_li
   let msg = CodeGeneratorResponse_File::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
         (2, _) =>
-          msg.insertion_point = reader |> @protobuf.async_read_string() |> Some
-        (15, _) => msg.content = reader |> @protobuf.async_read_string() |> Some
+          msg.insertion_point = reader |> @protobuf.read_string() |> Some
+        (15, _) => msg.content = reader |> @protobuf.read_string() |> Some
         (16, _) =>
           msg.generated_code_info = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 @protobuf1.GeneratedCodeInfo::default()
               } else {
@@ -562,7 +749,7 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse_File::read_with_li
               }
             }
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -574,35 +761,35 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse_File::read_with_li
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] CodeGeneratorResponse_File::write(
+pub fn[W : @protobuf.Writer] CodeGeneratorResponse_File::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.insertion_point {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.content {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(122UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(122UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.generated_code_info {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(130UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(130UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
@@ -658,6 +845,96 @@ pub impl @json.FromJson for CodeGeneratorResponse_File with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse_File::async_read(
+  reader : R,
+) -> CodeGeneratorResponse_File raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  CodeGeneratorResponse_File::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse_File::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> CodeGeneratorResponse_File raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = CodeGeneratorResponse_File::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+        (2, _) =>
+          msg.insertion_point = reader |> @protobuf.async_read_string() |> Some
+        (15, _) => msg.content = reader |> @protobuf.async_read_string() |> Some
+        (16, _) =>
+          msg.generated_code_info = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                @protobuf1.GeneratedCodeInfo::default()
+              } else {
+                @protobuf1.GeneratedCodeInfo::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            }
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] CodeGeneratorResponse_File::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.insertion_point {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.content {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(122UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.generated_code_info {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(130UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct CodeGeneratorResponse {
   mut error : String?
   mut supported_features : UInt64?
@@ -710,7 +987,7 @@ pub impl Default for CodeGeneratorResponse with default() -> CodeGeneratorRespon
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse::read(
+pub fn[R : @protobuf.Reader] CodeGeneratorResponse::read(
   reader : R,
 ) -> CodeGeneratorResponse raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -718,7 +995,7 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse::read_with_limit(
+pub fn[R : @protobuf.Reader] CodeGeneratorResponse::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> CodeGeneratorResponse raise {
@@ -734,20 +1011,16 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse::read_with_limit(
   let msg = CodeGeneratorResponse::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.error = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.error = reader |> @protobuf.read_string() |> Some
         (2, _) =>
-          msg.supported_features = reader
-            |> @protobuf.async_read_uint64()
-            |> Some
-        (3, _) =>
-          msg.minimum_edition = reader |> @protobuf.async_read_int32() |> Some
-        (4, _) =>
-          msg.maximum_edition = reader |> @protobuf.async_read_int32() |> Some
+          msg.supported_features = reader |> @protobuf.read_uint64() |> Some
+        (3, _) => msg.minimum_edition = reader |> @protobuf.read_int32() |> Some
+        (4, _) => msg.maximum_edition = reader |> @protobuf.read_int32() |> Some
         (15, _) =>
           msg.file.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 CodeGeneratorResponse_File::default()
               } else {
@@ -755,7 +1028,7 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -767,41 +1040,41 @@ pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] CodeGeneratorResponse::write(
+pub fn[W : @protobuf.Writer] CodeGeneratorResponse::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.error {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.supported_features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_uint64(v)
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_uint64(v)
     }
     None => ()
   }
   match self.minimum_edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.maximum_edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(32UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   for item in self.file {
-    writer |> @protobuf.async_write_varint(122UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(122UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -857,4 +1130,104 @@ pub impl @json.FromJson for CodeGeneratorResponse with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse::async_read(
+  reader : R,
+) -> CodeGeneratorResponse raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  CodeGeneratorResponse::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] CodeGeneratorResponse::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> CodeGeneratorResponse raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = CodeGeneratorResponse::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.error = reader |> @protobuf.async_read_string() |> Some
+        (2, _) =>
+          msg.supported_features = reader
+            |> @protobuf.async_read_uint64()
+            |> Some
+        (3, _) =>
+          msg.minimum_edition = reader |> @protobuf.async_read_int32() |> Some
+        (4, _) =>
+          msg.maximum_edition = reader |> @protobuf.async_read_int32() |> Some
+        (15, _) =>
+          msg.file.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                CodeGeneratorResponse_File::default()
+              } else {
+                CodeGeneratorResponse_File::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] CodeGeneratorResponse::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.error {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.supported_features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_uint64(v)
+    }
+    None => ()
+  }
+  match self.minimum_edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.maximum_edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  for item in self.file {
+    writer |> @protobuf.async_write_varint(122UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
 }

--- a/plugin/src/google/protobuf/protobuf.mbti
+++ b/plugin/src/google/protobuf/protobuf.mbti
@@ -7,6 +7,8 @@ import(
 
 // Values
 
+// Errors
+
 // Types and methods
 pub(all) struct DescriptorProto {
   mut name : String?
@@ -20,9 +22,12 @@ pub(all) struct DescriptorProto {
   mut reserved_range : Array[DescriptorProto_ReservedRange]
   mut reserved_name : Array[String]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] DescriptorProto::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] DescriptorProto::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] DescriptorProto::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] DescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] DescriptorProto::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for DescriptorProto
 impl Default for DescriptorProto
 impl Eq for DescriptorProto
@@ -35,9 +40,12 @@ pub(all) struct DescriptorProto_ExtensionRange {
   mut end : Int?
   mut options : ExtensionRangeOptions?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto_ExtensionRange::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto_ExtensionRange::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] DescriptorProto_ExtensionRange::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto_ExtensionRange::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto_ExtensionRange::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] DescriptorProto_ExtensionRange::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] DescriptorProto_ExtensionRange::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] DescriptorProto_ExtensionRange::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] DescriptorProto_ExtensionRange::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for DescriptorProto_ExtensionRange
 impl Default for DescriptorProto_ExtensionRange
 impl Eq for DescriptorProto_ExtensionRange
@@ -49,9 +57,12 @@ pub(all) struct DescriptorProto_ReservedRange {
   mut start : Int?
   mut end : Int?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto_ReservedRange::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto_ReservedRange::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] DescriptorProto_ReservedRange::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto_ReservedRange::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] DescriptorProto_ReservedRange::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] DescriptorProto_ReservedRange::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] DescriptorProto_ReservedRange::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] DescriptorProto_ReservedRange::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] DescriptorProto_ReservedRange::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for DescriptorProto_ReservedRange
 impl Default for DescriptorProto_ReservedRange
 impl Eq for DescriptorProto_ReservedRange
@@ -89,9 +100,12 @@ pub(all) struct EnumDescriptorProto {
   mut reserved_range : Array[EnumDescriptorProto_EnumReservedRange]
   mut reserved_name : Array[String]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] EnumDescriptorProto::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] EnumDescriptorProto::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] EnumDescriptorProto::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] EnumDescriptorProto::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] EnumDescriptorProto::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] EnumDescriptorProto::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] EnumDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] EnumDescriptorProto::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for EnumDescriptorProto
 impl Default for EnumDescriptorProto
 impl Eq for EnumDescriptorProto
@@ -103,9 +117,12 @@ pub(all) struct EnumDescriptorProto_EnumReservedRange {
   mut start : Int?
   mut end : Int?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] EnumDescriptorProto_EnumReservedRange::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] EnumDescriptorProto_EnumReservedRange::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] EnumDescriptorProto_EnumReservedRange::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] EnumDescriptorProto_EnumReservedRange::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] EnumDescriptorProto_EnumReservedRange::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for EnumDescriptorProto_EnumReservedRange
 impl Default for EnumDescriptorProto_EnumReservedRange
 impl Eq for EnumDescriptorProto_EnumReservedRange
@@ -120,9 +137,12 @@ pub(all) struct EnumOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] EnumOptions::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] EnumOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] EnumOptions::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] EnumOptions::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] EnumOptions::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] EnumOptions::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] EnumOptions::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] EnumOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] EnumOptions::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for EnumOptions
 impl Default for EnumOptions
 impl Eq for EnumOptions
@@ -135,9 +155,12 @@ pub(all) struct EnumValueDescriptorProto {
   mut number : Int?
   mut options : EnumValueOptions?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] EnumValueDescriptorProto::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] EnumValueDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] EnumValueDescriptorProto::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] EnumValueDescriptorProto::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] EnumValueDescriptorProto::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] EnumValueDescriptorProto::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] EnumValueDescriptorProto::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] EnumValueDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] EnumValueDescriptorProto::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for EnumValueDescriptorProto
 impl Default for EnumValueDescriptorProto
 impl Eq for EnumValueDescriptorProto
@@ -152,9 +175,12 @@ pub(all) struct EnumValueOptions {
   mut feature_support : FieldOptions_FeatureSupport?
   mut uninterpreted_option : Array[UninterpretedOption]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] EnumValueOptions::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] EnumValueOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] EnumValueOptions::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] EnumValueOptions::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] EnumValueOptions::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] EnumValueOptions::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] EnumValueOptions::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] EnumValueOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] EnumValueOptions::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for EnumValueOptions
 impl Default for EnumValueOptions
 impl Eq for EnumValueOptions
@@ -168,9 +194,12 @@ pub(all) struct ExtensionRangeOptions {
   mut features : FeatureSet?
   mut verification : ExtensionRangeOptions_VerificationState?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] ExtensionRangeOptions::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] ExtensionRangeOptions::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] ExtensionRangeOptions::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] ExtensionRangeOptions::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] ExtensionRangeOptions::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] ExtensionRangeOptions::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] ExtensionRangeOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] ExtensionRangeOptions::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for ExtensionRangeOptions
 impl Default for ExtensionRangeOptions
 impl Eq for ExtensionRangeOptions
@@ -185,9 +214,12 @@ pub(all) struct ExtensionRangeOptions_Declaration {
   mut reserved : Bool?
   mut repeated : Bool?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] ExtensionRangeOptions_Declaration::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] ExtensionRangeOptions_Declaration::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] ExtensionRangeOptions_Declaration::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] ExtensionRangeOptions_Declaration::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] ExtensionRangeOptions_Declaration::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] ExtensionRangeOptions_Declaration::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] ExtensionRangeOptions_Declaration::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] ExtensionRangeOptions_Declaration::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] ExtensionRangeOptions_Declaration::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for ExtensionRangeOptions_Declaration
 impl Default for ExtensionRangeOptions_Declaration
 impl Eq for ExtensionRangeOptions_Declaration
@@ -216,9 +248,12 @@ pub(all) struct FeatureSet {
   mut message_encoding : FeatureSet_MessageEncoding?
   mut json_format : FeatureSet_JsonFormat?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSet::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSet::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] FeatureSet::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSet::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSet::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] FeatureSet::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] FeatureSet::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] FeatureSet::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] FeatureSet::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for FeatureSet
 impl Default for FeatureSet
 impl Eq for FeatureSet
@@ -231,9 +266,12 @@ pub(all) struct FeatureSetDefaults {
   mut minimum_edition : Edition?
   mut maximum_edition : Edition?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSetDefaults::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSetDefaults::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] FeatureSetDefaults::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSetDefaults::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSetDefaults::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] FeatureSetDefaults::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] FeatureSetDefaults::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] FeatureSetDefaults::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] FeatureSetDefaults::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for FeatureSetDefaults
 impl Default for FeatureSetDefaults
 impl Eq for FeatureSetDefaults
@@ -246,9 +284,12 @@ pub(all) struct FeatureSetDefaults_FeatureSetEditionDefault {
   mut overridable_features : FeatureSet?
   mut fixed_features : FeatureSet?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] FeatureSetDefaults_FeatureSetEditionDefault::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] FeatureSetDefaults_FeatureSetEditionDefault::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] FeatureSetDefaults_FeatureSetEditionDefault::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] FeatureSetDefaults_FeatureSetEditionDefault::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] FeatureSetDefaults_FeatureSetEditionDefault::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for FeatureSetDefaults_FeatureSetEditionDefault
 impl Default for FeatureSetDefaults_FeatureSetEditionDefault
 impl Eq for FeatureSetDefaults_FeatureSetEditionDefault
@@ -354,9 +395,12 @@ pub(all) struct FieldDescriptorProto {
   mut options : FieldOptions?
   mut proto3_optional : Bool?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] FieldDescriptorProto::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] FieldDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] FieldDescriptorProto::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FieldDescriptorProto::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FieldDescriptorProto::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] FieldDescriptorProto::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] FieldDescriptorProto::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] FieldDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] FieldDescriptorProto::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for FieldDescriptorProto
 impl Default for FieldDescriptorProto
 impl Eq for FieldDescriptorProto
@@ -423,9 +467,12 @@ pub(all) struct FieldOptions {
   mut feature_support : FieldOptions_FeatureSupport?
   mut uninterpreted_option : Array[UninterpretedOption]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] FieldOptions::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] FieldOptions::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] FieldOptions::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] FieldOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] FieldOptions::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for FieldOptions
 impl Default for FieldOptions
 impl Eq for FieldOptions
@@ -451,9 +498,12 @@ pub(all) struct FieldOptions_EditionDefault {
   mut edition : Edition?
   mut value : String?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions_EditionDefault::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions_EditionDefault::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] FieldOptions_EditionDefault::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions_EditionDefault::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions_EditionDefault::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] FieldOptions_EditionDefault::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] FieldOptions_EditionDefault::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] FieldOptions_EditionDefault::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] FieldOptions_EditionDefault::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for FieldOptions_EditionDefault
 impl Default for FieldOptions_EditionDefault
 impl Eq for FieldOptions_EditionDefault
@@ -467,9 +517,12 @@ pub(all) struct FieldOptions_FeatureSupport {
   mut deprecation_warning : String?
   mut edition_removed : Edition?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions_FeatureSupport::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions_FeatureSupport::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] FieldOptions_FeatureSupport::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions_FeatureSupport::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FieldOptions_FeatureSupport::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] FieldOptions_FeatureSupport::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] FieldOptions_FeatureSupport::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] FieldOptions_FeatureSupport::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] FieldOptions_FeatureSupport::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for FieldOptions_FeatureSupport
 impl Default for FieldOptions_FeatureSupport
 impl Eq for FieldOptions_FeatureSupport
@@ -541,9 +594,12 @@ pub(all) struct FileDescriptorProto {
   mut syntax : String?
   mut edition : Edition?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] FileDescriptorProto::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] FileDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] FileDescriptorProto::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FileDescriptorProto::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FileDescriptorProto::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] FileDescriptorProto::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] FileDescriptorProto::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] FileDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] FileDescriptorProto::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for FileDescriptorProto
 impl Default for FileDescriptorProto
 impl Eq for FileDescriptorProto
@@ -554,9 +610,12 @@ impl @json.FromJson for FileDescriptorProto
 pub(all) struct FileDescriptorSet {
   mut file : Array[FileDescriptorProto]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] FileDescriptorSet::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] FileDescriptorSet::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] FileDescriptorSet::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FileDescriptorSet::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FileDescriptorSet::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] FileDescriptorSet::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] FileDescriptorSet::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] FileDescriptorSet::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] FileDescriptorSet::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for FileDescriptorSet
 impl Default for FileDescriptorSet
 impl Eq for FileDescriptorSet
@@ -587,9 +646,12 @@ pub(all) struct FileOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] FileOptions::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] FileOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] FileOptions::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FileOptions::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] FileOptions::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] FileOptions::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] FileOptions::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] FileOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] FileOptions::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for FileOptions
 impl Default for FileOptions
 impl Eq for FileOptions
@@ -614,9 +676,12 @@ impl @json.FromJson for FileOptions_OptimizeMode
 pub(all) struct GeneratedCodeInfo {
   mut annotation : Array[GeneratedCodeInfo_Annotation]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] GeneratedCodeInfo::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] GeneratedCodeInfo::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] GeneratedCodeInfo::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] GeneratedCodeInfo::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] GeneratedCodeInfo::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] GeneratedCodeInfo::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] GeneratedCodeInfo::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] GeneratedCodeInfo::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] GeneratedCodeInfo::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for GeneratedCodeInfo
 impl Default for GeneratedCodeInfo
 impl Eq for GeneratedCodeInfo
@@ -631,9 +696,12 @@ pub(all) struct GeneratedCodeInfo_Annotation {
   mut end : Int?
   mut semantic : GeneratedCodeInfo_Annotation_Semantic?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] GeneratedCodeInfo_Annotation::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] GeneratedCodeInfo_Annotation::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] GeneratedCodeInfo_Annotation::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] GeneratedCodeInfo_Annotation::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] GeneratedCodeInfo_Annotation::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] GeneratedCodeInfo_Annotation::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] GeneratedCodeInfo_Annotation::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] GeneratedCodeInfo_Annotation::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] GeneratedCodeInfo_Annotation::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for GeneratedCodeInfo_Annotation
 impl Default for GeneratedCodeInfo_Annotation
 impl Eq for GeneratedCodeInfo_Annotation
@@ -664,9 +732,12 @@ pub(all) struct MessageOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] MessageOptions::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] MessageOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] MessageOptions::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] MessageOptions::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] MessageOptions::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] MessageOptions::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] MessageOptions::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] MessageOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] MessageOptions::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for MessageOptions
 impl Default for MessageOptions
 impl Eq for MessageOptions
@@ -682,9 +753,12 @@ pub(all) struct MethodDescriptorProto {
   mut client_streaming : Bool?
   mut server_streaming : Bool?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] MethodDescriptorProto::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] MethodDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] MethodDescriptorProto::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] MethodDescriptorProto::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] MethodDescriptorProto::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] MethodDescriptorProto::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] MethodDescriptorProto::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] MethodDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] MethodDescriptorProto::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for MethodDescriptorProto
 impl Default for MethodDescriptorProto
 impl Eq for MethodDescriptorProto
@@ -698,9 +772,12 @@ pub(all) struct MethodOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] MethodOptions::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] MethodOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] MethodOptions::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] MethodOptions::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] MethodOptions::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] MethodOptions::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] MethodOptions::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] MethodOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] MethodOptions::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for MethodOptions
 impl Default for MethodOptions
 impl Eq for MethodOptions
@@ -726,9 +803,12 @@ pub(all) struct OneofDescriptorProto {
   mut name : String?
   mut options : OneofOptions?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] OneofDescriptorProto::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] OneofDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] OneofDescriptorProto::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] OneofDescriptorProto::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] OneofDescriptorProto::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] OneofDescriptorProto::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] OneofDescriptorProto::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] OneofDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] OneofDescriptorProto::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for OneofDescriptorProto
 impl Default for OneofDescriptorProto
 impl Eq for OneofDescriptorProto
@@ -740,9 +820,12 @@ pub(all) struct OneofOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] OneofOptions::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] OneofOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] OneofOptions::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] OneofOptions::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] OneofOptions::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] OneofOptions::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] OneofOptions::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] OneofOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] OneofOptions::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for OneofOptions
 impl Default for OneofOptions
 impl Eq for OneofOptions
@@ -755,9 +838,12 @@ pub(all) struct ServiceDescriptorProto {
   mut method_ : Array[MethodDescriptorProto]
   mut options : ServiceOptions?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] ServiceDescriptorProto::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] ServiceDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] ServiceDescriptorProto::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] ServiceDescriptorProto::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] ServiceDescriptorProto::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] ServiceDescriptorProto::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] ServiceDescriptorProto::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] ServiceDescriptorProto::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] ServiceDescriptorProto::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for ServiceDescriptorProto
 impl Default for ServiceDescriptorProto
 impl Eq for ServiceDescriptorProto
@@ -770,9 +856,12 @@ pub(all) struct ServiceOptions {
   mut deprecated : Bool?
   mut uninterpreted_option : Array[UninterpretedOption]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] ServiceOptions::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] ServiceOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] ServiceOptions::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] ServiceOptions::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] ServiceOptions::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] ServiceOptions::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] ServiceOptions::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] ServiceOptions::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] ServiceOptions::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for ServiceOptions
 impl Default for ServiceOptions
 impl Eq for ServiceOptions
@@ -783,9 +872,12 @@ impl @json.FromJson for ServiceOptions
 pub(all) struct SourceCodeInfo {
   mut location : Array[SourceCodeInfo_Location]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] SourceCodeInfo::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] SourceCodeInfo::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] SourceCodeInfo::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] SourceCodeInfo::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] SourceCodeInfo::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] SourceCodeInfo::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] SourceCodeInfo::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] SourceCodeInfo::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] SourceCodeInfo::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for SourceCodeInfo
 impl Default for SourceCodeInfo
 impl Eq for SourceCodeInfo
@@ -800,9 +892,12 @@ pub(all) struct SourceCodeInfo_Location {
   mut trailing_comments : String?
   mut leading_detached_comments : Array[String]
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] SourceCodeInfo_Location::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] SourceCodeInfo_Location::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] SourceCodeInfo_Location::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] SourceCodeInfo_Location::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] SourceCodeInfo_Location::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] SourceCodeInfo_Location::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] SourceCodeInfo_Location::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] SourceCodeInfo_Location::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] SourceCodeInfo_Location::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for SourceCodeInfo_Location
 impl Default for SourceCodeInfo_Location
 impl Eq for SourceCodeInfo_Location
@@ -819,9 +914,12 @@ pub(all) struct UninterpretedOption {
   mut string_value : Bytes?
   mut aggregate_value : String?
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] UninterpretedOption::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] UninterpretedOption::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] UninterpretedOption::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] UninterpretedOption::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] UninterpretedOption::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] UninterpretedOption::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] UninterpretedOption::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] UninterpretedOption::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] UninterpretedOption::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for UninterpretedOption
 impl Default for UninterpretedOption
 impl Eq for UninterpretedOption
@@ -833,9 +931,12 @@ pub(all) struct UninterpretedOption_NamePart {
   mut name_part : String
   mut is_extension : Bool
 }
-async fn[R : @moonbit-community/protobuf.AsyncReader] UninterpretedOption_NamePart::read(R) -> Self raise
-async fn[R : @moonbit-community/protobuf.AsyncReader] UninterpretedOption_NamePart::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
-async fn[W : @moonbit-community/protobuf.AsyncWriter] UninterpretedOption_NamePart::write(Self, W) -> Unit raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] UninterpretedOption_NamePart::async_read(R) -> Self raise
+async fn[R : @moonbit-community/protobuf.AsyncReader] UninterpretedOption_NamePart::async_read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+async fn[W : @moonbit-community/protobuf.AsyncWriter] UninterpretedOption_NamePart::async_write(Self, W) -> Unit raise
+fn[R : @moonbit-community/protobuf.Reader] UninterpretedOption_NamePart::read(R) -> Self raise
+fn[R : @moonbit-community/protobuf.Reader] UninterpretedOption_NamePart::read_with_limit(@moonbit-community/protobuf.LimitedReader[R], limit? : Int) -> Self raise
+fn[W : @moonbit-community/protobuf.Writer] UninterpretedOption_NamePart::write(Self, W) -> Unit raise
 impl @moonbit-community/protobuf.Sized for UninterpretedOption_NamePart
 impl Default for UninterpretedOption_NamePart
 impl Eq for UninterpretedOption_NamePart

--- a/plugin/src/google/protobuf/top.mbt
+++ b/plugin/src/google/protobuf/top.mbt
@@ -138,7 +138,7 @@ pub impl Default for FileDescriptorSet with default() -> FileDescriptorSet {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FileDescriptorSet::read(
+pub fn[R : @protobuf.Reader] FileDescriptorSet::read(
   reader : R,
 ) -> FileDescriptorSet raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -146,7 +146,7 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorSet::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FileDescriptorSet::read_with_limit(
+pub fn[R : @protobuf.Reader] FileDescriptorSet::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FileDescriptorSet raise {
@@ -162,11 +162,11 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorSet::read_with_limit(
   let msg = FileDescriptorSet::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.file.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FileDescriptorProto::default()
               } else {
@@ -174,7 +174,7 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorSet::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -186,13 +186,13 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorSet::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FileDescriptorSet::write(
+pub fn[W : @protobuf.Writer] FileDescriptorSet::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   for item in self.file {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -225,6 +225,66 @@ pub impl @json.FromJson for FileDescriptorSet with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FileDescriptorSet::async_read(
+  reader : R,
+) -> FileDescriptorSet raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FileDescriptorSet::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FileDescriptorSet::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FileDescriptorSet raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FileDescriptorSet::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.file.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FileDescriptorProto::default()
+              } else {
+                FileDescriptorProto::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FileDescriptorSet::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  for item in self.file {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
 }
 
 ///|
@@ -354,7 +414,7 @@ pub impl Default for FileDescriptorProto with default() -> FileDescriptorProto {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::read(
+pub fn[R : @protobuf.Reader] FileDescriptorProto::read(
   reader : R,
 ) -> FileDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -362,7 +422,7 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(
+pub fn[R : @protobuf.Reader] FileDescriptorProto::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FileDescriptorProto raise {
@@ -378,18 +438,16 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(
   let msg = FileDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
-        (2, _) => msg.package_ = reader |> @protobuf.async_read_string() |> Some
-        (3, _) => msg.dependency.push(reader |> @protobuf.async_read_string())
-        (10, _) =>
-          msg.public_dependency.push(reader |> @protobuf.async_read_int32())
-        (11, _) =>
-          msg.weak_dependency.push(reader |> @protobuf.async_read_int32())
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
+        (2, _) => msg.package_ = reader |> @protobuf.read_string() |> Some
+        (3, _) => msg.dependency.push(reader |> @protobuf.read_string())
+        (10, _) => msg.public_dependency.push(reader |> @protobuf.read_int32())
+        (11, _) => msg.weak_dependency.push(reader |> @protobuf.read_int32())
         (4, _) =>
           msg.message_type.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 DescriptorProto::default()
               } else {
@@ -400,7 +458,7 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(
         (5, _) =>
           msg.enum_type.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 EnumDescriptorProto::default()
               } else {
@@ -411,7 +469,7 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(
         (6, _) =>
           msg.service.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 ServiceDescriptorProto::default()
               } else {
@@ -422,7 +480,7 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(
         (7, _) =>
           msg.extension.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FieldDescriptorProto::default()
               } else {
@@ -432,7 +490,7 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(
           )
         (8, _) =>
           msg.options = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FileOptions::default()
               } else {
@@ -442,7 +500,7 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(
             |> Some
         (9, _) =>
           msg.source_code_info = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 SourceCodeInfo::default()
               } else {
@@ -450,13 +508,13 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(
               }
             }
             |> Some
-        (12, _) => msg.syntax = reader |> @protobuf.async_read_string() |> Some
+        (12, _) => msg.syntax = reader |> @protobuf.read_string() |> Some
         (14, _) =>
           msg.edition = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> Edition::from_enum
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -468,83 +526,83 @@ pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FileDescriptorProto::write(
+pub fn[W : @protobuf.Writer] FileDescriptorProto::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.package_ {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   for item in self.dependency {
-    writer |> @protobuf.async_write_varint(26UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(26UL)
+    writer |> @protobuf.write_string(item)
   }
   for item in self.public_dependency {
-    writer |> @protobuf.async_write_varint(80UL)
-    writer |> @protobuf.async_write_int32(item)
+    writer |> @protobuf.write_varint(80UL)
+    writer |> @protobuf.write_int32(item)
   }
   for item in self.weak_dependency {
-    writer |> @protobuf.async_write_varint(88UL)
-    writer |> @protobuf.async_write_int32(item)
+    writer |> @protobuf.write_varint(88UL)
+    writer |> @protobuf.write_int32(item)
   }
   for item in self.message_type {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.enum_type {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.service {
-    writer |> @protobuf.async_write_varint(50UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(50UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.extension {
-    writer |> @protobuf.async_write_varint(58UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(58UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(66UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(66UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.source_code_info {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(74UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(74UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.syntax {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(98UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(98UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(112UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(112UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
@@ -645,6 +703,203 @@ pub impl @json.FromJson for FileDescriptorProto with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::async_read(
+  reader : R,
+) -> FileDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FileDescriptorProto::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FileDescriptorProto::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FileDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FileDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+        (2, _) => msg.package_ = reader |> @protobuf.async_read_string() |> Some
+        (3, _) => msg.dependency.push(reader |> @protobuf.async_read_string())
+        (10, _) =>
+          msg.public_dependency.push(reader |> @protobuf.async_read_int32())
+        (11, _) =>
+          msg.weak_dependency.push(reader |> @protobuf.async_read_int32())
+        (4, _) =>
+          msg.message_type.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                DescriptorProto::default()
+              } else {
+                DescriptorProto::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (5, _) =>
+          msg.enum_type.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                EnumDescriptorProto::default()
+              } else {
+                EnumDescriptorProto::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (6, _) =>
+          msg.service.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                ServiceDescriptorProto::default()
+              } else {
+                ServiceDescriptorProto::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (7, _) =>
+          msg.extension.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FieldDescriptorProto::default()
+              } else {
+                FieldDescriptorProto::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (8, _) =>
+          msg.options = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FileOptions::default()
+              } else {
+                FileOptions::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (9, _) =>
+          msg.source_code_info = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                SourceCodeInfo::default()
+              } else {
+                SourceCodeInfo::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (12, _) => msg.syntax = reader |> @protobuf.async_read_string() |> Some
+        (14, _) =>
+          msg.edition = reader
+            |> @protobuf.async_read_enum()
+            |> Edition::from_enum
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FileDescriptorProto::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.package_ {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  for item in self.dependency {
+    writer |> @protobuf.async_write_varint(26UL)
+    writer |> @protobuf.async_write_string(item)
+  }
+  for item in self.public_dependency {
+    writer |> @protobuf.async_write_varint(80UL)
+    writer |> @protobuf.async_write_int32(item)
+  }
+  for item in self.weak_dependency {
+    writer |> @protobuf.async_write_varint(88UL)
+    writer |> @protobuf.async_write_int32(item)
+  }
+  for item in self.message_type {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.enum_type {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.service {
+    writer |> @protobuf.async_write_varint(50UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.extension {
+    writer |> @protobuf.async_write_varint(58UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(66UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.source_code_info {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(74UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.syntax {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(98UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(112UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct DescriptorProto_ExtensionRange {
   mut start : Int?
   mut end : Int?
@@ -680,7 +935,7 @@ pub impl Default for DescriptorProto_ExtensionRange with default() -> Descriptor
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ExtensionRange::read(
+pub fn[R : @protobuf.Reader] DescriptorProto_ExtensionRange::read(
   reader : R,
 ) -> DescriptorProto_ExtensionRange raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -688,7 +943,7 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ExtensionRange::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ExtensionRange::read_with_limit(
+pub fn[R : @protobuf.Reader] DescriptorProto_ExtensionRange::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> DescriptorProto_ExtensionRange raise {
@@ -704,12 +959,12 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ExtensionRange::read_wit
   let msg = DescriptorProto_ExtensionRange::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
-        (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.start = reader |> @protobuf.read_int32() |> Some
+        (2, _) => msg.end = reader |> @protobuf.read_int32() |> Some
         (3, _) =>
           msg.options = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 ExtensionRangeOptions::default()
               } else {
@@ -717,7 +972,7 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ExtensionRange::read_wit
               }
             }
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -729,28 +984,28 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ExtensionRange::read_wit
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] DescriptorProto_ExtensionRange::write(
+pub fn[W : @protobuf.Writer] DescriptorProto_ExtensionRange::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.start {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(8UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.end {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(26UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
@@ -799,6 +1054,84 @@ pub impl @json.FromJson for DescriptorProto_ExtensionRange with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ExtensionRange::async_read(
+  reader : R,
+) -> DescriptorProto_ExtensionRange raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  DescriptorProto_ExtensionRange::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ExtensionRange::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> DescriptorProto_ExtensionRange raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = DescriptorProto_ExtensionRange::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
+        (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
+        (3, _) =>
+          msg.options = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                ExtensionRangeOptions::default()
+              } else {
+                ExtensionRangeOptions::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] DescriptorProto_ExtensionRange::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.start {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.end {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct DescriptorProto_ReservedRange {
   mut start : Int?
   mut end : Int?
@@ -824,7 +1157,7 @@ pub impl Default for DescriptorProto_ReservedRange with default() -> DescriptorP
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ReservedRange::read(
+pub fn[R : @protobuf.Reader] DescriptorProto_ReservedRange::read(
   reader : R,
 ) -> DescriptorProto_ReservedRange raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -832,7 +1165,7 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ReservedRange::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ReservedRange::read_with_limit(
+pub fn[R : @protobuf.Reader] DescriptorProto_ReservedRange::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> DescriptorProto_ReservedRange raise {
@@ -848,10 +1181,10 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ReservedRange::read_with
   let msg = DescriptorProto_ReservedRange::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
-        (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.start = reader |> @protobuf.read_int32() |> Some
+        (2, _) => msg.end = reader |> @protobuf.read_int32() |> Some
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -863,21 +1196,21 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ReservedRange::read_with
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] DescriptorProto_ReservedRange::write(
+pub fn[W : @protobuf.Writer] DescriptorProto_ReservedRange::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.start {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(8UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.end {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
@@ -916,6 +1249,66 @@ pub impl @json.FromJson for DescriptorProto_ReservedRange with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ReservedRange::async_read(
+  reader : R,
+) -> DescriptorProto_ReservedRange raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  DescriptorProto_ReservedRange::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] DescriptorProto_ReservedRange::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> DescriptorProto_ReservedRange raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = DescriptorProto_ReservedRange::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
+        (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] DescriptorProto_ReservedRange::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.start {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.end {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -1013,7 +1406,7 @@ pub impl Default for DescriptorProto with default() -> DescriptorProto {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read(
+pub fn[R : @protobuf.Reader] DescriptorProto::read(
   reader : R,
 ) -> DescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -1021,7 +1414,7 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read_with_limit(
+pub fn[R : @protobuf.Reader] DescriptorProto::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> DescriptorProto raise {
@@ -1037,12 +1430,12 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read_with_limit(
   let msg = DescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
         (2, _) =>
           msg.field.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FieldDescriptorProto::default()
               } else {
@@ -1053,7 +1446,7 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read_with_limit(
         (6, _) =>
           msg.extension.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FieldDescriptorProto::default()
               } else {
@@ -1064,7 +1457,7 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read_with_limit(
         (3, _) =>
           msg.nested_type.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 DescriptorProto::default()
               } else {
@@ -1075,7 +1468,7 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read_with_limit(
         (4, _) =>
           msg.enum_type.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 EnumDescriptorProto::default()
               } else {
@@ -1086,7 +1479,7 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read_with_limit(
         (5, _) =>
           msg.extension_range.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 DescriptorProto_ExtensionRange::default()
               } else {
@@ -1100,7 +1493,7 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read_with_limit(
         (8, _) =>
           msg.oneof_decl.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 OneofDescriptorProto::default()
               } else {
@@ -1110,7 +1503,7 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read_with_limit(
           )
         (7, _) =>
           msg.options = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 MessageOptions::default()
               } else {
@@ -1121,7 +1514,7 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read_with_limit(
         (9, _) =>
           msg.reserved_range.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 DescriptorProto_ReservedRange::default()
               } else {
@@ -1132,9 +1525,8 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read_with_limit(
               }
             },
           )
-        (10, _) =>
-          msg.reserved_name.push(reader |> @protobuf.async_read_string())
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (10, _) => msg.reserved_name.push(reader |> @protobuf.read_string())
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1146,63 +1538,63 @@ pub async fn[R : @protobuf.AsyncReader] DescriptorProto::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] DescriptorProto::write(
+pub fn[W : @protobuf.Writer] DescriptorProto::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   for item in self.field {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(18UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.extension {
-    writer |> @protobuf.async_write_varint(50UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(50UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.nested_type {
-    writer |> @protobuf.async_write_varint(26UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(26UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.enum_type {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.extension_range {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.oneof_decl {
-    writer |> @protobuf.async_write_varint(66UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(66UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(58UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(58UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   for item in self.reserved_range {
-    writer |> @protobuf.async_write_varint(74UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(74UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.reserved_name {
-    writer |> @protobuf.async_write_varint(82UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(82UL)
+    writer |> @protobuf.write_string(item)
   }
 }
 
@@ -1280,6 +1672,200 @@ pub impl @json.FromJson for DescriptorProto with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] DescriptorProto::async_read(
+  reader : R,
+) -> DescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  DescriptorProto::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] DescriptorProto::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> DescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = DescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+        (2, _) =>
+          msg.field.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FieldDescriptorProto::default()
+              } else {
+                FieldDescriptorProto::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (6, _) =>
+          msg.extension.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FieldDescriptorProto::default()
+              } else {
+                FieldDescriptorProto::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (3, _) =>
+          msg.nested_type.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                DescriptorProto::default()
+              } else {
+                DescriptorProto::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (4, _) =>
+          msg.enum_type.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                EnumDescriptorProto::default()
+              } else {
+                EnumDescriptorProto::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (5, _) =>
+          msg.extension_range.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                DescriptorProto_ExtensionRange::default()
+              } else {
+                DescriptorProto_ExtensionRange::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (8, _) =>
+          msg.oneof_decl.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                OneofDescriptorProto::default()
+              } else {
+                OneofDescriptorProto::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (7, _) =>
+          msg.options = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                MessageOptions::default()
+              } else {
+                MessageOptions::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (9, _) =>
+          msg.reserved_range.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                DescriptorProto_ReservedRange::default()
+              } else {
+                DescriptorProto_ReservedRange::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (10, _) =>
+          msg.reserved_name.push(reader |> @protobuf.async_read_string())
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] DescriptorProto::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  for item in self.field {
+    writer |> @protobuf.async_write_varint(18UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.extension {
+    writer |> @protobuf.async_write_varint(50UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.nested_type {
+    writer |> @protobuf.async_write_varint(26UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.enum_type {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.extension_range {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.oneof_decl {
+    writer |> @protobuf.async_write_varint(66UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(58UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  for item in self.reserved_range {
+    writer |> @protobuf.async_write_varint(74UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.reserved_name {
+    writer |> @protobuf.async_write_varint(82UL)
+    writer |> @protobuf.async_write_string(item)
+  }
 }
 
 ///|
@@ -1408,7 +1994,7 @@ pub impl Default for ExtensionRangeOptions_Declaration with default() -> Extensi
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::read(
+pub fn[R : @protobuf.Reader] ExtensionRangeOptions_Declaration::read(
   reader : R,
 ) -> ExtensionRangeOptions_Declaration raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -1416,7 +2002,7 @@ pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::read_with_limit(
+pub fn[R : @protobuf.Reader] ExtensionRangeOptions_Declaration::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> ExtensionRangeOptions_Declaration raise {
@@ -1432,14 +2018,13 @@ pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::read_
   let msg = ExtensionRangeOptions_Declaration::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
-        (2, _) =>
-          msg.full_name = reader |> @protobuf.async_read_string() |> Some
-        (3, _) => msg.type_ = reader |> @protobuf.async_read_string() |> Some
-        (5, _) => msg.reserved = reader |> @protobuf.async_read_bool() |> Some
-        (6, _) => msg.repeated = reader |> @protobuf.async_read_bool() |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.number = reader |> @protobuf.read_int32() |> Some
+        (2, _) => msg.full_name = reader |> @protobuf.read_string() |> Some
+        (3, _) => msg.type_ = reader |> @protobuf.read_string() |> Some
+        (5, _) => msg.reserved = reader |> @protobuf.read_bool() |> Some
+        (6, _) => msg.repeated = reader |> @protobuf.read_bool() |> Some
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1451,42 +2036,42 @@ pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::read_
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] ExtensionRangeOptions_Declaration::write(
+pub fn[W : @protobuf.Writer] ExtensionRangeOptions_Declaration::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.number {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(8UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.full_name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.type_ {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.reserved {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(40UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.repeated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(48UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(48UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
@@ -1546,6 +2131,91 @@ pub impl @json.FromJson for ExtensionRangeOptions_Declaration with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::async_read(
+  reader : R,
+) -> ExtensionRangeOptions_Declaration raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  ExtensionRangeOptions_Declaration::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> ExtensionRangeOptions_Declaration raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = ExtensionRangeOptions_Declaration::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
+        (2, _) =>
+          msg.full_name = reader |> @protobuf.async_read_string() |> Some
+        (3, _) => msg.type_ = reader |> @protobuf.async_read_string() |> Some
+        (5, _) => msg.reserved = reader |> @protobuf.async_read_bool() |> Some
+        (6, _) => msg.repeated = reader |> @protobuf.async_read_bool() |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] ExtensionRangeOptions_Declaration::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.number {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.full_name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.type_ {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.reserved {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.repeated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(48UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct ExtensionRangeOptions {
   mut uninterpreted_option : Array[UninterpretedOption]
   mut declaration : Array[ExtensionRangeOptions_Declaration]
@@ -1593,7 +2263,7 @@ pub impl Default for ExtensionRangeOptions with default() -> ExtensionRangeOptio
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions::read(
+pub fn[R : @protobuf.Reader] ExtensionRangeOptions::read(
   reader : R,
 ) -> ExtensionRangeOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -1601,7 +2271,7 @@ pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(
+pub fn[R : @protobuf.Reader] ExtensionRangeOptions::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> ExtensionRangeOptions raise {
@@ -1617,11 +2287,11 @@ pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(
   let msg = ExtensionRangeOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (999, _) =>
           msg.uninterpreted_option.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 UninterpretedOption::default()
               } else {
@@ -1632,7 +2302,7 @@ pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(
         (2, _) =>
           msg.declaration.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 ExtensionRangeOptions_Declaration::default()
               } else {
@@ -1645,7 +2315,7 @@ pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(
           )
         (50, _) =>
           msg.features = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSet::default()
               } else {
@@ -1655,10 +2325,10 @@ pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(
             |> Some
         (3, _) =>
           msg.verification = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> ExtensionRangeOptions_VerificationState::from_enum
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1670,32 +2340,32 @@ pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] ExtensionRangeOptions::write(
+pub fn[W : @protobuf.Writer] ExtensionRangeOptions::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.declaration {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(18UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(402UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(402UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.verification {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
@@ -1747,6 +2417,115 @@ pub impl @json.FromJson for ExtensionRangeOptions with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions::async_read(
+  reader : R,
+) -> ExtensionRangeOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  ExtensionRangeOptions::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] ExtensionRangeOptions::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> ExtensionRangeOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = ExtensionRangeOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (999, _) =>
+          msg.uninterpreted_option.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                UninterpretedOption::default()
+              } else {
+                UninterpretedOption::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (2, _) =>
+          msg.declaration.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                ExtensionRangeOptions_Declaration::default()
+              } else {
+                ExtensionRangeOptions_Declaration::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (50, _) =>
+          msg.features = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSet::default()
+              } else {
+                FeatureSet::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (3, _) =>
+          msg.verification = reader
+            |> @protobuf.async_read_enum()
+            |> ExtensionRangeOptions_VerificationState::from_enum
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] ExtensionRangeOptions::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.declaration {
+    writer |> @protobuf.async_write_varint(18UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(402UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.verification {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -2096,7 +2875,7 @@ pub impl Default for FieldDescriptorProto with default() -> FieldDescriptorProto
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FieldDescriptorProto::read(
+pub fn[R : @protobuf.Reader] FieldDescriptorProto::read(
   reader : R,
 ) -> FieldDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -2104,7 +2883,7 @@ pub async fn[R : @protobuf.AsyncReader] FieldDescriptorProto::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FieldDescriptorProto::read_with_limit(
+pub fn[R : @protobuf.Reader] FieldDescriptorProto::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FieldDescriptorProto raise {
@@ -2120,31 +2899,27 @@ pub async fn[R : @protobuf.AsyncReader] FieldDescriptorProto::read_with_limit(
   let msg = FieldDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
-        (3, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
+        (3, _) => msg.number = reader |> @protobuf.read_int32() |> Some
         (4, _) =>
           msg.label = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FieldDescriptorProto_Label::from_enum
             |> Some
         (5, _) =>
           msg.type_ = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FieldDescriptorProto_Type::from_enum
             |> Some
-        (6, _) =>
-          msg.type_name = reader |> @protobuf.async_read_string() |> Some
-        (2, _) => msg.extendee = reader |> @protobuf.async_read_string() |> Some
-        (7, _) =>
-          msg.default_value = reader |> @protobuf.async_read_string() |> Some
-        (9, _) =>
-          msg.oneof_index = reader |> @protobuf.async_read_int32() |> Some
-        (10, _) =>
-          msg.json_name = reader |> @protobuf.async_read_string() |> Some
+        (6, _) => msg.type_name = reader |> @protobuf.read_string() |> Some
+        (2, _) => msg.extendee = reader |> @protobuf.read_string() |> Some
+        (7, _) => msg.default_value = reader |> @protobuf.read_string() |> Some
+        (9, _) => msg.oneof_index = reader |> @protobuf.read_int32() |> Some
+        (10, _) => msg.json_name = reader |> @protobuf.read_string() |> Some
         (8, _) =>
           msg.options = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FieldOptions::default()
               } else {
@@ -2152,9 +2927,8 @@ pub async fn[R : @protobuf.AsyncReader] FieldDescriptorProto::read_with_limit(
               }
             }
             |> Some
-        (17, _) =>
-          msg.proto3_optional = reader |> @protobuf.async_read_bool() |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (17, _) => msg.proto3_optional = reader |> @protobuf.read_bool() |> Some
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -2166,85 +2940,85 @@ pub async fn[R : @protobuf.AsyncReader] FieldDescriptorProto::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FieldDescriptorProto::write(
+pub fn[W : @protobuf.Writer] FieldDescriptorProto::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.number {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.label {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(32UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.type_ {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(40UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.type_name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(50UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(50UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.extendee {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.default_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(58UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(58UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.oneof_index {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(72UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(72UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.json_name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(82UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(82UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(66UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(66UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.proto3_optional {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(136UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(136UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
@@ -2338,6 +3112,161 @@ pub impl @json.FromJson for FieldDescriptorProto with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] FieldDescriptorProto::async_read(
+  reader : R,
+) -> FieldDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FieldDescriptorProto::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FieldDescriptorProto::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FieldDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FieldDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+        (3, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
+        (4, _) =>
+          msg.label = reader
+            |> @protobuf.async_read_enum()
+            |> FieldDescriptorProto_Label::from_enum
+            |> Some
+        (5, _) =>
+          msg.type_ = reader
+            |> @protobuf.async_read_enum()
+            |> FieldDescriptorProto_Type::from_enum
+            |> Some
+        (6, _) =>
+          msg.type_name = reader |> @protobuf.async_read_string() |> Some
+        (2, _) => msg.extendee = reader |> @protobuf.async_read_string() |> Some
+        (7, _) =>
+          msg.default_value = reader |> @protobuf.async_read_string() |> Some
+        (9, _) =>
+          msg.oneof_index = reader |> @protobuf.async_read_int32() |> Some
+        (10, _) =>
+          msg.json_name = reader |> @protobuf.async_read_string() |> Some
+        (8, _) =>
+          msg.options = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FieldOptions::default()
+              } else {
+                FieldOptions::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (17, _) =>
+          msg.proto3_optional = reader |> @protobuf.async_read_bool() |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FieldDescriptorProto::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.number {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.label {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.type_ {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.type_name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(50UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.extendee {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.default_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(58UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.oneof_index {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(72UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.json_name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(82UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(66UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.proto3_optional {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(136UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct OneofDescriptorProto {
   mut name : String?
   mut options : OneofOptions?
@@ -2373,7 +3302,7 @@ pub impl Default for OneofDescriptorProto with default() -> OneofDescriptorProto
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] OneofDescriptorProto::read(
+pub fn[R : @protobuf.Reader] OneofDescriptorProto::read(
   reader : R,
 ) -> OneofDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -2381,7 +3310,7 @@ pub async fn[R : @protobuf.AsyncReader] OneofDescriptorProto::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] OneofDescriptorProto::read_with_limit(
+pub fn[R : @protobuf.Reader] OneofDescriptorProto::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> OneofDescriptorProto raise {
@@ -2397,11 +3326,11 @@ pub async fn[R : @protobuf.AsyncReader] OneofDescriptorProto::read_with_limit(
   let msg = OneofDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
         (2, _) =>
           msg.options = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 OneofOptions::default()
               } else {
@@ -2409,7 +3338,7 @@ pub async fn[R : @protobuf.AsyncReader] OneofDescriptorProto::read_with_limit(
               }
             }
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -2421,21 +3350,21 @@ pub async fn[R : @protobuf.AsyncReader] OneofDescriptorProto::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] OneofDescriptorProto::write(
+pub fn[W : @protobuf.Writer] OneofDescriptorProto::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(18UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
@@ -2479,6 +3408,76 @@ pub impl @json.FromJson for OneofDescriptorProto with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] OneofDescriptorProto::async_read(
+  reader : R,
+) -> OneofDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  OneofDescriptorProto::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] OneofDescriptorProto::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> OneofDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = OneofDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+        (2, _) =>
+          msg.options = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                OneofOptions::default()
+              } else {
+                OneofOptions::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] OneofDescriptorProto::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct EnumDescriptorProto_EnumReservedRange {
   mut start : Int?
   mut end : Int?
@@ -2506,7 +3505,7 @@ pub impl Default for EnumDescriptorProto_EnumReservedRange with default() -> Enu
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::read(
+pub fn[R : @protobuf.Reader] EnumDescriptorProto_EnumReservedRange::read(
   reader : R,
 ) -> EnumDescriptorProto_EnumReservedRange raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -2514,7 +3513,7 @@ pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::r
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::read_with_limit(
+pub fn[R : @protobuf.Reader] EnumDescriptorProto_EnumReservedRange::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> EnumDescriptorProto_EnumReservedRange raise {
@@ -2530,10 +3529,10 @@ pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::r
   let msg = EnumDescriptorProto_EnumReservedRange::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
-        (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.start = reader |> @protobuf.read_int32() |> Some
+        (2, _) => msg.end = reader |> @protobuf.read_int32() |> Some
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -2545,21 +3544,21 @@ pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::r
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] EnumDescriptorProto_EnumReservedRange::write(
+pub fn[W : @protobuf.Writer] EnumDescriptorProto_EnumReservedRange::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.start {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(8UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.end {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
@@ -2598,6 +3597,66 @@ pub impl @json.FromJson for EnumDescriptorProto_EnumReservedRange with from_json
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::async_read(
+  reader : R,
+) -> EnumDescriptorProto_EnumReservedRange raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EnumDescriptorProto_EnumReservedRange::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> EnumDescriptorProto_EnumReservedRange raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = EnumDescriptorProto_EnumReservedRange::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
+        (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] EnumDescriptorProto_EnumReservedRange::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.start {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.end {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -2660,7 +3719,7 @@ pub impl Default for EnumDescriptorProto with default() -> EnumDescriptorProto {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto::read(
+pub fn[R : @protobuf.Reader] EnumDescriptorProto::read(
   reader : R,
 ) -> EnumDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -2668,7 +3727,7 @@ pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(
+pub fn[R : @protobuf.Reader] EnumDescriptorProto::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> EnumDescriptorProto raise {
@@ -2684,12 +3743,12 @@ pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(
   let msg = EnumDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
         (2, _) =>
           msg.value.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 EnumValueDescriptorProto::default()
               } else {
@@ -2699,7 +3758,7 @@ pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(
           )
         (3, _) =>
           msg.options = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 EnumOptions::default()
               } else {
@@ -2710,7 +3769,7 @@ pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(
         (4, _) =>
           msg.reserved_range.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 EnumDescriptorProto_EnumReservedRange::default()
               } else {
@@ -2721,9 +3780,8 @@ pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(
               }
             },
           )
-        (5, _) =>
-          msg.reserved_name.push(reader |> @protobuf.async_read_string())
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (5, _) => msg.reserved_name.push(reader |> @protobuf.read_string())
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -2735,38 +3793,38 @@ pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] EnumDescriptorProto::write(
+pub fn[W : @protobuf.Writer] EnumDescriptorProto::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   for item in self.value {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(18UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(26UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   for item in self.reserved_range {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   for item in self.reserved_name {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_string(item)
   }
 }
 
@@ -2822,6 +3880,120 @@ pub impl @json.FromJson for EnumDescriptorProto with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto::async_read(
+  reader : R,
+) -> EnumDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EnumDescriptorProto::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] EnumDescriptorProto::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> EnumDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = EnumDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+        (2, _) =>
+          msg.value.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                EnumValueDescriptorProto::default()
+              } else {
+                EnumValueDescriptorProto::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (3, _) =>
+          msg.options = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                EnumOptions::default()
+              } else {
+                EnumOptions::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (4, _) =>
+          msg.reserved_range.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                EnumDescriptorProto_EnumReservedRange::default()
+              } else {
+                EnumDescriptorProto_EnumReservedRange::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (5, _) =>
+          msg.reserved_name.push(reader |> @protobuf.async_read_string())
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] EnumDescriptorProto::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  for item in self.value {
+    writer |> @protobuf.async_write_varint(18UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  for item in self.reserved_range {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  for item in self.reserved_name {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_string(item)
+  }
+}
+
+///|
 pub(all) struct EnumValueDescriptorProto {
   mut name : String?
   mut number : Int?
@@ -2862,7 +4034,7 @@ pub impl Default for EnumValueDescriptorProto with default() -> EnumValueDescrip
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EnumValueDescriptorProto::read(
+pub fn[R : @protobuf.Reader] EnumValueDescriptorProto::read(
   reader : R,
 ) -> EnumValueDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -2870,7 +4042,7 @@ pub async fn[R : @protobuf.AsyncReader] EnumValueDescriptorProto::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EnumValueDescriptorProto::read_with_limit(
+pub fn[R : @protobuf.Reader] EnumValueDescriptorProto::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> EnumValueDescriptorProto raise {
@@ -2886,12 +4058,12 @@ pub async fn[R : @protobuf.AsyncReader] EnumValueDescriptorProto::read_with_limi
   let msg = EnumValueDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
-        (2, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
+        (2, _) => msg.number = reader |> @protobuf.read_int32() |> Some
         (3, _) =>
           msg.options = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 EnumValueOptions::default()
               } else {
@@ -2899,7 +4071,7 @@ pub async fn[R : @protobuf.AsyncReader] EnumValueDescriptorProto::read_with_limi
               }
             }
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -2911,28 +4083,28 @@ pub async fn[R : @protobuf.AsyncReader] EnumValueDescriptorProto::read_with_limi
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] EnumValueDescriptorProto::write(
+pub fn[W : @protobuf.Writer] EnumValueDescriptorProto::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.number {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(26UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
@@ -2981,6 +4153,84 @@ pub impl @json.FromJson for EnumValueDescriptorProto with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] EnumValueDescriptorProto::async_read(
+  reader : R,
+) -> EnumValueDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EnumValueDescriptorProto::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] EnumValueDescriptorProto::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> EnumValueDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = EnumValueDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+        (2, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
+        (3, _) =>
+          msg.options = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                EnumValueOptions::default()
+              } else {
+                EnumValueOptions::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] EnumValueDescriptorProto::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.number {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct ServiceDescriptorProto {
   mut name : String?
   mut method_ : Array[MethodDescriptorProto]
@@ -3022,7 +4272,7 @@ pub impl Default for ServiceDescriptorProto with default() -> ServiceDescriptorP
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] ServiceDescriptorProto::read(
+pub fn[R : @protobuf.Reader] ServiceDescriptorProto::read(
   reader : R,
 ) -> ServiceDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -3030,7 +4280,7 @@ pub async fn[R : @protobuf.AsyncReader] ServiceDescriptorProto::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] ServiceDescriptorProto::read_with_limit(
+pub fn[R : @protobuf.Reader] ServiceDescriptorProto::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> ServiceDescriptorProto raise {
@@ -3046,12 +4296,12 @@ pub async fn[R : @protobuf.AsyncReader] ServiceDescriptorProto::read_with_limit(
   let msg = ServiceDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
         (2, _) =>
           msg.method_.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 MethodDescriptorProto::default()
               } else {
@@ -3061,7 +4311,7 @@ pub async fn[R : @protobuf.AsyncReader] ServiceDescriptorProto::read_with_limit(
           )
         (3, _) =>
           msg.options = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 ServiceOptions::default()
               } else {
@@ -3069,7 +4319,7 @@ pub async fn[R : @protobuf.AsyncReader] ServiceDescriptorProto::read_with_limit(
               }
             }
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -3081,26 +4331,26 @@ pub async fn[R : @protobuf.AsyncReader] ServiceDescriptorProto::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] ServiceDescriptorProto::write(
+pub fn[W : @protobuf.Writer] ServiceDescriptorProto::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   for item in self.method_ {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(18UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(26UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
@@ -3146,6 +4396,92 @@ pub impl @json.FromJson for ServiceDescriptorProto with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] ServiceDescriptorProto::async_read(
+  reader : R,
+) -> ServiceDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  ServiceDescriptorProto::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] ServiceDescriptorProto::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> ServiceDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = ServiceDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+        (2, _) =>
+          msg.method_.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                MethodDescriptorProto::default()
+              } else {
+                MethodDescriptorProto::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (3, _) =>
+          msg.options = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                ServiceOptions::default()
+              } else {
+                ServiceOptions::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] ServiceDescriptorProto::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  for item in self.method_ {
+    writer |> @protobuf.async_write_varint(18UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -3221,7 +4557,7 @@ pub impl Default for MethodDescriptorProto with default() -> MethodDescriptorPro
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] MethodDescriptorProto::read(
+pub fn[R : @protobuf.Reader] MethodDescriptorProto::read(
   reader : R,
 ) -> MethodDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -3229,7 +4565,7 @@ pub async fn[R : @protobuf.AsyncReader] MethodDescriptorProto::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] MethodDescriptorProto::read_with_limit(
+pub fn[R : @protobuf.Reader] MethodDescriptorProto::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> MethodDescriptorProto raise {
@@ -3245,15 +4581,13 @@ pub async fn[R : @protobuf.AsyncReader] MethodDescriptorProto::read_with_limit(
   let msg = MethodDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
-        (2, _) =>
-          msg.input_type = reader |> @protobuf.async_read_string() |> Some
-        (3, _) =>
-          msg.output_type = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
+        (2, _) => msg.input_type = reader |> @protobuf.read_string() |> Some
+        (3, _) => msg.output_type = reader |> @protobuf.read_string() |> Some
         (4, _) =>
           msg.options = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 MethodOptions::default()
               } else {
@@ -3261,11 +4595,9 @@ pub async fn[R : @protobuf.AsyncReader] MethodDescriptorProto::read_with_limit(
               }
             }
             |> Some
-        (5, _) =>
-          msg.client_streaming = reader |> @protobuf.async_read_bool() |> Some
-        (6, _) =>
-          msg.server_streaming = reader |> @protobuf.async_read_bool() |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (5, _) => msg.client_streaming = reader |> @protobuf.read_bool() |> Some
+        (6, _) => msg.server_streaming = reader |> @protobuf.read_bool() |> Some
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -3277,50 +4609,50 @@ pub async fn[R : @protobuf.AsyncReader] MethodDescriptorProto::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] MethodDescriptorProto::write(
+pub fn[W : @protobuf.Writer] MethodDescriptorProto::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.input_type {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.output_type {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(34UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.client_streaming {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(40UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.server_streaming {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(48UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(48UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
@@ -3384,6 +4716,112 @@ pub impl @json.FromJson for MethodDescriptorProto with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] MethodDescriptorProto::async_read(
+  reader : R,
+) -> MethodDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  MethodDescriptorProto::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] MethodDescriptorProto::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> MethodDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = MethodDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+        (2, _) =>
+          msg.input_type = reader |> @protobuf.async_read_string() |> Some
+        (3, _) =>
+          msg.output_type = reader |> @protobuf.async_read_string() |> Some
+        (4, _) =>
+          msg.options = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                MethodOptions::default()
+              } else {
+                MethodOptions::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (5, _) =>
+          msg.client_streaming = reader |> @protobuf.async_read_bool() |> Some
+        (6, _) =>
+          msg.server_streaming = reader |> @protobuf.async_read_bool() |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] MethodDescriptorProto::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.input_type {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.output_type {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.client_streaming {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.server_streaming {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(48UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -3657,15 +5095,13 @@ pub impl Default for FileOptions with default() -> FileOptions {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FileOptions::read(
-  reader : R,
-) -> FileOptions raise {
+pub fn[R : @protobuf.Reader] FileOptions::read(reader : R) -> FileOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FileOptions::read_with_limit(reader)
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FileOptions::read_with_limit(
+pub fn[R : @protobuf.Reader] FileOptions::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FileOptions raise {
@@ -3681,69 +5117,47 @@ pub async fn[R : @protobuf.AsyncReader] FileOptions::read_with_limit(
   let msg = FileOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) =>
-          msg.java_package = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.java_package = reader |> @protobuf.read_string() |> Some
         (8, _) =>
-          msg.java_outer_classname = reader
-            |> @protobuf.async_read_string()
-            |> Some
+          msg.java_outer_classname = reader |> @protobuf.read_string() |> Some
         (10, _) =>
-          msg.java_multiple_files = reader
-            |> @protobuf.async_read_bool()
-            |> Some
+          msg.java_multiple_files = reader |> @protobuf.read_bool() |> Some
         (20, _) =>
           msg.java_generate_equals_and_hash = reader
-            |> @protobuf.async_read_bool()
+            |> @protobuf.read_bool()
             |> Some
         (27, _) =>
-          msg.java_string_check_utf8 = reader
-            |> @protobuf.async_read_bool()
-            |> Some
+          msg.java_string_check_utf8 = reader |> @protobuf.read_bool() |> Some
         (9, _) =>
           msg.optimize_for = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FileOptions_OptimizeMode::from_enum
             |> Some
-        (11, _) =>
-          msg.go_package = reader |> @protobuf.async_read_string() |> Some
+        (11, _) => msg.go_package = reader |> @protobuf.read_string() |> Some
         (16, _) =>
-          msg.cc_generic_services = reader
-            |> @protobuf.async_read_bool()
-            |> Some
+          msg.cc_generic_services = reader |> @protobuf.read_bool() |> Some
         (17, _) =>
-          msg.java_generic_services = reader
-            |> @protobuf.async_read_bool()
-            |> Some
+          msg.java_generic_services = reader |> @protobuf.read_bool() |> Some
         (18, _) =>
-          msg.py_generic_services = reader
-            |> @protobuf.async_read_bool()
-            |> Some
-        (23, _) =>
-          msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+          msg.py_generic_services = reader |> @protobuf.read_bool() |> Some
+        (23, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
         (31, _) =>
-          msg.cc_enable_arenas = reader |> @protobuf.async_read_bool() |> Some
+          msg.cc_enable_arenas = reader |> @protobuf.read_bool() |> Some
         (36, _) =>
-          msg.objc_class_prefix = reader
-            |> @protobuf.async_read_string()
-            |> Some
+          msg.objc_class_prefix = reader |> @protobuf.read_string() |> Some
         (37, _) =>
-          msg.csharp_namespace = reader |> @protobuf.async_read_string() |> Some
-        (39, _) =>
-          msg.swift_prefix = reader |> @protobuf.async_read_string() |> Some
+          msg.csharp_namespace = reader |> @protobuf.read_string() |> Some
+        (39, _) => msg.swift_prefix = reader |> @protobuf.read_string() |> Some
         (40, _) =>
-          msg.php_class_prefix = reader |> @protobuf.async_read_string() |> Some
-        (41, _) =>
-          msg.php_namespace = reader |> @protobuf.async_read_string() |> Some
+          msg.php_class_prefix = reader |> @protobuf.read_string() |> Some
+        (41, _) => msg.php_namespace = reader |> @protobuf.read_string() |> Some
         (44, _) =>
-          msg.php_metadata_namespace = reader
-            |> @protobuf.async_read_string()
-            |> Some
-        (45, _) =>
-          msg.ruby_package = reader |> @protobuf.async_read_string() |> Some
+          msg.php_metadata_namespace = reader |> @protobuf.read_string() |> Some
+        (45, _) => msg.ruby_package = reader |> @protobuf.read_string() |> Some
         (50, _) =>
           msg.features = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSet::default()
               } else {
@@ -3754,7 +5168,7 @@ pub async fn[R : @protobuf.AsyncReader] FileOptions::read_with_limit(
         (999, _) =>
           msg.uninterpreted_option.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 UninterpretedOption::default()
               } else {
@@ -3762,7 +5176,7 @@ pub async fn[R : @protobuf.AsyncReader] FileOptions::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -3774,154 +5188,154 @@ pub async fn[R : @protobuf.AsyncReader] FileOptions::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FileOptions::write(
+pub fn[W : @protobuf.Writer] FileOptions::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.java_package {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.java_outer_classname {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(66UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(66UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.java_multiple_files {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(80UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(80UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.java_generate_equals_and_hash {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(160UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(160UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.java_string_check_utf8 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(216UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(216UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.optimize_for {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(72UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(72UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.go_package {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(90UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(90UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.cc_generic_services {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(128UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(128UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.java_generic_services {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(136UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(136UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.py_generic_services {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(144UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(144UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(184UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(184UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.cc_enable_arenas {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(248UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(248UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.objc_class_prefix {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(290UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(290UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.csharp_namespace {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(298UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(298UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.swift_prefix {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(314UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(314UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.php_class_prefix {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(322UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(322UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.php_namespace {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(330UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(330UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.php_metadata_namespace {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(354UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(354UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.ruby_package {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(362UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(362UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(402UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(402UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -4078,6 +5492,276 @@ pub impl @json.FromJson for FileOptions with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] FileOptions::async_read(
+  reader : R,
+) -> FileOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FileOptions::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FileOptions::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FileOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FileOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.java_package = reader |> @protobuf.async_read_string() |> Some
+        (8, _) =>
+          msg.java_outer_classname = reader
+            |> @protobuf.async_read_string()
+            |> Some
+        (10, _) =>
+          msg.java_multiple_files = reader
+            |> @protobuf.async_read_bool()
+            |> Some
+        (20, _) =>
+          msg.java_generate_equals_and_hash = reader
+            |> @protobuf.async_read_bool()
+            |> Some
+        (27, _) =>
+          msg.java_string_check_utf8 = reader
+            |> @protobuf.async_read_bool()
+            |> Some
+        (9, _) =>
+          msg.optimize_for = reader
+            |> @protobuf.async_read_enum()
+            |> FileOptions_OptimizeMode::from_enum
+            |> Some
+        (11, _) =>
+          msg.go_package = reader |> @protobuf.async_read_string() |> Some
+        (16, _) =>
+          msg.cc_generic_services = reader
+            |> @protobuf.async_read_bool()
+            |> Some
+        (17, _) =>
+          msg.java_generic_services = reader
+            |> @protobuf.async_read_bool()
+            |> Some
+        (18, _) =>
+          msg.py_generic_services = reader
+            |> @protobuf.async_read_bool()
+            |> Some
+        (23, _) =>
+          msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+        (31, _) =>
+          msg.cc_enable_arenas = reader |> @protobuf.async_read_bool() |> Some
+        (36, _) =>
+          msg.objc_class_prefix = reader
+            |> @protobuf.async_read_string()
+            |> Some
+        (37, _) =>
+          msg.csharp_namespace = reader |> @protobuf.async_read_string() |> Some
+        (39, _) =>
+          msg.swift_prefix = reader |> @protobuf.async_read_string() |> Some
+        (40, _) =>
+          msg.php_class_prefix = reader |> @protobuf.async_read_string() |> Some
+        (41, _) =>
+          msg.php_namespace = reader |> @protobuf.async_read_string() |> Some
+        (44, _) =>
+          msg.php_metadata_namespace = reader
+            |> @protobuf.async_read_string()
+            |> Some
+        (45, _) =>
+          msg.ruby_package = reader |> @protobuf.async_read_string() |> Some
+        (50, _) =>
+          msg.features = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSet::default()
+              } else {
+                FeatureSet::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (999, _) =>
+          msg.uninterpreted_option.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                UninterpretedOption::default()
+              } else {
+                UninterpretedOption::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FileOptions::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.java_package {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.java_outer_classname {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(66UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.java_multiple_files {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(80UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.java_generate_equals_and_hash {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(160UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.java_string_check_utf8 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(216UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.optimize_for {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(72UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.go_package {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(90UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.cc_generic_services {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(128UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.java_generic_services {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(136UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.py_generic_services {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(144UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(184UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.cc_enable_arenas {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(248UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.objc_class_prefix {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(290UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.csharp_namespace {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(298UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.swift_prefix {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(314UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.php_class_prefix {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(322UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.php_namespace {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(330UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.php_metadata_namespace {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(354UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.ruby_package {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(362UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(402UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+}
+
+///|
 pub(all) struct MessageOptions {
   mut message_set_wire_format : Bool?
   mut no_standard_descriptor_accessor : Bool?
@@ -4142,7 +5826,7 @@ pub impl Default for MessageOptions with default() -> MessageOptions {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] MessageOptions::read(
+pub fn[R : @protobuf.Reader] MessageOptions::read(
   reader : R,
 ) -> MessageOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -4150,7 +5834,7 @@ pub async fn[R : @protobuf.AsyncReader] MessageOptions::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] MessageOptions::read_with_limit(
+pub fn[R : @protobuf.Reader] MessageOptions::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> MessageOptions raise {
@@ -4166,24 +5850,22 @@ pub async fn[R : @protobuf.AsyncReader] MessageOptions::read_with_limit(
   let msg = MessageOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
-          msg.message_set_wire_format = reader
-            |> @protobuf.async_read_bool()
-            |> Some
+          msg.message_set_wire_format = reader |> @protobuf.read_bool() |> Some
         (2, _) =>
           msg.no_standard_descriptor_accessor = reader
-            |> @protobuf.async_read_bool()
+            |> @protobuf.read_bool()
             |> Some
-        (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
-        (7, _) => msg.map_entry = reader |> @protobuf.async_read_bool() |> Some
+        (3, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
+        (7, _) => msg.map_entry = reader |> @protobuf.read_bool() |> Some
         (11, _) =>
           msg.deprecated_legacy_json_field_conflicts = reader
-            |> @protobuf.async_read_bool()
+            |> @protobuf.read_bool()
             |> Some
         (12, _) =>
           msg.features = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSet::default()
               } else {
@@ -4194,7 +5876,7 @@ pub async fn[R : @protobuf.AsyncReader] MessageOptions::read_with_limit(
         (999, _) =>
           msg.uninterpreted_option.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 UninterpretedOption::default()
               } else {
@@ -4202,7 +5884,7 @@ pub async fn[R : @protobuf.AsyncReader] MessageOptions::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -4214,56 +5896,56 @@ pub async fn[R : @protobuf.AsyncReader] MessageOptions::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] MessageOptions::write(
+pub fn[W : @protobuf.Writer] MessageOptions::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.message_set_wire_format {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(8UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.no_standard_descriptor_accessor {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.map_entry {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(56UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(56UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.deprecated_legacy_json_field_conflicts {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(88UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(88UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(98UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(98UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -4334,6 +6016,133 @@ pub impl @json.FromJson for MessageOptions with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] MessageOptions::async_read(
+  reader : R,
+) -> MessageOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  MessageOptions::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] MessageOptions::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> MessageOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = MessageOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.message_set_wire_format = reader
+            |> @protobuf.async_read_bool()
+            |> Some
+        (2, _) =>
+          msg.no_standard_descriptor_accessor = reader
+            |> @protobuf.async_read_bool()
+            |> Some
+        (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+        (7, _) => msg.map_entry = reader |> @protobuf.async_read_bool() |> Some
+        (11, _) =>
+          msg.deprecated_legacy_json_field_conflicts = reader
+            |> @protobuf.async_read_bool()
+            |> Some
+        (12, _) =>
+          msg.features = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSet::default()
+              } else {
+                FeatureSet::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (999, _) =>
+          msg.uninterpreted_option.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                UninterpretedOption::default()
+              } else {
+                UninterpretedOption::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] MessageOptions::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.message_set_wire_format {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.no_standard_descriptor_accessor {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.map_entry {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(56UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.deprecated_legacy_json_field_conflicts {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(88UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(98UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
 }
 
 ///|
@@ -4703,7 +6512,7 @@ pub impl Default for FieldOptions_EditionDefault with default() -> FieldOptions_
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FieldOptions_EditionDefault::read(
+pub fn[R : @protobuf.Reader] FieldOptions_EditionDefault::read(
   reader : R,
 ) -> FieldOptions_EditionDefault raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -4711,7 +6520,7 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions_EditionDefault::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FieldOptions_EditionDefault::read_with_limit(
+pub fn[R : @protobuf.Reader] FieldOptions_EditionDefault::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FieldOptions_EditionDefault raise {
@@ -4727,14 +6536,14 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions_EditionDefault::read_with_l
   let msg = FieldOptions_EditionDefault::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (3, _) =>
           msg.edition = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> Edition::from_enum
             |> Some
-        (2, _) => msg.value = reader |> @protobuf.async_read_string() |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (2, _) => msg.value = reader |> @protobuf.read_string() |> Some
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -4746,21 +6555,21 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions_EditionDefault::read_with_l
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FieldOptions_EditionDefault::write(
+pub fn[W : @protobuf.Writer] FieldOptions_EditionDefault::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
@@ -4800,6 +6609,70 @@ pub impl @json.FromJson for FieldOptions_EditionDefault with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FieldOptions_EditionDefault::async_read(
+  reader : R,
+) -> FieldOptions_EditionDefault raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FieldOptions_EditionDefault::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FieldOptions_EditionDefault::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FieldOptions_EditionDefault raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FieldOptions_EditionDefault::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (3, _) =>
+          msg.edition = reader
+            |> @protobuf.async_read_enum()
+            |> Edition::from_enum
+            |> Some
+        (2, _) => msg.value = reader |> @protobuf.async_read_string() |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FieldOptions_EditionDefault::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -4848,7 +6721,7 @@ pub impl Default for FieldOptions_FeatureSupport with default() -> FieldOptions_
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FieldOptions_FeatureSupport::read(
+pub fn[R : @protobuf.Reader] FieldOptions_FeatureSupport::read(
   reader : R,
 ) -> FieldOptions_FeatureSupport raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -4856,7 +6729,7 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions_FeatureSupport::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FieldOptions_FeatureSupport::read_with_limit(
+pub fn[R : @protobuf.Reader] FieldOptions_FeatureSupport::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FieldOptions_FeatureSupport raise {
@@ -4872,27 +6745,25 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions_FeatureSupport::read_with_l
   let msg = FieldOptions_FeatureSupport::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.edition_introduced = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> Edition::from_enum
             |> Some
         (2, _) =>
           msg.edition_deprecated = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> Edition::from_enum
             |> Some
         (3, _) =>
-          msg.deprecation_warning = reader
-            |> @protobuf.async_read_string()
-            |> Some
+          msg.deprecation_warning = reader |> @protobuf.read_string() |> Some
         (4, _) =>
           msg.edition_removed = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> Edition::from_enum
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -4904,35 +6775,35 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions_FeatureSupport::read_with_l
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FieldOptions_FeatureSupport::write(
+pub fn[W : @protobuf.Writer] FieldOptions_FeatureSupport::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.edition_introduced {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(8UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.edition_deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.deprecation_warning {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.edition_removed {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(32UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
@@ -4985,6 +6856,97 @@ pub impl @json.FromJson for FieldOptions_FeatureSupport with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FieldOptions_FeatureSupport::async_read(
+  reader : R,
+) -> FieldOptions_FeatureSupport raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FieldOptions_FeatureSupport::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FieldOptions_FeatureSupport::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FieldOptions_FeatureSupport raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FieldOptions_FeatureSupport::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.edition_introduced = reader
+            |> @protobuf.async_read_enum()
+            |> Edition::from_enum
+            |> Some
+        (2, _) =>
+          msg.edition_deprecated = reader
+            |> @protobuf.async_read_enum()
+            |> Edition::from_enum
+            |> Some
+        (3, _) =>
+          msg.deprecation_warning = reader
+            |> @protobuf.async_read_string()
+            |> Some
+        (4, _) =>
+          msg.edition_removed = reader
+            |> @protobuf.async_read_enum()
+            |> Edition::from_enum
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FieldOptions_FeatureSupport::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.edition_introduced {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.edition_deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.deprecation_warning {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.edition_removed {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -5101,7 +7063,7 @@ pub impl Default for FieldOptions with default() -> FieldOptions {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FieldOptions::read(
+pub fn[R : @protobuf.Reader] FieldOptions::read(
   reader : R,
 ) -> FieldOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -5109,7 +7071,7 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FieldOptions::read_with_limit(
+pub fn[R : @protobuf.Reader] FieldOptions::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FieldOptions raise {
@@ -5125,40 +7087,38 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions::read_with_limit(
   let msg = FieldOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.ctype = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FieldOptions_CType::from_enum
             |> Some
-        (2, _) => msg.packed = reader |> @protobuf.async_read_bool() |> Some
+        (2, _) => msg.packed = reader |> @protobuf.read_bool() |> Some
         (6, _) =>
           msg.jstype = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FieldOptions_JSType::from_enum
             |> Some
-        (5, _) => msg.lazy_ = reader |> @protobuf.async_read_bool() |> Some
-        (15, _) =>
-          msg.unverified_lazy = reader |> @protobuf.async_read_bool() |> Some
-        (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
-        (10, _) => msg.weak = reader |> @protobuf.async_read_bool() |> Some
-        (16, _) =>
-          msg.debug_redact = reader |> @protobuf.async_read_bool() |> Some
+        (5, _) => msg.lazy_ = reader |> @protobuf.read_bool() |> Some
+        (15, _) => msg.unverified_lazy = reader |> @protobuf.read_bool() |> Some
+        (3, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
+        (10, _) => msg.weak = reader |> @protobuf.read_bool() |> Some
+        (16, _) => msg.debug_redact = reader |> @protobuf.read_bool() |> Some
         (17, _) =>
           msg.retention = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FieldOptions_OptionRetention::from_enum
             |> Some
         (19, _) =>
           msg.targets.push(
             reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FieldOptions_OptionTargetType::from_enum,
           )
         (20, _) =>
           msg.edition_defaults.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FieldOptions_EditionDefault::default()
               } else {
@@ -5168,7 +7128,7 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions::read_with_limit(
           )
         (21, _) =>
           msg.features = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSet::default()
               } else {
@@ -5178,7 +7138,7 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions::read_with_limit(
             |> Some
         (22, _) =>
           msg.feature_support = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FieldOptions_FeatureSupport::default()
               } else {
@@ -5189,7 +7149,7 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions::read_with_limit(
         (999, _) =>
           msg.uninterpreted_option.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 UninterpretedOption::default()
               } else {
@@ -5197,7 +7157,7 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -5209,101 +7169,101 @@ pub async fn[R : @protobuf.AsyncReader] FieldOptions::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FieldOptions::write(
+pub fn[W : @protobuf.Writer] FieldOptions::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.ctype {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(8UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.packed {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.jstype {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(48UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(48UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.lazy_ {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(40UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.unverified_lazy {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(120UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(120UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.weak {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(80UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(80UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.debug_redact {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(128UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(128UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.retention {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(136UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(136UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   for item in self.targets {
-    writer |> @protobuf.async_write_varint(152UL)
-    writer |> @protobuf.async_write_enum(item.to_enum())
+    writer |> @protobuf.write_varint(152UL)
+    writer |> @protobuf.write_enum(item.to_enum())
   }
   for item in self.edition_defaults {
-    writer |> @protobuf.async_write_varint(162UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(162UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(170UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(170UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.feature_support {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(178UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(178UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -5409,6 +7369,220 @@ pub impl @json.FromJson for FieldOptions with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] FieldOptions::async_read(
+  reader : R,
+) -> FieldOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FieldOptions::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FieldOptions::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FieldOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FieldOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.ctype = reader
+            |> @protobuf.async_read_enum()
+            |> FieldOptions_CType::from_enum
+            |> Some
+        (2, _) => msg.packed = reader |> @protobuf.async_read_bool() |> Some
+        (6, _) =>
+          msg.jstype = reader
+            |> @protobuf.async_read_enum()
+            |> FieldOptions_JSType::from_enum
+            |> Some
+        (5, _) => msg.lazy_ = reader |> @protobuf.async_read_bool() |> Some
+        (15, _) =>
+          msg.unverified_lazy = reader |> @protobuf.async_read_bool() |> Some
+        (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+        (10, _) => msg.weak = reader |> @protobuf.async_read_bool() |> Some
+        (16, _) =>
+          msg.debug_redact = reader |> @protobuf.async_read_bool() |> Some
+        (17, _) =>
+          msg.retention = reader
+            |> @protobuf.async_read_enum()
+            |> FieldOptions_OptionRetention::from_enum
+            |> Some
+        (19, _) =>
+          msg.targets.push(
+            reader
+            |> @protobuf.async_read_enum()
+            |> FieldOptions_OptionTargetType::from_enum,
+          )
+        (20, _) =>
+          msg.edition_defaults.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FieldOptions_EditionDefault::default()
+              } else {
+                FieldOptions_EditionDefault::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (21, _) =>
+          msg.features = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSet::default()
+              } else {
+                FeatureSet::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (22, _) =>
+          msg.feature_support = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FieldOptions_FeatureSupport::default()
+              } else {
+                FieldOptions_FeatureSupport::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            }
+            |> Some
+        (999, _) =>
+          msg.uninterpreted_option.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                UninterpretedOption::default()
+              } else {
+                UninterpretedOption::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FieldOptions::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.ctype {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.packed {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.jstype {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(48UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.lazy_ {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.unverified_lazy {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(120UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.weak {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(80UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.debug_redact {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(128UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.retention {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(136UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  for item in self.targets {
+    writer |> @protobuf.async_write_varint(152UL)
+    writer |> @protobuf.async_write_enum(item.to_enum())
+  }
+  for item in self.edition_defaults {
+    writer |> @protobuf.async_write_varint(162UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(170UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.feature_support {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(178UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+}
+
+///|
 pub(all) struct OneofOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
@@ -5440,7 +7614,7 @@ pub impl Default for OneofOptions with default() -> OneofOptions {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] OneofOptions::read(
+pub fn[R : @protobuf.Reader] OneofOptions::read(
   reader : R,
 ) -> OneofOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -5448,7 +7622,7 @@ pub async fn[R : @protobuf.AsyncReader] OneofOptions::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] OneofOptions::read_with_limit(
+pub fn[R : @protobuf.Reader] OneofOptions::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> OneofOptions raise {
@@ -5464,10 +7638,10 @@ pub async fn[R : @protobuf.AsyncReader] OneofOptions::read_with_limit(
   let msg = OneofOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.features = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSet::default()
               } else {
@@ -5478,7 +7652,7 @@ pub async fn[R : @protobuf.AsyncReader] OneofOptions::read_with_limit(
         (999, _) =>
           msg.uninterpreted_option.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 UninterpretedOption::default()
               } else {
@@ -5486,7 +7660,7 @@ pub async fn[R : @protobuf.AsyncReader] OneofOptions::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -5498,21 +7672,21 @@ pub async fn[R : @protobuf.AsyncReader] OneofOptions::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] OneofOptions::write(
+pub fn[W : @protobuf.Writer] OneofOptions::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -5549,6 +7723,84 @@ pub impl @json.FromJson for OneofOptions with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] OneofOptions::async_read(
+  reader : R,
+) -> OneofOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  OneofOptions::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] OneofOptions::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> OneofOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = OneofOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.features = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSet::default()
+              } else {
+                FeatureSet::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (999, _) =>
+          msg.uninterpreted_option.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                UninterpretedOption::default()
+              } else {
+                UninterpretedOption::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] OneofOptions::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
 }
 
 ///|
@@ -5604,15 +7856,13 @@ pub impl Default for EnumOptions with default() -> EnumOptions {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EnumOptions::read(
-  reader : R,
-) -> EnumOptions raise {
+pub fn[R : @protobuf.Reader] EnumOptions::read(reader : R) -> EnumOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
   EnumOptions::read_with_limit(reader)
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EnumOptions::read_with_limit(
+pub fn[R : @protobuf.Reader] EnumOptions::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> EnumOptions raise {
@@ -5628,17 +7878,16 @@ pub async fn[R : @protobuf.AsyncReader] EnumOptions::read_with_limit(
   let msg = EnumOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (2, _) =>
-          msg.allow_alias = reader |> @protobuf.async_read_bool() |> Some
-        (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (2, _) => msg.allow_alias = reader |> @protobuf.read_bool() |> Some
+        (3, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
         (6, _) =>
           msg.deprecated_legacy_json_field_conflicts = reader
-            |> @protobuf.async_read_bool()
+            |> @protobuf.read_bool()
             |> Some
         (7, _) =>
           msg.features = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSet::default()
               } else {
@@ -5649,7 +7898,7 @@ pub async fn[R : @protobuf.AsyncReader] EnumOptions::read_with_limit(
         (999, _) =>
           msg.uninterpreted_option.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 UninterpretedOption::default()
               } else {
@@ -5657,7 +7906,7 @@ pub async fn[R : @protobuf.AsyncReader] EnumOptions::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -5669,42 +7918,42 @@ pub async fn[R : @protobuf.AsyncReader] EnumOptions::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] EnumOptions::write(
+pub fn[W : @protobuf.Writer] EnumOptions::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.allow_alias {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.deprecated_legacy_json_field_conflicts {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(48UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(48UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(58UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(58UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -5761,6 +8010,112 @@ pub impl @json.FromJson for EnumOptions with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] EnumOptions::async_read(
+  reader : R,
+) -> EnumOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EnumOptions::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] EnumOptions::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> EnumOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = EnumOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (2, _) =>
+          msg.allow_alias = reader |> @protobuf.async_read_bool() |> Some
+        (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+        (6, _) =>
+          msg.deprecated_legacy_json_field_conflicts = reader
+            |> @protobuf.async_read_bool()
+            |> Some
+        (7, _) =>
+          msg.features = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSet::default()
+              } else {
+                FeatureSet::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (999, _) =>
+          msg.uninterpreted_option.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                UninterpretedOption::default()
+              } else {
+                UninterpretedOption::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] EnumOptions::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.allow_alias {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.deprecated_legacy_json_field_conflicts {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(48UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(58UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
 }
 
 ///|
@@ -5821,7 +8176,7 @@ pub impl Default for EnumValueOptions with default() -> EnumValueOptions {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EnumValueOptions::read(
+pub fn[R : @protobuf.Reader] EnumValueOptions::read(
   reader : R,
 ) -> EnumValueOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -5829,7 +8184,7 @@ pub async fn[R : @protobuf.AsyncReader] EnumValueOptions::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EnumValueOptions::read_with_limit(
+pub fn[R : @protobuf.Reader] EnumValueOptions::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> EnumValueOptions raise {
@@ -5845,11 +8200,11 @@ pub async fn[R : @protobuf.AsyncReader] EnumValueOptions::read_with_limit(
   let msg = EnumValueOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
         (2, _) =>
           msg.features = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSet::default()
               } else {
@@ -5857,11 +8212,10 @@ pub async fn[R : @protobuf.AsyncReader] EnumValueOptions::read_with_limit(
               }
             }
             |> Some
-        (3, _) =>
-          msg.debug_redact = reader |> @protobuf.async_read_bool() |> Some
+        (3, _) => msg.debug_redact = reader |> @protobuf.read_bool() |> Some
         (4, _) =>
           msg.feature_support = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FieldOptions_FeatureSupport::default()
               } else {
@@ -5872,7 +8226,7 @@ pub async fn[R : @protobuf.AsyncReader] EnumValueOptions::read_with_limit(
         (999, _) =>
           msg.uninterpreted_option.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 UninterpretedOption::default()
               } else {
@@ -5880,7 +8234,7 @@ pub async fn[R : @protobuf.AsyncReader] EnumValueOptions::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -5892,43 +8246,43 @@ pub async fn[R : @protobuf.AsyncReader] EnumValueOptions::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] EnumValueOptions::write(
+pub fn[W : @protobuf.Writer] EnumValueOptions::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(8UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(18UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.debug_redact {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.feature_support {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(34UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -5988,6 +8342,122 @@ pub impl @json.FromJson for EnumValueOptions with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] EnumValueOptions::async_read(
+  reader : R,
+) -> EnumValueOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EnumValueOptions::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] EnumValueOptions::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> EnumValueOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = EnumValueOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+        (2, _) =>
+          msg.features = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSet::default()
+              } else {
+                FeatureSet::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (3, _) =>
+          msg.debug_redact = reader |> @protobuf.async_read_bool() |> Some
+        (4, _) =>
+          msg.feature_support = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FieldOptions_FeatureSupport::default()
+              } else {
+                FieldOptions_FeatureSupport::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            }
+            |> Some
+        (999, _) =>
+          msg.uninterpreted_option.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                UninterpretedOption::default()
+              } else {
+                UninterpretedOption::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] EnumValueOptions::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.debug_redact {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.feature_support {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+}
+
+///|
 pub(all) struct ServiceOptions {
   mut features : FeatureSet?
   mut deprecated : Bool?
@@ -6028,7 +8498,7 @@ pub impl Default for ServiceOptions with default() -> ServiceOptions {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] ServiceOptions::read(
+pub fn[R : @protobuf.Reader] ServiceOptions::read(
   reader : R,
 ) -> ServiceOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -6036,7 +8506,7 @@ pub async fn[R : @protobuf.AsyncReader] ServiceOptions::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] ServiceOptions::read_with_limit(
+pub fn[R : @protobuf.Reader] ServiceOptions::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> ServiceOptions raise {
@@ -6052,10 +8522,10 @@ pub async fn[R : @protobuf.AsyncReader] ServiceOptions::read_with_limit(
   let msg = ServiceOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (34, _) =>
           msg.features = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSet::default()
               } else {
@@ -6063,12 +8533,11 @@ pub async fn[R : @protobuf.AsyncReader] ServiceOptions::read_with_limit(
               }
             }
             |> Some
-        (33, _) =>
-          msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+        (33, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
         (999, _) =>
           msg.uninterpreted_option.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 UninterpretedOption::default()
               } else {
@@ -6076,7 +8545,7 @@ pub async fn[R : @protobuf.AsyncReader] ServiceOptions::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -6088,28 +8557,28 @@ pub async fn[R : @protobuf.AsyncReader] ServiceOptions::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] ServiceOptions::write(
+pub fn[W : @protobuf.Writer] ServiceOptions::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(274UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(274UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(264UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(264UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -6152,6 +8621,93 @@ pub impl @json.FromJson for ServiceOptions with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] ServiceOptions::async_read(
+  reader : R,
+) -> ServiceOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  ServiceOptions::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] ServiceOptions::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> ServiceOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = ServiceOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (34, _) =>
+          msg.features = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSet::default()
+              } else {
+                FeatureSet::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (33, _) =>
+          msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+        (999, _) =>
+          msg.uninterpreted_option.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                UninterpretedOption::default()
+              } else {
+                UninterpretedOption::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] ServiceOptions::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(274UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(264UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
 }
 
 ///|
@@ -6274,7 +8830,7 @@ pub impl Default for MethodOptions with default() -> MethodOptions {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] MethodOptions::read(
+pub fn[R : @protobuf.Reader] MethodOptions::read(
   reader : R,
 ) -> MethodOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -6282,7 +8838,7 @@ pub async fn[R : @protobuf.AsyncReader] MethodOptions::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] MethodOptions::read_with_limit(
+pub fn[R : @protobuf.Reader] MethodOptions::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> MethodOptions raise {
@@ -6298,17 +8854,16 @@ pub async fn[R : @protobuf.AsyncReader] MethodOptions::read_with_limit(
   let msg = MethodOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (33, _) =>
-          msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (33, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
         (34, _) =>
           msg.idempotency_level = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> MethodOptions_IdempotencyLevel::from_enum
             |> Some
         (35, _) =>
           msg.features = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSet::default()
               } else {
@@ -6319,7 +8874,7 @@ pub async fn[R : @protobuf.AsyncReader] MethodOptions::read_with_limit(
         (999, _) =>
           msg.uninterpreted_option.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 UninterpretedOption::default()
               } else {
@@ -6327,7 +8882,7 @@ pub async fn[R : @protobuf.AsyncReader] MethodOptions::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -6339,35 +8894,35 @@ pub async fn[R : @protobuf.AsyncReader] MethodOptions::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] MethodOptions::write(
+pub fn[W : @protobuf.Writer] MethodOptions::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(264UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(264UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.idempotency_level {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(272UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(272UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(282UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(282UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -6420,6 +8975,105 @@ pub impl @json.FromJson for MethodOptions with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] MethodOptions::async_read(
+  reader : R,
+) -> MethodOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  MethodOptions::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] MethodOptions::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> MethodOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = MethodOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (33, _) =>
+          msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+        (34, _) =>
+          msg.idempotency_level = reader
+            |> @protobuf.async_read_enum()
+            |> MethodOptions_IdempotencyLevel::from_enum
+            |> Some
+        (35, _) =>
+          msg.features = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSet::default()
+              } else {
+                FeatureSet::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (999, _) =>
+          msg.uninterpreted_option.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                UninterpretedOption::default()
+              } else {
+                UninterpretedOption::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] MethodOptions::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(264UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.idempotency_level {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(272UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(282UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+}
+
+///|
 pub(all) struct UninterpretedOption_NamePart {
   mut name_part : String
   mut is_extension : Bool
@@ -6446,7 +9100,7 @@ pub impl Default for UninterpretedOption_NamePart with default() -> Uninterprete
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] UninterpretedOption_NamePart::read(
+pub fn[R : @protobuf.Reader] UninterpretedOption_NamePart::read(
   reader : R,
 ) -> UninterpretedOption_NamePart raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -6454,7 +9108,7 @@ pub async fn[R : @protobuf.AsyncReader] UninterpretedOption_NamePart::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] UninterpretedOption_NamePart::read_with_limit(
+pub fn[R : @protobuf.Reader] UninterpretedOption_NamePart::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> UninterpretedOption_NamePart raise {
@@ -6470,10 +9124,10 @@ pub async fn[R : @protobuf.AsyncReader] UninterpretedOption_NamePart::read_with_
   let msg = UninterpretedOption_NamePart::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.name_part = reader |> @protobuf.async_read_string()
-        (2, _) => msg.is_extension = reader |> @protobuf.async_read_bool()
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.name_part = reader |> @protobuf.read_string()
+        (2, _) => msg.is_extension = reader |> @protobuf.read_bool()
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -6485,14 +9139,14 @@ pub async fn[R : @protobuf.AsyncReader] UninterpretedOption_NamePart::read_with_
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] UninterpretedOption_NamePart::write(
+pub fn[W : @protobuf.Writer] UninterpretedOption_NamePart::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL)
-  writer |> @protobuf.async_write_string(self.name_part)
-  writer |> @protobuf.async_write_varint(16UL)
-  writer |> @protobuf.async_write_bool(self.is_extension)
+  writer |> @protobuf.write_varint(10UL)
+  writer |> @protobuf.write_string(self.name_part)
+  writer |> @protobuf.write_varint(16UL)
+  writer |> @protobuf.write_bool(self.is_extension)
 }
 
 ///|
@@ -6527,6 +9181,56 @@ pub impl @json.FromJson for UninterpretedOption_NamePart with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] UninterpretedOption_NamePart::async_read(
+  reader : R,
+) -> UninterpretedOption_NamePart raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  UninterpretedOption_NamePart::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] UninterpretedOption_NamePart::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> UninterpretedOption_NamePart raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = UninterpretedOption_NamePart::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.name_part = reader |> @protobuf.async_read_string()
+        (2, _) => msg.is_extension = reader |> @protobuf.async_read_bool()
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] UninterpretedOption_NamePart::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL)
+  writer |> @protobuf.async_write_string(self.name_part)
+  writer |> @protobuf.async_write_varint(16UL)
+  writer |> @protobuf.async_write_bool(self.is_extension)
 }
 
 ///|
@@ -6604,7 +9308,7 @@ pub impl Default for UninterpretedOption with default() -> UninterpretedOption {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] UninterpretedOption::read(
+pub fn[R : @protobuf.Reader] UninterpretedOption::read(
   reader : R,
 ) -> UninterpretedOption raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -6612,7 +9316,7 @@ pub async fn[R : @protobuf.AsyncReader] UninterpretedOption::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] UninterpretedOption::read_with_limit(
+pub fn[R : @protobuf.Reader] UninterpretedOption::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> UninterpretedOption raise {
@@ -6628,11 +9332,11 @@ pub async fn[R : @protobuf.AsyncReader] UninterpretedOption::read_with_limit(
   let msg = UninterpretedOption::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (2, _) =>
           msg.name.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 UninterpretedOption_NamePart::default()
               } else {
@@ -6641,22 +9345,16 @@ pub async fn[R : @protobuf.AsyncReader] UninterpretedOption::read_with_limit(
             },
           )
         (3, _) =>
-          msg.identifier_value = reader |> @protobuf.async_read_string() |> Some
+          msg.identifier_value = reader |> @protobuf.read_string() |> Some
         (4, _) =>
-          msg.positive_int_value = reader
-            |> @protobuf.async_read_uint64()
-            |> Some
+          msg.positive_int_value = reader |> @protobuf.read_uint64() |> Some
         (5, _) =>
-          msg.negative_int_value = reader
-            |> @protobuf.async_read_int64()
-            |> Some
-        (6, _) =>
-          msg.double_value = reader |> @protobuf.async_read_double() |> Some
-        (7, _) =>
-          msg.string_value = reader |> @protobuf.async_read_bytes() |> Some
+          msg.negative_int_value = reader |> @protobuf.read_int64() |> Some
+        (6, _) => msg.double_value = reader |> @protobuf.read_double() |> Some
+        (7, _) => msg.string_value = reader |> @protobuf.read_bytes() |> Some
         (8, _) =>
-          msg.aggregate_value = reader |> @protobuf.async_read_string() |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+          msg.aggregate_value = reader |> @protobuf.read_string() |> Some
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -6668,54 +9366,54 @@ pub async fn[R : @protobuf.AsyncReader] UninterpretedOption::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] UninterpretedOption::write(
+pub fn[W : @protobuf.Writer] UninterpretedOption::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   for item in self.name {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(18UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.identifier_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.positive_int_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL)
-      writer |> @protobuf.async_write_uint64(v)
+      writer |> @protobuf.write_varint(32UL)
+      writer |> @protobuf.write_uint64(v)
     }
     None => ()
   }
   match self.negative_int_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL)
-      writer |> @protobuf.async_write_int64(v)
+      writer |> @protobuf.write_varint(40UL)
+      writer |> @protobuf.write_int64(v)
     }
     None => ()
   }
   match self.double_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(49UL)
-      writer |> @protobuf.async_write_double(v)
+      writer |> @protobuf.write_varint(49UL)
+      writer |> @protobuf.write_double(v)
     }
     None => ()
   }
   match self.string_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(58UL)
-      writer |> @protobuf.async_write_bytes(v)
+      writer |> @protobuf.write_varint(58UL)
+      writer |> @protobuf.write_bytes(v)
     }
     None => ()
   }
   match self.aggregate_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(66UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(66UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
@@ -6785,6 +9483,127 @@ pub impl @json.FromJson for UninterpretedOption with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] UninterpretedOption::async_read(
+  reader : R,
+) -> UninterpretedOption raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  UninterpretedOption::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] UninterpretedOption::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> UninterpretedOption raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = UninterpretedOption::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (2, _) =>
+          msg.name.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                UninterpretedOption_NamePart::default()
+              } else {
+                UninterpretedOption_NamePart::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (3, _) =>
+          msg.identifier_value = reader |> @protobuf.async_read_string() |> Some
+        (4, _) =>
+          msg.positive_int_value = reader
+            |> @protobuf.async_read_uint64()
+            |> Some
+        (5, _) =>
+          msg.negative_int_value = reader
+            |> @protobuf.async_read_int64()
+            |> Some
+        (6, _) =>
+          msg.double_value = reader |> @protobuf.async_read_double() |> Some
+        (7, _) =>
+          msg.string_value = reader |> @protobuf.async_read_bytes() |> Some
+        (8, _) =>
+          msg.aggregate_value = reader |> @protobuf.async_read_string() |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] UninterpretedOption::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  for item in self.name {
+    writer |> @protobuf.async_write_varint(18UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.identifier_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.positive_int_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL)
+      writer |> @protobuf.async_write_uint64(v)
+    }
+    None => ()
+  }
+  match self.negative_int_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL)
+      writer |> @protobuf.async_write_int64(v)
+    }
+    None => ()
+  }
+  match self.double_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(49UL)
+      writer |> @protobuf.async_write_double(v)
+    }
+    None => ()
+  }
+  match self.string_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(58UL)
+      writer |> @protobuf.async_write_bytes(v)
+    }
+    None => ()
+  }
+  match self.aggregate_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(66UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -7284,15 +10103,13 @@ pub impl Default for FeatureSet with default() -> FeatureSet {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FeatureSet::read(
-  reader : R,
-) -> FeatureSet raise {
+pub fn[R : @protobuf.Reader] FeatureSet::read(reader : R) -> FeatureSet raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FeatureSet::read_with_limit(reader)
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FeatureSet::read_with_limit(
+pub fn[R : @protobuf.Reader] FeatureSet::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FeatureSet raise {
@@ -7308,38 +10125,38 @@ pub async fn[R : @protobuf.AsyncReader] FeatureSet::read_with_limit(
   let msg = FeatureSet::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.field_presence = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FeatureSet_FieldPresence::from_enum
             |> Some
         (2, _) =>
           msg.enum_type = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FeatureSet_EnumType::from_enum
             |> Some
         (3, _) =>
           msg.repeated_field_encoding = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FeatureSet_RepeatedFieldEncoding::from_enum
             |> Some
         (4, _) =>
           msg.utf8_validation = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FeatureSet_Utf8Validation::from_enum
             |> Some
         (5, _) =>
           msg.message_encoding = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FeatureSet_MessageEncoding::from_enum
             |> Some
         (6, _) =>
           msg.json_format = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FeatureSet_JsonFormat::from_enum
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -7351,49 +10168,49 @@ pub async fn[R : @protobuf.AsyncReader] FeatureSet::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FeatureSet::write(
+pub fn[W : @protobuf.Writer] FeatureSet::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.field_presence {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(8UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.enum_type {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.repeated_field_encoding {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.utf8_validation {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(32UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.message_encoding {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(40UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.json_format {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(48UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(48UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
@@ -7459,6 +10276,122 @@ pub impl @json.FromJson for FeatureSet with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] FeatureSet::async_read(
+  reader : R,
+) -> FeatureSet raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FeatureSet::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FeatureSet::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FeatureSet raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FeatureSet::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.field_presence = reader
+            |> @protobuf.async_read_enum()
+            |> FeatureSet_FieldPresence::from_enum
+            |> Some
+        (2, _) =>
+          msg.enum_type = reader
+            |> @protobuf.async_read_enum()
+            |> FeatureSet_EnumType::from_enum
+            |> Some
+        (3, _) =>
+          msg.repeated_field_encoding = reader
+            |> @protobuf.async_read_enum()
+            |> FeatureSet_RepeatedFieldEncoding::from_enum
+            |> Some
+        (4, _) =>
+          msg.utf8_validation = reader
+            |> @protobuf.async_read_enum()
+            |> FeatureSet_Utf8Validation::from_enum
+            |> Some
+        (5, _) =>
+          msg.message_encoding = reader
+            |> @protobuf.async_read_enum()
+            |> FeatureSet_MessageEncoding::from_enum
+            |> Some
+        (6, _) =>
+          msg.json_format = reader
+            |> @protobuf.async_read_enum()
+            |> FeatureSet_JsonFormat::from_enum
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FeatureSet::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.field_presence {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.enum_type {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.repeated_field_encoding {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.utf8_validation {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.message_encoding {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.json_format {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(48UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct FeatureSetDefaults_FeatureSetEditionDefault {
   mut edition : Edition?
   mut overridable_features : FeatureSet?
@@ -7505,7 +10438,7 @@ pub impl Default for FeatureSetDefaults_FeatureSetEditionDefault with default() 
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::read(
+pub fn[R : @protobuf.Reader] FeatureSetDefaults_FeatureSetEditionDefault::read(
   reader : R,
 ) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -7513,7 +10446,7 @@ pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefa
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::read_with_limit(
+pub fn[R : @protobuf.Reader] FeatureSetDefaults_FeatureSetEditionDefault::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
@@ -7529,15 +10462,15 @@ pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefa
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (3, _) =>
           msg.edition = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> Edition::from_enum
             |> Some
         (4, _) =>
           msg.overridable_features = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSet::default()
               } else {
@@ -7547,7 +10480,7 @@ pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefa
             |> Some
         (5, _) =>
           msg.fixed_features = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSet::default()
               } else {
@@ -7555,7 +10488,7 @@ pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefa
               }
             }
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -7567,29 +10500,29 @@ pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefa
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FeatureSetDefaults_FeatureSetEditionDefault::write(
+pub fn[W : @protobuf.Writer] FeatureSetDefaults_FeatureSetEditionDefault::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.overridable_features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(34UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.fixed_features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(42UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(42UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
@@ -7644,6 +10577,98 @@ pub impl @json.FromJson for FeatureSetDefaults_FeatureSetEditionDefault with fro
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::async_read(
+  reader : R,
+) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FeatureSetDefaults_FeatureSetEditionDefault::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (3, _) =>
+          msg.edition = reader
+            |> @protobuf.async_read_enum()
+            |> Edition::from_enum
+            |> Some
+        (4, _) =>
+          msg.overridable_features = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSet::default()
+              } else {
+                FeatureSet::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (5, _) =>
+          msg.fixed_features = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSet::default()
+              } else {
+                FeatureSet::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FeatureSetDefaults_FeatureSetEditionDefault::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.overridable_features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.fixed_features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(42UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct FeatureSetDefaults {
   mut defaults : Array[FeatureSetDefaults_FeatureSetEditionDefault]
   mut minimum_edition : Edition?
@@ -7679,7 +10704,7 @@ pub impl Default for FeatureSetDefaults with default() -> FeatureSetDefaults {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults::read(
+pub fn[R : @protobuf.Reader] FeatureSetDefaults::read(
   reader : R,
 ) -> FeatureSetDefaults raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -7687,7 +10712,7 @@ pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults::read_with_limit(
+pub fn[R : @protobuf.Reader] FeatureSetDefaults::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FeatureSetDefaults raise {
@@ -7703,11 +10728,11 @@ pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults::read_with_limit(
   let msg = FeatureSetDefaults::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.defaults.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 FeatureSetDefaults_FeatureSetEditionDefault::default()
               } else {
@@ -7720,15 +10745,15 @@ pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults::read_with_limit(
           )
         (4, _) =>
           msg.minimum_edition = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> Edition::from_enum
             |> Some
         (5, _) =>
           msg.maximum_edition = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> Edition::from_enum
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -7740,26 +10765,26 @@ pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FeatureSetDefaults::write(
+pub fn[W : @protobuf.Writer] FeatureSetDefaults::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   for item in self.defaults {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.minimum_edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(32UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.maximum_edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(40UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
@@ -7805,6 +10830,93 @@ pub impl @json.FromJson for FeatureSetDefaults with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults::async_read(
+  reader : R,
+) -> FeatureSetDefaults raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FeatureSetDefaults::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FeatureSetDefaults::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FeatureSetDefaults raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FeatureSetDefaults::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.defaults.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                FeatureSetDefaults_FeatureSetEditionDefault::default()
+              } else {
+                FeatureSetDefaults_FeatureSetEditionDefault::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (4, _) =>
+          msg.minimum_edition = reader
+            |> @protobuf.async_read_enum()
+            |> Edition::from_enum
+            |> Some
+        (5, _) =>
+          msg.maximum_edition = reader
+            |> @protobuf.async_read_enum()
+            |> Edition::from_enum
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FeatureSetDefaults::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  for item in self.defaults {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.minimum_edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.maximum_edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -7873,7 +10985,7 @@ pub impl Default for SourceCodeInfo_Location with default() -> SourceCodeInfo_Lo
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo_Location::read(
+pub fn[R : @protobuf.Reader] SourceCodeInfo_Location::read(
   reader : R,
 ) -> SourceCodeInfo_Location raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -7881,7 +10993,7 @@ pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo_Location::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo_Location::read_with_limit(
+pub fn[R : @protobuf.Reader] SourceCodeInfo_Location::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> SourceCodeInfo_Location raise {
@@ -7897,28 +11009,22 @@ pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo_Location::read_with_limit
   let msg = SourceCodeInfo_Location::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.path.push_iter(
-            (reader
-            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+            (reader |> @protobuf.read_packed(@protobuf.read_int32, None)).iter(),
           )
         (2, _) =>
           msg.span.push_iter(
-            (reader
-            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+            (reader |> @protobuf.read_packed(@protobuf.read_int32, None)).iter(),
           )
         (3, _) =>
-          msg.leading_comments = reader |> @protobuf.async_read_string() |> Some
+          msg.leading_comments = reader |> @protobuf.read_string() |> Some
         (4, _) =>
-          msg.trailing_comments = reader
-            |> @protobuf.async_read_string()
-            |> Some
+          msg.trailing_comments = reader |> @protobuf.read_string() |> Some
         (6, _) =>
-          msg.leading_detached_comments.push(
-            reader |> @protobuf.async_read_string(),
-          )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+          msg.leading_detached_comments.push(reader |> @protobuf.read_string())
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -7930,39 +11036,39 @@ pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo_Location::read_with_limit
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] SourceCodeInfo_Location::write(
+pub fn[W : @protobuf.Writer] SourceCodeInfo_Location::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL)
+  writer |> @protobuf.write_varint(10UL)
   let size = self.path.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.path {
-    writer |> @protobuf.async_write_int32(item)
+    writer |> @protobuf.write_int32(item)
   }
-  writer |> @protobuf.async_write_varint(18UL)
+  writer |> @protobuf.write_varint(18UL)
   let size = self.span.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.span {
-    writer |> @protobuf.async_write_int32(item)
+    writer |> @protobuf.write_int32(item)
   }
   match self.leading_comments {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.trailing_comments {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(34UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   for item in self.leading_detached_comments {
-    writer |> @protobuf.async_write_varint(50UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(50UL)
+    writer |> @protobuf.write_string(item)
   }
 }
 
@@ -8022,6 +11128,100 @@ pub impl @json.FromJson for SourceCodeInfo_Location with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo_Location::async_read(
+  reader : R,
+) -> SourceCodeInfo_Location raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  SourceCodeInfo_Location::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo_Location::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> SourceCodeInfo_Location raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = SourceCodeInfo_Location::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.path.push_iter(
+            (reader
+            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+          )
+        (2, _) =>
+          msg.span.push_iter(
+            (reader
+            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+          )
+        (3, _) =>
+          msg.leading_comments = reader |> @protobuf.async_read_string() |> Some
+        (4, _) =>
+          msg.trailing_comments = reader
+            |> @protobuf.async_read_string()
+            |> Some
+        (6, _) =>
+          msg.leading_detached_comments.push(
+            reader |> @protobuf.async_read_string(),
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] SourceCodeInfo_Location::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL)
+  let size = self.path.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.path {
+    writer |> @protobuf.async_write_int32(item)
+  }
+  writer |> @protobuf.async_write_varint(18UL)
+  let size = self.span.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.span {
+    writer |> @protobuf.async_write_int32(item)
+  }
+  match self.leading_comments {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.trailing_comments {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  for item in self.leading_detached_comments {
+    writer |> @protobuf.async_write_varint(50UL)
+    writer |> @protobuf.async_write_string(item)
+  }
+}
+
+///|
 pub(all) struct SourceCodeInfo {
   mut location : Array[SourceCodeInfo_Location]
 } derive(Eq, Show)
@@ -8043,7 +11243,7 @@ pub impl Default for SourceCodeInfo with default() -> SourceCodeInfo {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo::read(
+pub fn[R : @protobuf.Reader] SourceCodeInfo::read(
   reader : R,
 ) -> SourceCodeInfo raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -8051,7 +11251,7 @@ pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo::read_with_limit(
+pub fn[R : @protobuf.Reader] SourceCodeInfo::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> SourceCodeInfo raise {
@@ -8067,11 +11267,11 @@ pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo::read_with_limit(
   let msg = SourceCodeInfo::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.location.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 SourceCodeInfo_Location::default()
               } else {
@@ -8079,7 +11279,7 @@ pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -8091,13 +11291,13 @@ pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] SourceCodeInfo::write(
+pub fn[W : @protobuf.Writer] SourceCodeInfo::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   for item in self.location {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -8128,6 +11328,69 @@ pub impl @json.FromJson for SourceCodeInfo with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo::async_read(
+  reader : R,
+) -> SourceCodeInfo raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  SourceCodeInfo::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] SourceCodeInfo::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> SourceCodeInfo raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = SourceCodeInfo::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.location.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                SourceCodeInfo_Location::default()
+              } else {
+                SourceCodeInfo_Location::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] SourceCodeInfo::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  for item in self.location {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
 }
 
 ///|
@@ -8258,7 +11521,7 @@ pub impl Default for GeneratedCodeInfo_Annotation with default() -> GeneratedCod
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::read(
+pub fn[R : @protobuf.Reader] GeneratedCodeInfo_Annotation::read(
   reader : R,
 ) -> GeneratedCodeInfo_Annotation raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -8266,7 +11529,7 @@ pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::read_with_limit(
+pub fn[R : @protobuf.Reader] GeneratedCodeInfo_Annotation::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> GeneratedCodeInfo_Annotation raise {
@@ -8282,22 +11545,20 @@ pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::read_with_
   let msg = GeneratedCodeInfo_Annotation::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.path.push_iter(
-            (reader
-            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+            (reader |> @protobuf.read_packed(@protobuf.read_int32, None)).iter(),
           )
-        (2, _) =>
-          msg.source_file = reader |> @protobuf.async_read_string() |> Some
-        (3, _) => msg.begin = reader |> @protobuf.async_read_int32() |> Some
-        (4, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
+        (2, _) => msg.source_file = reader |> @protobuf.read_string() |> Some
+        (3, _) => msg.begin = reader |> @protobuf.read_int32() |> Some
+        (4, _) => msg.end = reader |> @protobuf.read_int32() |> Some
         (5, _) =>
           msg.semantic = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> GeneratedCodeInfo_Annotation_Semantic::from_enum
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -8309,41 +11570,41 @@ pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::read_with_
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] GeneratedCodeInfo_Annotation::write(
+pub fn[W : @protobuf.Writer] GeneratedCodeInfo_Annotation::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL)
+  writer |> @protobuf.write_varint(10UL)
   let size = self.path.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.path {
-    writer |> @protobuf.async_write_int32(item)
+    writer |> @protobuf.write_int32(item)
   }
   match self.source_file {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.begin {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.end {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(32UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.semantic {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(40UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
@@ -8402,6 +11663,98 @@ pub impl @json.FromJson for GeneratedCodeInfo_Annotation with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::async_read(
+  reader : R,
+) -> GeneratedCodeInfo_Annotation raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  GeneratedCodeInfo_Annotation::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> GeneratedCodeInfo_Annotation raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = GeneratedCodeInfo_Annotation::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.path.push_iter(
+            (reader
+            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+          )
+        (2, _) =>
+          msg.source_file = reader |> @protobuf.async_read_string() |> Some
+        (3, _) => msg.begin = reader |> @protobuf.async_read_int32() |> Some
+        (4, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
+        (5, _) =>
+          msg.semantic = reader
+            |> @protobuf.async_read_enum()
+            |> GeneratedCodeInfo_Annotation_Semantic::from_enum
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] GeneratedCodeInfo_Annotation::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL)
+  let size = self.path.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.path {
+    writer |> @protobuf.async_write_int32(item)
+  }
+  match self.source_file {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.begin {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.end {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.semantic {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct GeneratedCodeInfo {
   mut annotation : Array[GeneratedCodeInfo_Annotation]
 } derive(Eq, Show)
@@ -8423,7 +11776,7 @@ pub impl Default for GeneratedCodeInfo with default() -> GeneratedCodeInfo {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo::read(
+pub fn[R : @protobuf.Reader] GeneratedCodeInfo::read(
   reader : R,
 ) -> GeneratedCodeInfo raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -8431,7 +11784,7 @@ pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo::read_with_limit(
+pub fn[R : @protobuf.Reader] GeneratedCodeInfo::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> GeneratedCodeInfo raise {
@@ -8447,11 +11800,11 @@ pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo::read_with_limit(
   let msg = GeneratedCodeInfo::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.annotation.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 GeneratedCodeInfo_Annotation::default()
               } else {
@@ -8459,7 +11812,7 @@ pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -8471,13 +11824,13 @@ pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] GeneratedCodeInfo::write(
+pub fn[W : @protobuf.Writer] GeneratedCodeInfo::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   for item in self.annotation {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -8510,4 +11863,67 @@ pub impl @json.FromJson for GeneratedCodeInfo with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo::async_read(
+  reader : R,
+) -> GeneratedCodeInfo raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  GeneratedCodeInfo::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] GeneratedCodeInfo::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> GeneratedCodeInfo raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = GeneratedCodeInfo::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.annotation.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                GeneratedCodeInfo_Annotation::default()
+              } else {
+                GeneratedCodeInfo_Annotation::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] GeneratedCodeInfo::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  for item in self.annotation {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
 }

--- a/scripts/generate_plugin.py
+++ b/scripts/generate_plugin.py
@@ -52,7 +52,6 @@ def main():
             module_config = json.load(f)
 
         module_config["deps"]["tonyfettes/uv"] = "0.10.1"
-        module_config["deps"]["moonbitlang/async"] = "0.2.2"
 
         with open(PLUGIN_PROTO_DIR / "moon.mod.json", "w") as f:
             json.dump(module_config, f, indent=2)

--- a/scripts/generate_plugin.py
+++ b/scripts/generate_plugin.py
@@ -52,6 +52,7 @@ def main():
             module_config = json.load(f)
 
         module_config["deps"]["tonyfettes/uv"] = "0.10.1"
+        module_config["deps"]["moonbitlang/async"] = "0.2.2"
 
         with open(PLUGIN_PROTO_DIR / "moon.mod.json", "w") as f:
             json.dump(module_config, f, indent=2)

--- a/test/reader/gen_proto2/src/top.mbt
+++ b/test/reader/gen_proto2/src/top.mbt
@@ -74,7 +74,7 @@ pub impl Default for BarMessageP2 with default() -> BarMessageP2 {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BarMessageP2::read(
+pub fn[R : @protobuf.Reader] BarMessageP2::read(
   reader : R,
 ) -> BarMessageP2 raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -82,7 +82,81 @@ pub async fn[R : @protobuf.AsyncReader] BarMessageP2::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BarMessageP2::read_with_limit(
+pub fn[R : @protobuf.Reader] BarMessageP2::read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> BarMessageP2 raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = BarMessageP2::default()
+  try {
+    for {
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.b_int32 = reader |> @protobuf.read_int32()
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub fn[W : @protobuf.Writer] BarMessageP2::write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.write_varint(8UL)
+  writer |> @protobuf.write_int32(self.b_int32)
+}
+
+///|
+pub impl ToJson for BarMessageP2 with to_json(self) {
+  let json : Map[String, Json] = {}
+  if self.b_int32 != Default::default() {
+    json["bInt32"] = self.b_int32.to_json()
+  }
+  Json::object(json)
+}
+
+///|
+pub impl @json.FromJson for BarMessageP2 with from_json(
+  json : Json,
+  path : @json.JsonPath,
+) -> BarMessageP2 raise {
+  guard json is Object(obj) else {
+    raise @json.JsonDecodeError((path, "Expected an object for BarMessageP2"))
+  }
+  let message = BarMessageP2::default()
+  for key, value in obj {
+    match (key, value) {
+      ("bInt32", value) => message.b_int32 = @json.from_json(value, path~)
+      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+    }
+  }
+  message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] BarMessageP2::async_read(
+  reader : R,
+) -> BarMessageP2 raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BarMessageP2::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] BarMessageP2::async_read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> BarMessageP2 raise {
@@ -112,39 +186,12 @@ pub async fn[R : @protobuf.AsyncReader] BarMessageP2::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] BarMessageP2::write(
+pub async fn[W : @protobuf.AsyncWriter] BarMessageP2::async_write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   writer |> @protobuf.async_write_varint(8UL)
   writer |> @protobuf.async_write_int32(self.b_int32)
-}
-
-///|
-pub impl ToJson for BarMessageP2 with to_json(self) {
-  let json : Map[String, Json] = {}
-  if self.b_int32 != Default::default() {
-    json["bInt32"] = self.b_int32.to_json()
-  }
-  Json::object(json)
-}
-
-///|
-pub impl @json.FromJson for BarMessageP2 with from_json(
-  json : Json,
-  path : @json.JsonPath,
-) -> BarMessageP2 raise {
-  guard json is Object(obj) else {
-    raise @json.JsonDecodeError((path, "Expected an object for BarMessageP2"))
-  }
-  let message = BarMessageP2::default()
-  for key, value in obj {
-    match (key, value) {
-      ("bInt32", value) => message.b_int32 = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
-    }
-  }
-  message
 }
 
 ///|
@@ -417,7 +464,7 @@ pub impl Default for FooMessageP2 with default() -> FooMessageP2 {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FooMessageP2::read(
+pub fn[R : @protobuf.Reader] FooMessageP2::read(
   reader : R,
 ) -> FooMessageP2 raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -425,7 +472,7 @@ pub async fn[R : @protobuf.AsyncReader] FooMessageP2::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FooMessageP2::read_with_limit(
+pub fn[R : @protobuf.Reader] FooMessageP2::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FooMessageP2 raise {
@@ -441,40 +488,32 @@ pub async fn[R : @protobuf.AsyncReader] FooMessageP2::read_with_limit(
   let msg = FooMessageP2::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.f_int32 = reader |> @protobuf.async_read_int32()
-        (2, _) => msg.f_int64 = reader |> @protobuf.async_read_int64()
-        (3, _) => msg.f_uint32 = reader |> @protobuf.async_read_uint32() |> Some
-        (4, _) => msg.f_uint64 = reader |> @protobuf.async_read_uint64() |> Some
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.f_int32 = reader |> @protobuf.read_int32()
+        (2, _) => msg.f_int64 = reader |> @protobuf.read_int64()
+        (3, _) => msg.f_uint32 = reader |> @protobuf.read_uint32() |> Some
+        (4, _) => msg.f_uint64 = reader |> @protobuf.read_uint64() |> Some
         (5, _) =>
-          msg.f_sint32 = (reader |> @protobuf.async_read_sint32()).inner()
-            |> Some
+          msg.f_sint32 = (reader |> @protobuf.read_sint32()).inner() |> Some
         (6, _) =>
-          msg.f_sint64 = (reader |> @protobuf.async_read_sint64()).inner()
-            |> Some
-        (7, _) => msg.f_bool = reader |> @protobuf.async_read_bool() |> Some
+          msg.f_sint64 = (reader |> @protobuf.read_sint64()).inner() |> Some
+        (7, _) => msg.f_bool = reader |> @protobuf.read_bool() |> Some
         (8, _) =>
           msg.f_foo_enum = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FooEnumP2::from_enum
             |> Some
-        (9, _) =>
-          msg.f_fixed64 = reader |> @protobuf.async_read_fixed64() |> Some
-        (10, _) =>
-          msg.f_sfixed64 = reader |> @protobuf.async_read_sfixed64() |> Some
-        (11, _) =>
-          msg.f_fixed32 = reader |> @protobuf.async_read_fixed32() |> Some
-        (12, _) =>
-          msg.f_sfixed32 = reader |> @protobuf.async_read_sfixed32() |> Some
-        (13, _) =>
-          msg.f_double = reader |> @protobuf.async_read_double() |> Some
-        (14, _) => msg.f_float = reader |> @protobuf.async_read_float() |> Some
-        (15, _) => msg.f_bytes = reader |> @protobuf.async_read_bytes() |> Some
-        (16, _) =>
-          msg.f_string = reader |> @protobuf.async_read_string() |> Some
+        (9, _) => msg.f_fixed64 = reader |> @protobuf.read_fixed64() |> Some
+        (10, _) => msg.f_sfixed64 = reader |> @protobuf.read_sfixed64() |> Some
+        (11, _) => msg.f_fixed32 = reader |> @protobuf.read_fixed32() |> Some
+        (12, _) => msg.f_sfixed32 = reader |> @protobuf.read_sfixed32() |> Some
+        (13, _) => msg.f_double = reader |> @protobuf.read_double() |> Some
+        (14, _) => msg.f_float = reader |> @protobuf.read_float() |> Some
+        (15, _) => msg.f_bytes = reader |> @protobuf.read_bytes() |> Some
+        (16, _) => msg.f_string = reader |> @protobuf.read_string() |> Some
         (18, _) =>
           msg.f_bar_message = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 BarMessageP2::default()
               } else {
@@ -482,21 +521,18 @@ pub async fn[R : @protobuf.AsyncReader] FooMessageP2::read_with_limit(
               }
             }
             |> Some
-        (19, _) =>
-          msg.f_repeated_int32.push(reader |> @protobuf.async_read_int32())
+        (19, _) => msg.f_repeated_int32.push(reader |> @protobuf.read_int32())
         (20, _) =>
           msg.f_repeated_packed_int32.push_iter(
-            (reader
-            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+            (reader |> @protobuf.read_packed(@protobuf.read_int32, None)).iter(),
           )
         (21, _) =>
           msg.f_repeated_packed_float.push_iter(
-            (reader
-            |> @protobuf.async_read_packed(@protobuf.async_read_float, Some(4))).iter(),
+            (reader |> @protobuf.read_packed(@protobuf.read_float, Some(4))).iter(),
           )
         (23, _) =>
           msg.f_baz = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 BazMessageP2::default()
               } else {
@@ -506,7 +542,7 @@ pub async fn[R : @protobuf.AsyncReader] FooMessageP2::read_with_limit(
             |> Some
         (24, _) =>
           msg.f_nested = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 BazMessageP2_Nested::default()
               } else {
@@ -516,13 +552,13 @@ pub async fn[R : @protobuf.AsyncReader] FooMessageP2::read_with_limit(
             |> Some
         (25, _) =>
           msg.f_nested_enum = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> BazMessageP2_Nested_NestedEnum::from_enum
             |> Some
         (27, _) =>
           msg.f_map.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 MapEntryP2::default()
               } else {
@@ -530,15 +566,14 @@ pub async fn[R : @protobuf.AsyncReader] FooMessageP2::read_with_limit(
               }
             },
           )
-        (28, _) => msg.f1 = reader |> @protobuf.async_read_int32() |> Some
-        (29, _) => msg.f2 = reader |> @protobuf.async_read_bool() |> Some
-        (30, _) => msg.f3 = reader |> @protobuf.async_read_string() |> Some
-        (31, _) =>
-          msg.f_repeated_string.push(reader |> @protobuf.async_read_string())
+        (28, _) => msg.f1 = reader |> @protobuf.read_int32() |> Some
+        (29, _) => msg.f2 = reader |> @protobuf.read_bool() |> Some
+        (30, _) => msg.f3 = reader |> @protobuf.read_string() |> Some
+        (31, _) => msg.f_repeated_string.push(reader |> @protobuf.read_string())
         (32, _) =>
           msg.f_repeated_baz_message.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 BazMessageP2::default()
               } else {
@@ -547,23 +582,20 @@ pub async fn[R : @protobuf.AsyncReader] FooMessageP2::read_with_limit(
             },
           )
         (33, _) =>
-          msg.f_optional_string = reader
-            |> @protobuf.async_read_string()
-            |> Some
+          msg.f_optional_string = reader |> @protobuf.read_string() |> Some
         (34, _) =>
-          msg.f_default_int32 = reader |> @protobuf.async_read_int32() |> Some
+          msg.f_default_int32 = reader |> @protobuf.read_int32() |> Some
         (35, _) =>
-          msg.f_default_string = reader |> @protobuf.async_read_string() |> Some
-        (36, _) =>
-          msg.f_default_bool = reader |> @protobuf.async_read_bool() |> Some
+          msg.f_default_string = reader |> @protobuf.read_string() |> Some
+        (36, _) => msg.f_default_bool = reader |> @protobuf.read_bool() |> Some
         (37, _) =>
-          msg.f_default_double = reader |> @protobuf.async_read_double() |> Some
+          msg.f_default_double = reader |> @protobuf.read_double() |> Some
         (38, _) =>
           msg.f_default_enum = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> FooEnumP2::from_enum
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -575,236 +607,236 @@ pub async fn[R : @protobuf.AsyncReader] FooMessageP2::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FooMessageP2::write(
+pub fn[W : @protobuf.Writer] FooMessageP2::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(8UL)
-  writer |> @protobuf.async_write_int32(self.f_int32)
-  writer |> @protobuf.async_write_varint(16UL)
-  writer |> @protobuf.async_write_int64(self.f_int64)
+  writer |> @protobuf.write_varint(8UL)
+  writer |> @protobuf.write_int32(self.f_int32)
+  writer |> @protobuf.write_varint(16UL)
+  writer |> @protobuf.write_int64(self.f_int64)
   match self.f_uint32 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL)
-      writer |> @protobuf.async_write_uint32(v)
+      writer |> @protobuf.write_varint(24UL)
+      writer |> @protobuf.write_uint32(v)
     }
     None => ()
   }
   match self.f_uint64 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL)
-      writer |> @protobuf.async_write_uint64(v)
+      writer |> @protobuf.write_varint(32UL)
+      writer |> @protobuf.write_uint64(v)
     }
     None => ()
   }
   match self.f_sint32 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL)
-      writer |> @protobuf.async_write_sint32(v)
+      writer |> @protobuf.write_varint(40UL)
+      writer |> @protobuf.write_sint32(v)
     }
     None => ()
   }
   match self.f_sint64 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(48UL)
-      writer |> @protobuf.async_write_sint64(v)
+      writer |> @protobuf.write_varint(48UL)
+      writer |> @protobuf.write_sint64(v)
     }
     None => ()
   }
   match self.f_bool {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(56UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(56UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.f_foo_enum {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(64UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(64UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   match self.f_fixed64 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(73UL)
-      writer |> @protobuf.async_write_fixed64(v)
+      writer |> @protobuf.write_varint(73UL)
+      writer |> @protobuf.write_fixed64(v)
     }
     None => ()
   }
   match self.f_sfixed64 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(81UL)
-      writer |> @protobuf.async_write_sfixed64(v)
+      writer |> @protobuf.write_varint(81UL)
+      writer |> @protobuf.write_sfixed64(v)
     }
     None => ()
   }
   match self.f_fixed32 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(93UL)
-      writer |> @protobuf.async_write_fixed32(v)
+      writer |> @protobuf.write_varint(93UL)
+      writer |> @protobuf.write_fixed32(v)
     }
     None => ()
   }
   match self.f_sfixed32 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(101UL)
-      writer |> @protobuf.async_write_sfixed32(v)
+      writer |> @protobuf.write_varint(101UL)
+      writer |> @protobuf.write_sfixed32(v)
     }
     None => ()
   }
   match self.f_double {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(105UL)
-      writer |> @protobuf.async_write_double(v)
+      writer |> @protobuf.write_varint(105UL)
+      writer |> @protobuf.write_double(v)
     }
     None => ()
   }
   match self.f_float {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(117UL)
-      writer |> @protobuf.async_write_float(v)
+      writer |> @protobuf.write_varint(117UL)
+      writer |> @protobuf.write_float(v)
     }
     None => ()
   }
   match self.f_bytes {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(122UL)
-      writer |> @protobuf.async_write_bytes(v)
+      writer |> @protobuf.write_varint(122UL)
+      writer |> @protobuf.write_bytes(v)
     }
     None => ()
   }
   match self.f_string {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(130UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(130UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.f_bar_message {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(146UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(146UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   for item in self.f_repeated_int32 {
-    writer |> @protobuf.async_write_varint(152UL)
-    writer |> @protobuf.async_write_int32(item)
+    writer |> @protobuf.write_varint(152UL)
+    writer |> @protobuf.write_int32(item)
   }
-  writer |> @protobuf.async_write_varint(162UL)
+  writer |> @protobuf.write_varint(162UL)
   let size = self.f_repeated_packed_int32
     .iter()
     .map(@protobuf.size_of)
     .fold(init=0U, UInt::op_add)
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.f_repeated_packed_int32 {
-    writer |> @protobuf.async_write_int32(item)
+    writer |> @protobuf.write_int32(item)
   }
-  writer |> @protobuf.async_write_varint(170UL)
+  writer |> @protobuf.write_varint(170UL)
   let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.f_repeated_packed_float {
-    writer |> @protobuf.async_write_float(item)
+    writer |> @protobuf.write_float(item)
   }
   match self.f_baz {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(186UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(186UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.f_nested {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(194UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(194UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.f_nested_enum {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(200UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(200UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
   for item in self.f_map {
-    writer |> @protobuf.async_write_varint(218UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(218UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.f1 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(224UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(224UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.f2 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(232UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(232UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.f3 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(242UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(242UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   for item in self.f_repeated_string {
-    writer |> @protobuf.async_write_varint(250UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(250UL)
+    writer |> @protobuf.write_string(item)
   }
   for item in self.f_repeated_baz_message {
-    writer |> @protobuf.async_write_varint(258UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(258UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.f_optional_string {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(266UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(266UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.f_default_int32 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(272UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(272UL)
+      writer |> @protobuf.write_int32(v)
     }
     None => ()
   }
   match self.f_default_string {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(282UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(282UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.f_default_bool {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(288UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(288UL)
+      writer |> @protobuf.write_bool(v)
     }
     None => ()
   }
   match self.f_default_double {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(297UL)
-      writer |> @protobuf.async_write_double(v)
+      writer |> @protobuf.write_varint(297UL)
+      writer |> @protobuf.write_double(v)
     }
     None => ()
   }
   match self.f_default_enum {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(304UL)
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(304UL)
+      writer |> @protobuf.write_enum(v.to_enum())
     }
     None => ()
   }
@@ -1039,6 +1071,400 @@ pub impl @json.FromJson for FooMessageP2 with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] FooMessageP2::async_read(
+  reader : R,
+) -> FooMessageP2 raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FooMessageP2::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FooMessageP2::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FooMessageP2 raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FooMessageP2::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.f_int32 = reader |> @protobuf.async_read_int32()
+        (2, _) => msg.f_int64 = reader |> @protobuf.async_read_int64()
+        (3, _) => msg.f_uint32 = reader |> @protobuf.async_read_uint32() |> Some
+        (4, _) => msg.f_uint64 = reader |> @protobuf.async_read_uint64() |> Some
+        (5, _) =>
+          msg.f_sint32 = (reader |> @protobuf.async_read_sint32()).inner()
+            |> Some
+        (6, _) =>
+          msg.f_sint64 = (reader |> @protobuf.async_read_sint64()).inner()
+            |> Some
+        (7, _) => msg.f_bool = reader |> @protobuf.async_read_bool() |> Some
+        (8, _) =>
+          msg.f_foo_enum = reader
+            |> @protobuf.async_read_enum()
+            |> FooEnumP2::from_enum
+            |> Some
+        (9, _) =>
+          msg.f_fixed64 = reader |> @protobuf.async_read_fixed64() |> Some
+        (10, _) =>
+          msg.f_sfixed64 = reader |> @protobuf.async_read_sfixed64() |> Some
+        (11, _) =>
+          msg.f_fixed32 = reader |> @protobuf.async_read_fixed32() |> Some
+        (12, _) =>
+          msg.f_sfixed32 = reader |> @protobuf.async_read_sfixed32() |> Some
+        (13, _) =>
+          msg.f_double = reader |> @protobuf.async_read_double() |> Some
+        (14, _) => msg.f_float = reader |> @protobuf.async_read_float() |> Some
+        (15, _) => msg.f_bytes = reader |> @protobuf.async_read_bytes() |> Some
+        (16, _) =>
+          msg.f_string = reader |> @protobuf.async_read_string() |> Some
+        (18, _) =>
+          msg.f_bar_message = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                BarMessageP2::default()
+              } else {
+                BarMessageP2::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (19, _) =>
+          msg.f_repeated_int32.push(reader |> @protobuf.async_read_int32())
+        (20, _) =>
+          msg.f_repeated_packed_int32.push_iter(
+            (reader
+            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+          )
+        (21, _) =>
+          msg.f_repeated_packed_float.push_iter(
+            (reader
+            |> @protobuf.async_read_packed(@protobuf.async_read_float, Some(4))).iter(),
+          )
+        (23, _) =>
+          msg.f_baz = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                BazMessageP2::default()
+              } else {
+                BazMessageP2::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (24, _) =>
+          msg.f_nested = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                BazMessageP2_Nested::default()
+              } else {
+                BazMessageP2_Nested::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (25, _) =>
+          msg.f_nested_enum = reader
+            |> @protobuf.async_read_enum()
+            |> BazMessageP2_Nested_NestedEnum::from_enum
+            |> Some
+        (27, _) =>
+          msg.f_map.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                MapEntryP2::default()
+              } else {
+                MapEntryP2::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (28, _) => msg.f1 = reader |> @protobuf.async_read_int32() |> Some
+        (29, _) => msg.f2 = reader |> @protobuf.async_read_bool() |> Some
+        (30, _) => msg.f3 = reader |> @protobuf.async_read_string() |> Some
+        (31, _) =>
+          msg.f_repeated_string.push(reader |> @protobuf.async_read_string())
+        (32, _) =>
+          msg.f_repeated_baz_message.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                BazMessageP2::default()
+              } else {
+                BazMessageP2::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (33, _) =>
+          msg.f_optional_string = reader
+            |> @protobuf.async_read_string()
+            |> Some
+        (34, _) =>
+          msg.f_default_int32 = reader |> @protobuf.async_read_int32() |> Some
+        (35, _) =>
+          msg.f_default_string = reader |> @protobuf.async_read_string() |> Some
+        (36, _) =>
+          msg.f_default_bool = reader |> @protobuf.async_read_bool() |> Some
+        (37, _) =>
+          msg.f_default_double = reader |> @protobuf.async_read_double() |> Some
+        (38, _) =>
+          msg.f_default_enum = reader
+            |> @protobuf.async_read_enum()
+            |> FooEnumP2::from_enum
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FooMessageP2::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(8UL)
+  writer |> @protobuf.async_write_int32(self.f_int32)
+  writer |> @protobuf.async_write_varint(16UL)
+  writer |> @protobuf.async_write_int64(self.f_int64)
+  match self.f_uint32 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL)
+      writer |> @protobuf.async_write_uint32(v)
+    }
+    None => ()
+  }
+  match self.f_uint64 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL)
+      writer |> @protobuf.async_write_uint64(v)
+    }
+    None => ()
+  }
+  match self.f_sint32 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL)
+      writer |> @protobuf.async_write_sint32(v)
+    }
+    None => ()
+  }
+  match self.f_sint64 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(48UL)
+      writer |> @protobuf.async_write_sint64(v)
+    }
+    None => ()
+  }
+  match self.f_bool {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(56UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.f_foo_enum {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(64UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  match self.f_fixed64 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(73UL)
+      writer |> @protobuf.async_write_fixed64(v)
+    }
+    None => ()
+  }
+  match self.f_sfixed64 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(81UL)
+      writer |> @protobuf.async_write_sfixed64(v)
+    }
+    None => ()
+  }
+  match self.f_fixed32 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(93UL)
+      writer |> @protobuf.async_write_fixed32(v)
+    }
+    None => ()
+  }
+  match self.f_sfixed32 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(101UL)
+      writer |> @protobuf.async_write_sfixed32(v)
+    }
+    None => ()
+  }
+  match self.f_double {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(105UL)
+      writer |> @protobuf.async_write_double(v)
+    }
+    None => ()
+  }
+  match self.f_float {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(117UL)
+      writer |> @protobuf.async_write_float(v)
+    }
+    None => ()
+  }
+  match self.f_bytes {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(122UL)
+      writer |> @protobuf.async_write_bytes(v)
+    }
+    None => ()
+  }
+  match self.f_string {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(130UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.f_bar_message {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(146UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  for item in self.f_repeated_int32 {
+    writer |> @protobuf.async_write_varint(152UL)
+    writer |> @protobuf.async_write_int32(item)
+  }
+  writer |> @protobuf.async_write_varint(162UL)
+  let size = self.f_repeated_packed_int32
+    .iter()
+    .map(@protobuf.size_of)
+    .fold(init=0U, UInt::op_add)
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.f_repeated_packed_int32 {
+    writer |> @protobuf.async_write_int32(item)
+  }
+  writer |> @protobuf.async_write_varint(170UL)
+  let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.f_repeated_packed_float {
+    writer |> @protobuf.async_write_float(item)
+  }
+  match self.f_baz {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(186UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.f_nested {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(194UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.f_nested_enum {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(200UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+  for item in self.f_map {
+    writer |> @protobuf.async_write_varint(218UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.f1 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(224UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.f2 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(232UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.f3 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(242UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  for item in self.f_repeated_string {
+    writer |> @protobuf.async_write_varint(250UL)
+    writer |> @protobuf.async_write_string(item)
+  }
+  for item in self.f_repeated_baz_message {
+    writer |> @protobuf.async_write_varint(258UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.f_optional_string {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(266UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.f_default_int32 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(272UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    None => ()
+  }
+  match self.f_default_string {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(282UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.f_default_bool {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(288UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    None => ()
+  }
+  match self.f_default_double {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(297UL)
+      writer |> @protobuf.async_write_double(v)
+    }
+    None => ()
+  }
+  match self.f_default_enum {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(304UL)
+      writer |> @protobuf.async_write_enum(v.to_enum())
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct MapEntryP2 {
   mut key : String
   mut value : Int
@@ -1062,15 +1488,13 @@ pub impl Default for MapEntryP2 with default() -> MapEntryP2 {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] MapEntryP2::read(
-  reader : R,
-) -> MapEntryP2 raise {
+pub fn[R : @protobuf.Reader] MapEntryP2::read(reader : R) -> MapEntryP2 raise {
   let reader = @protobuf.LimitedReader::new(reader)
   MapEntryP2::read_with_limit(reader)
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] MapEntryP2::read_with_limit(
+pub fn[R : @protobuf.Reader] MapEntryP2::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> MapEntryP2 raise {
@@ -1086,10 +1510,10 @@ pub async fn[R : @protobuf.AsyncReader] MapEntryP2::read_with_limit(
   let msg = MapEntryP2::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.key = reader |> @protobuf.async_read_string()
-        (2, _) => msg.value = reader |> @protobuf.async_read_int32()
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.key = reader |> @protobuf.read_string()
+        (2, _) => msg.value = reader |> @protobuf.read_int32()
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1101,14 +1525,14 @@ pub async fn[R : @protobuf.AsyncReader] MapEntryP2::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] MapEntryP2::write(
+pub fn[W : @protobuf.Writer] MapEntryP2::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL)
-  writer |> @protobuf.async_write_string(self.key)
-  writer |> @protobuf.async_write_varint(16UL)
-  writer |> @protobuf.async_write_int32(self.value)
+  writer |> @protobuf.write_varint(10UL)
+  writer |> @protobuf.write_string(self.key)
+  writer |> @protobuf.write_varint(16UL)
+  writer |> @protobuf.write_int32(self.value)
 }
 
 ///|
@@ -1140,6 +1564,56 @@ pub impl @json.FromJson for MapEntryP2 with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] MapEntryP2::async_read(
+  reader : R,
+) -> MapEntryP2 raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  MapEntryP2::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] MapEntryP2::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> MapEntryP2 raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = MapEntryP2::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.key = reader |> @protobuf.async_read_string()
+        (2, _) => msg.value = reader |> @protobuf.async_read_int32()
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] MapEntryP2::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL)
+  writer |> @protobuf.async_write_string(self.key)
+  writer |> @protobuf.async_write_varint(16UL)
+  writer |> @protobuf.async_write_int32(self.value)
 }
 
 ///|
@@ -1234,7 +1708,7 @@ pub impl Default for BazMessageP2_Nested_NestedMessage with default() -> BazMess
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested_NestedMessage::read(
+pub fn[R : @protobuf.Reader] BazMessageP2_Nested_NestedMessage::read(
   reader : R,
 ) -> BazMessageP2_Nested_NestedMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -1242,7 +1716,7 @@ pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested_NestedMessage::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested_NestedMessage::read_with_limit(
+pub fn[R : @protobuf.Reader] BazMessageP2_Nested_NestedMessage::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> BazMessageP2_Nested_NestedMessage raise {
@@ -1258,9 +1732,9 @@ pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested_NestedMessage::read_
   let msg = BazMessageP2_Nested_NestedMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.f_nested = reader |> @protobuf.async_read_int32()
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.f_nested = reader |> @protobuf.read_int32()
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1272,12 +1746,12 @@ pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested_NestedMessage::read_
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] BazMessageP2_Nested_NestedMessage::write(
+pub fn[W : @protobuf.Writer] BazMessageP2_Nested_NestedMessage::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(8UL)
-  writer |> @protobuf.async_write_int32(self.f_nested)
+  writer |> @protobuf.write_varint(8UL)
+  writer |> @protobuf.write_int32(self.f_nested)
 }
 
 ///|
@@ -1310,6 +1784,53 @@ pub impl @json.FromJson for BazMessageP2_Nested_NestedMessage with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested_NestedMessage::async_read(
+  reader : R,
+) -> BazMessageP2_Nested_NestedMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BazMessageP2_Nested_NestedMessage::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested_NestedMessage::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> BazMessageP2_Nested_NestedMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = BazMessageP2_Nested_NestedMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.f_nested = reader |> @protobuf.async_read_int32()
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] BazMessageP2_Nested_NestedMessage::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(8UL)
+  writer |> @protobuf.async_write_int32(self.f_nested)
+}
+
+///|
 pub(all) struct BazMessageP2_Nested {
   mut f_nested : BazMessageP2_Nested_NestedMessage?
 } derive(Eq, Show)
@@ -1335,7 +1856,7 @@ pub impl Default for BazMessageP2_Nested with default() -> BazMessageP2_Nested {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested::read(
+pub fn[R : @protobuf.Reader] BazMessageP2_Nested::read(
   reader : R,
 ) -> BazMessageP2_Nested raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -1343,7 +1864,7 @@ pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested::read_with_limit(
+pub fn[R : @protobuf.Reader] BazMessageP2_Nested::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> BazMessageP2_Nested raise {
@@ -1359,10 +1880,10 @@ pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested::read_with_limit(
   let msg = BazMessageP2_Nested::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.f_nested = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 BazMessageP2_Nested_NestedMessage::default()
               } else {
@@ -1373,7 +1894,7 @@ pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested::read_with_limit(
               }
             }
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1385,14 +1906,14 @@ pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] BazMessageP2_Nested::write(
+pub fn[W : @protobuf.Writer] BazMessageP2_Nested::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.f_nested {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
@@ -1428,6 +1949,71 @@ pub impl @json.FromJson for BazMessageP2_Nested with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested::async_read(
+  reader : R,
+) -> BazMessageP2_Nested raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BazMessageP2_Nested::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] BazMessageP2_Nested::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> BazMessageP2_Nested raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = BazMessageP2_Nested::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.f_nested = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                BazMessageP2_Nested_NestedMessage::default()
+              } else {
+                BazMessageP2_Nested_NestedMessage::async_read_with_limit(
+                  reader,
+                  limit=len,
+                )
+              }
+            }
+            |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] BazMessageP2_Nested::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.f_nested {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
 }
 
 ///|
@@ -1471,7 +2057,7 @@ pub impl Default for BazMessageP2 with default() -> BazMessageP2 {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessageP2::read(
+pub fn[R : @protobuf.Reader] BazMessageP2::read(
   reader : R,
 ) -> BazMessageP2 raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -1479,7 +2065,7 @@ pub async fn[R : @protobuf.AsyncReader] BazMessageP2::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessageP2::read_with_limit(
+pub fn[R : @protobuf.Reader] BazMessageP2::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> BazMessageP2 raise {
@@ -1495,10 +2081,10 @@ pub async fn[R : @protobuf.AsyncReader] BazMessageP2::read_with_limit(
   let msg = BazMessageP2::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.nested = {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 BazMessageP2_Nested::default()
               } else {
@@ -1506,9 +2092,9 @@ pub async fn[R : @protobuf.AsyncReader] BazMessageP2::read_with_limit(
               }
             }
             |> Some
-        (2, _) => msg.b_int64 = reader |> @protobuf.async_read_int64() |> Some
-        (3, _) => msg.b_string = reader |> @protobuf.async_read_string() |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (2, _) => msg.b_int64 = reader |> @protobuf.read_int64() |> Some
+        (3, _) => msg.b_string = reader |> @protobuf.read_string() |> Some
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1520,29 +2106,29 @@ pub async fn[R : @protobuf.AsyncReader] BazMessageP2::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] BazMessageP2::write(
+pub fn[W : @protobuf.Writer] BazMessageP2::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   match self.nested {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL)
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      writer |> @protobuf.write_varint(10UL)
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v))
       v.write(writer)
     }
     None => ()
   }
   match self.b_int64 {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL)
-      writer |> @protobuf.async_write_int64(v)
+      writer |> @protobuf.write_varint(16UL)
+      writer |> @protobuf.write_int64(v)
     }
     None => ()
   }
   match self.b_string {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
@@ -1588,6 +2174,84 @@ pub impl @json.FromJson for BazMessageP2 with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] BazMessageP2::async_read(
+  reader : R,
+) -> BazMessageP2 raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BazMessageP2::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] BazMessageP2::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> BazMessageP2 raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = BazMessageP2::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.nested = {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                BazMessageP2_Nested::default()
+              } else {
+                BazMessageP2_Nested::async_read_with_limit(reader, limit=len)
+              }
+            }
+            |> Some
+        (2, _) => msg.b_int64 = reader |> @protobuf.async_read_int64() |> Some
+        (3, _) => msg.b_string = reader |> @protobuf.async_read_string() |> Some
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] BazMessageP2::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  match self.nested {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
+      v.async_write(writer)
+    }
+    None => ()
+  }
+  match self.b_int64 {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL)
+      writer |> @protobuf.async_write_int64(v)
+    }
+    None => ()
+  }
+  match self.b_string {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+}
+
+///|
 pub(all) struct RepeatedMessageP2 {
   mut bar_message : Array[BarMessageP2]
 } derive(Eq, Show)
@@ -1609,7 +2273,7 @@ pub impl Default for RepeatedMessageP2 with default() -> RepeatedMessageP2 {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] RepeatedMessageP2::read(
+pub fn[R : @protobuf.Reader] RepeatedMessageP2::read(
   reader : R,
 ) -> RepeatedMessageP2 raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -1617,7 +2281,7 @@ pub async fn[R : @protobuf.AsyncReader] RepeatedMessageP2::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] RepeatedMessageP2::read_with_limit(
+pub fn[R : @protobuf.Reader] RepeatedMessageP2::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> RepeatedMessageP2 raise {
@@ -1633,11 +2297,11 @@ pub async fn[R : @protobuf.AsyncReader] RepeatedMessageP2::read_with_limit(
   let msg = RepeatedMessageP2::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.bar_message.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 BarMessageP2::default()
               } else {
@@ -1645,7 +2309,7 @@ pub async fn[R : @protobuf.AsyncReader] RepeatedMessageP2::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1657,13 +2321,13 @@ pub async fn[R : @protobuf.AsyncReader] RepeatedMessageP2::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] RepeatedMessageP2::write(
+pub fn[W : @protobuf.Writer] RepeatedMessageP2::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   for item in self.bar_message {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -1696,4 +2360,64 @@ pub impl @json.FromJson for RepeatedMessageP2 with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] RepeatedMessageP2::async_read(
+  reader : R,
+) -> RepeatedMessageP2 raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  RepeatedMessageP2::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] RepeatedMessageP2::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> RepeatedMessageP2 raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = RepeatedMessageP2::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.bar_message.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                BarMessageP2::default()
+              } else {
+                BarMessageP2::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] RepeatedMessageP2::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  for item in self.bar_message {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
 }

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -74,15 +74,13 @@ pub impl Default for BarMessage with default() -> BarMessage {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BarMessage::read(
-  reader : R,
-) -> BarMessage raise {
+pub fn[R : @protobuf.Reader] BarMessage::read(reader : R) -> BarMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
   BarMessage::read_with_limit(reader)
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BarMessage::read_with_limit(
+pub fn[R : @protobuf.Reader] BarMessage::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> BarMessage raise {
@@ -98,9 +96,9 @@ pub async fn[R : @protobuf.AsyncReader] BarMessage::read_with_limit(
   let msg = BarMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.b_int32 = reader |> @protobuf.async_read_int32()
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.b_int32 = reader |> @protobuf.read_int32()
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -112,12 +110,12 @@ pub async fn[R : @protobuf.AsyncReader] BarMessage::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] BarMessage::write(
+pub fn[W : @protobuf.Writer] BarMessage::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(8UL)
-  writer |> @protobuf.async_write_int32(self.b_int32)
+  writer |> @protobuf.write_varint(8UL)
+  writer |> @protobuf.write_int32(self.b_int32)
 }
 
 ///|
@@ -148,6 +146,53 @@ pub impl @json.FromJson for BarMessage with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] BarMessage::async_read(
+  reader : R,
+) -> BarMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BarMessage::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] BarMessage::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> BarMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = BarMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.b_int32 = reader |> @protobuf.async_read_int32()
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] BarMessage::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(8UL)
+  writer |> @protobuf.async_write_int32(self.b_int32)
+}
+
+///|
 pub(all) struct FooMessage_FMapEntry {
   mut key : String
   mut value : Int
@@ -171,7 +216,7 @@ pub impl Default for FooMessage_FMapEntry with default() -> FooMessage_FMapEntry
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FooMessage_FMapEntry::read(
+pub fn[R : @protobuf.Reader] FooMessage_FMapEntry::read(
   reader : R,
 ) -> FooMessage_FMapEntry raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -179,7 +224,7 @@ pub async fn[R : @protobuf.AsyncReader] FooMessage_FMapEntry::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FooMessage_FMapEntry::read_with_limit(
+pub fn[R : @protobuf.Reader] FooMessage_FMapEntry::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FooMessage_FMapEntry raise {
@@ -195,10 +240,10 @@ pub async fn[R : @protobuf.AsyncReader] FooMessage_FMapEntry::read_with_limit(
   let msg = FooMessage_FMapEntry::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.key = reader |> @protobuf.async_read_string()
-        (2, _) => msg.value = reader |> @protobuf.async_read_int32()
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.key = reader |> @protobuf.read_string()
+        (2, _) => msg.value = reader |> @protobuf.read_int32()
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -210,14 +255,14 @@ pub async fn[R : @protobuf.AsyncReader] FooMessage_FMapEntry::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FooMessage_FMapEntry::write(
+pub fn[W : @protobuf.Writer] FooMessage_FMapEntry::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL)
-  writer |> @protobuf.async_write_string(self.key)
-  writer |> @protobuf.async_write_varint(16UL)
-  writer |> @protobuf.async_write_int32(self.value)
+  writer |> @protobuf.write_varint(10UL)
+  writer |> @protobuf.write_string(self.key)
+  writer |> @protobuf.write_varint(16UL)
+  writer |> @protobuf.write_int32(self.value)
 }
 
 ///|
@@ -251,6 +296,56 @@ pub impl @json.FromJson for FooMessage_FMapEntry with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FooMessage_FMapEntry::async_read(
+  reader : R,
+) -> FooMessage_FMapEntry raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FooMessage_FMapEntry::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FooMessage_FMapEntry::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FooMessage_FMapEntry raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FooMessage_FMapEntry::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.key = reader |> @protobuf.async_read_string()
+        (2, _) => msg.value = reader |> @protobuf.async_read_int32()
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FooMessage_FMapEntry::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL)
+  writer |> @protobuf.async_write_string(self.key)
+  writer |> @protobuf.async_write_varint(16UL)
+  writer |> @protobuf.async_write_int32(self.value)
 }
 
 ///|
@@ -475,15 +570,13 @@ pub impl Default for FooMessage with default() -> FooMessage {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FooMessage::read(
-  reader : R,
-) -> FooMessage raise {
+pub fn[R : @protobuf.Reader] FooMessage::read(reader : R) -> FooMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FooMessage::read_with_limit(reader)
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] FooMessage::read_with_limit(
+pub fn[R : @protobuf.Reader] FooMessage::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> FooMessage raise {
@@ -499,31 +592,27 @@ pub async fn[R : @protobuf.AsyncReader] FooMessage::read_with_limit(
   let msg = FooMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.f_int32 = reader |> @protobuf.async_read_int32()
-        (2, _) => msg.f_int64 = reader |> @protobuf.async_read_int64()
-        (3, _) => msg.f_uint32 = reader |> @protobuf.async_read_uint32()
-        (4, _) => msg.f_uint64 = reader |> @protobuf.async_read_uint64()
-        (5, _) =>
-          msg.f_sint32 = (reader |> @protobuf.async_read_sint32()).inner()
-        (6, _) =>
-          msg.f_sint64 = (reader |> @protobuf.async_read_sint64()).inner()
-        (7, _) => msg.f_bool = reader |> @protobuf.async_read_bool()
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.f_int32 = reader |> @protobuf.read_int32()
+        (2, _) => msg.f_int64 = reader |> @protobuf.read_int64()
+        (3, _) => msg.f_uint32 = reader |> @protobuf.read_uint32()
+        (4, _) => msg.f_uint64 = reader |> @protobuf.read_uint64()
+        (5, _) => msg.f_sint32 = (reader |> @protobuf.read_sint32()).inner()
+        (6, _) => msg.f_sint64 = (reader |> @protobuf.read_sint64()).inner()
+        (7, _) => msg.f_bool = reader |> @protobuf.read_bool()
         (8, _) =>
-          msg.f_foo_enum = reader
-            |> @protobuf.async_read_enum()
-            |> FooEnum::from_enum
-        (9, _) => msg.f_fixed64 = reader |> @protobuf.async_read_fixed64()
-        (10, _) => msg.f_sfixed64 = reader |> @protobuf.async_read_sfixed64()
-        (11, _) => msg.f_fixed32 = reader |> @protobuf.async_read_fixed32()
-        (12, _) => msg.f_sfixed32 = reader |> @protobuf.async_read_sfixed32()
-        (13, _) => msg.f_double = reader |> @protobuf.async_read_double()
-        (14, _) => msg.f_float = reader |> @protobuf.async_read_float()
-        (15, _) => msg.f_bytes = reader |> @protobuf.async_read_bytes()
-        (16, _) => msg.f_string = reader |> @protobuf.async_read_string()
+          msg.f_foo_enum = reader |> @protobuf.read_enum() |> FooEnum::from_enum
+        (9, _) => msg.f_fixed64 = reader |> @protobuf.read_fixed64()
+        (10, _) => msg.f_sfixed64 = reader |> @protobuf.read_sfixed64()
+        (11, _) => msg.f_fixed32 = reader |> @protobuf.read_fixed32()
+        (12, _) => msg.f_sfixed32 = reader |> @protobuf.read_sfixed32()
+        (13, _) => msg.f_double = reader |> @protobuf.read_double()
+        (14, _) => msg.f_float = reader |> @protobuf.read_float()
+        (15, _) => msg.f_bytes = reader |> @protobuf.read_bytes()
+        (16, _) => msg.f_string = reader |> @protobuf.read_string()
         (18, _) =>
           msg.f_bar_message = {
-            let len = reader |> @protobuf.async_read_int32()
+            let len = reader |> @protobuf.read_int32()
             if len == 0 {
               BarMessage::default()
             } else {
@@ -532,22 +621,19 @@ pub async fn[R : @protobuf.AsyncReader] FooMessage::read_with_limit(
           }
         (19, _) =>
           msg.f_repeated_int32.push_iter(
-            (reader
-            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+            (reader |> @protobuf.read_packed(@protobuf.read_int32, None)).iter(),
           )
         (20, _) =>
           msg.f_repeated_packed_int32.push_iter(
-            (reader
-            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+            (reader |> @protobuf.read_packed(@protobuf.read_int32, None)).iter(),
           )
         (21, _) =>
           msg.f_repeated_packed_float.push_iter(
-            (reader
-            |> @protobuf.async_read_packed(@protobuf.async_read_float, Some(4))).iter(),
+            (reader |> @protobuf.read_packed(@protobuf.read_float, Some(4))).iter(),
           )
         (23, _) =>
           msg.f_baz = {
-            let len = reader |> @protobuf.async_read_int32()
+            let len = reader |> @protobuf.read_int32()
             if len == 0 {
               BazMessage::default()
             } else {
@@ -556,7 +642,7 @@ pub async fn[R : @protobuf.AsyncReader] FooMessage::read_with_limit(
           }
         (24, _) =>
           msg.f_nested = {
-            let len = reader |> @protobuf.async_read_int32()
+            let len = reader |> @protobuf.read_int32()
             if len == 0 {
               BazMessage_Nested::default()
             } else {
@@ -565,11 +651,11 @@ pub async fn[R : @protobuf.AsyncReader] FooMessage::read_with_limit(
           }
         (25, _) =>
           msg.f_nested_enum = reader
-            |> @protobuf.async_read_enum()
+            |> @protobuf.read_enum()
             |> BazMessage_Nested_NestedEnum::from_enum
         (26, _) => {
           let { key, value } = {
-            let len = reader |> @protobuf.async_read_int32()
+            let len = reader |> @protobuf.read_int32()
             if len == 0 {
               FooMessage_FMapEntry::default()
             } else {
@@ -578,12 +664,11 @@ pub async fn[R : @protobuf.AsyncReader] FooMessage::read_with_limit(
           }
           msg.f_map[key] = value
         }
-        (30, _) =>
-          msg.f_repeated_string.push(reader |> @protobuf.async_read_string())
+        (30, _) => msg.f_repeated_string.push(reader |> @protobuf.read_string())
         (31, _) =>
           msg.f_repeated_baz_message.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 BazMessage::default()
               } else {
@@ -592,22 +677,20 @@ pub async fn[R : @protobuf.AsyncReader] FooMessage::read_with_limit(
             },
           )
         (32, _) =>
-          msg.f_optional_string = reader
-            |> @protobuf.async_read_string()
-            |> Some
+          msg.f_optional_string = reader |> @protobuf.read_string() |> Some
         (27, _) =>
           msg.test_oneof = reader
-            |> @protobuf.async_read_int32()
+            |> @protobuf.read_int32()
             |> FooMessage_TestOneof::F1
         (28, _) =>
           msg.test_oneof = reader
-            |> @protobuf.async_read_bool()
+            |> @protobuf.read_bool()
             |> FooMessage_TestOneof::F2
         (29, _) =>
           msg.test_oneof = reader
-            |> @protobuf.async_read_string()
+            |> @protobuf.read_string()
             |> FooMessage_TestOneof::F3
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -619,122 +702,122 @@ pub async fn[R : @protobuf.AsyncReader] FooMessage::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] FooMessage::write(
+pub fn[W : @protobuf.Writer] FooMessage::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(8UL)
-  writer |> @protobuf.async_write_int32(self.f_int32)
-  writer |> @protobuf.async_write_varint(16UL)
-  writer |> @protobuf.async_write_int64(self.f_int64)
-  writer |> @protobuf.async_write_varint(24UL)
-  writer |> @protobuf.async_write_uint32(self.f_uint32)
-  writer |> @protobuf.async_write_varint(32UL)
-  writer |> @protobuf.async_write_uint64(self.f_uint64)
-  writer |> @protobuf.async_write_varint(40UL)
-  writer |> @protobuf.async_write_sint32(self.f_sint32)
-  writer |> @protobuf.async_write_varint(48UL)
-  writer |> @protobuf.async_write_sint64(self.f_sint64)
-  writer |> @protobuf.async_write_varint(56UL)
-  writer |> @protobuf.async_write_bool(self.f_bool)
-  writer |> @protobuf.async_write_varint(64UL)
-  writer |> @protobuf.async_write_enum(self.f_foo_enum.to_enum())
-  writer |> @protobuf.async_write_varint(73UL)
-  writer |> @protobuf.async_write_fixed64(self.f_fixed64)
-  writer |> @protobuf.async_write_varint(81UL)
-  writer |> @protobuf.async_write_sfixed64(self.f_sfixed64)
-  writer |> @protobuf.async_write_varint(93UL)
-  writer |> @protobuf.async_write_fixed32(self.f_fixed32)
-  writer |> @protobuf.async_write_varint(101UL)
-  writer |> @protobuf.async_write_sfixed32(self.f_sfixed32)
-  writer |> @protobuf.async_write_varint(105UL)
-  writer |> @protobuf.async_write_double(self.f_double)
-  writer |> @protobuf.async_write_varint(117UL)
-  writer |> @protobuf.async_write_float(self.f_float)
-  writer |> @protobuf.async_write_varint(122UL)
-  writer |> @protobuf.async_write_bytes(self.f_bytes)
-  writer |> @protobuf.async_write_varint(130UL)
-  writer |> @protobuf.async_write_string(self.f_string)
-  writer |> @protobuf.async_write_varint(146UL)
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_bar_message))
+  writer |> @protobuf.write_varint(8UL)
+  writer |> @protobuf.write_int32(self.f_int32)
+  writer |> @protobuf.write_varint(16UL)
+  writer |> @protobuf.write_int64(self.f_int64)
+  writer |> @protobuf.write_varint(24UL)
+  writer |> @protobuf.write_uint32(self.f_uint32)
+  writer |> @protobuf.write_varint(32UL)
+  writer |> @protobuf.write_uint64(self.f_uint64)
+  writer |> @protobuf.write_varint(40UL)
+  writer |> @protobuf.write_sint32(self.f_sint32)
+  writer |> @protobuf.write_varint(48UL)
+  writer |> @protobuf.write_sint64(self.f_sint64)
+  writer |> @protobuf.write_varint(56UL)
+  writer |> @protobuf.write_bool(self.f_bool)
+  writer |> @protobuf.write_varint(64UL)
+  writer |> @protobuf.write_enum(self.f_foo_enum.to_enum())
+  writer |> @protobuf.write_varint(73UL)
+  writer |> @protobuf.write_fixed64(self.f_fixed64)
+  writer |> @protobuf.write_varint(81UL)
+  writer |> @protobuf.write_sfixed64(self.f_sfixed64)
+  writer |> @protobuf.write_varint(93UL)
+  writer |> @protobuf.write_fixed32(self.f_fixed32)
+  writer |> @protobuf.write_varint(101UL)
+  writer |> @protobuf.write_sfixed32(self.f_sfixed32)
+  writer |> @protobuf.write_varint(105UL)
+  writer |> @protobuf.write_double(self.f_double)
+  writer |> @protobuf.write_varint(117UL)
+  writer |> @protobuf.write_float(self.f_float)
+  writer |> @protobuf.write_varint(122UL)
+  writer |> @protobuf.write_bytes(self.f_bytes)
+  writer |> @protobuf.write_varint(130UL)
+  writer |> @protobuf.write_string(self.f_string)
+  writer |> @protobuf.write_varint(146UL)
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.f_bar_message))
   self.f_bar_message.write(writer)
-  writer |> @protobuf.async_write_varint(154UL)
+  writer |> @protobuf.write_varint(154UL)
   let size = self.f_repeated_int32
     .iter()
     .map(@protobuf.size_of)
     .fold(init=0U, UInt::op_add)
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.f_repeated_int32 {
-    writer |> @protobuf.async_write_int32(item)
+    writer |> @protobuf.write_int32(item)
   }
-  writer |> @protobuf.async_write_varint(162UL)
+  writer |> @protobuf.write_varint(162UL)
   let size = self.f_repeated_packed_int32
     .iter()
     .map(@protobuf.size_of)
     .fold(init=0U, UInt::op_add)
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.f_repeated_packed_int32 {
-    writer |> @protobuf.async_write_int32(item)
+    writer |> @protobuf.write_int32(item)
   }
-  writer |> @protobuf.async_write_varint(170UL)
+  writer |> @protobuf.write_varint(170UL)
   let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.f_repeated_packed_float {
-    writer |> @protobuf.async_write_float(item)
+    writer |> @protobuf.write_float(item)
   }
-  writer |> @protobuf.async_write_varint(186UL)
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_baz))
+  writer |> @protobuf.write_varint(186UL)
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.f_baz))
   self.f_baz.write(writer)
-  writer |> @protobuf.async_write_varint(194UL)
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_nested))
+  writer |> @protobuf.write_varint(194UL)
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.f_nested))
   self.f_nested.write(writer)
-  writer |> @protobuf.async_write_varint(200UL)
-  writer |> @protobuf.async_write_enum(self.f_nested_enum.to_enum())
+  writer |> @protobuf.write_varint(200UL)
+  writer |> @protobuf.write_enum(self.f_nested_enum.to_enum())
   let keys = self.f_map.keys().collect()
   for i in 0..<keys.length() {
     let k = keys[i]
     let v = self.f_map.get(k).unwrap()
-    writer |> @protobuf.async_write_varint(210UL)
+    writer |> @protobuf.write_varint(210UL)
     let key_size = 1U +
       {
         let size = @protobuf.size_of(k)
         @protobuf.size_of(size) + size
       }
     let value_size = 1U + @protobuf.size_of(v)
-    writer |> @protobuf.async_write_uint32(key_size + value_size)
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_string(k)
-    writer |> @protobuf.async_write_varint(16UL)
-    writer |> @protobuf.async_write_int32(v)
+    writer |> @protobuf.write_uint32(key_size + value_size)
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_string(k)
+    writer |> @protobuf.write_varint(16UL)
+    writer |> @protobuf.write_int32(v)
   }
   for item in self.f_repeated_string {
-    writer |> @protobuf.async_write_varint(242UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(242UL)
+    writer |> @protobuf.write_string(item)
   }
   for item in self.f_repeated_baz_message {
-    writer |> @protobuf.async_write_varint(250UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(250UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
   match self.f_optional_string {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(258UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(258UL)
+      writer |> @protobuf.write_string(v)
     }
     None => ()
   }
   match self.test_oneof {
     FooMessage_TestOneof::F1(v) => {
-      writer |> @protobuf.async_write_varint(216UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(216UL)
+      writer |> @protobuf.write_int32(v)
     }
     FooMessage_TestOneof::F2(v) => {
-      writer |> @protobuf.async_write_varint(224UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(224UL)
+      writer |> @protobuf.write_bool(v)
     }
     FooMessage_TestOneof::F3(v) => {
-      writer |> @protobuf.async_write_varint(234UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(234UL)
+      writer |> @protobuf.write_string(v)
     }
     FooMessage_TestOneof::NotSet => ()
   }
@@ -891,6 +974,272 @@ pub impl @json.FromJson for FooMessage with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] FooMessage::async_read(
+  reader : R,
+) -> FooMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FooMessage::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] FooMessage::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> FooMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = FooMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.f_int32 = reader |> @protobuf.async_read_int32()
+        (2, _) => msg.f_int64 = reader |> @protobuf.async_read_int64()
+        (3, _) => msg.f_uint32 = reader |> @protobuf.async_read_uint32()
+        (4, _) => msg.f_uint64 = reader |> @protobuf.async_read_uint64()
+        (5, _) =>
+          msg.f_sint32 = (reader |> @protobuf.async_read_sint32()).inner()
+        (6, _) =>
+          msg.f_sint64 = (reader |> @protobuf.async_read_sint64()).inner()
+        (7, _) => msg.f_bool = reader |> @protobuf.async_read_bool()
+        (8, _) =>
+          msg.f_foo_enum = reader
+            |> @protobuf.async_read_enum()
+            |> FooEnum::from_enum
+        (9, _) => msg.f_fixed64 = reader |> @protobuf.async_read_fixed64()
+        (10, _) => msg.f_sfixed64 = reader |> @protobuf.async_read_sfixed64()
+        (11, _) => msg.f_fixed32 = reader |> @protobuf.async_read_fixed32()
+        (12, _) => msg.f_sfixed32 = reader |> @protobuf.async_read_sfixed32()
+        (13, _) => msg.f_double = reader |> @protobuf.async_read_double()
+        (14, _) => msg.f_float = reader |> @protobuf.async_read_float()
+        (15, _) => msg.f_bytes = reader |> @protobuf.async_read_bytes()
+        (16, _) => msg.f_string = reader |> @protobuf.async_read_string()
+        (18, _) =>
+          msg.f_bar_message = {
+            let len = reader |> @protobuf.async_read_int32()
+            if len == 0 {
+              BarMessage::default()
+            } else {
+              BarMessage::async_read_with_limit(reader, limit=len)
+            }
+          }
+        (19, _) =>
+          msg.f_repeated_int32.push_iter(
+            (reader
+            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+          )
+        (20, _) =>
+          msg.f_repeated_packed_int32.push_iter(
+            (reader
+            |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter(),
+          )
+        (21, _) =>
+          msg.f_repeated_packed_float.push_iter(
+            (reader
+            |> @protobuf.async_read_packed(@protobuf.async_read_float, Some(4))).iter(),
+          )
+        (23, _) =>
+          msg.f_baz = {
+            let len = reader |> @protobuf.async_read_int32()
+            if len == 0 {
+              BazMessage::default()
+            } else {
+              BazMessage::async_read_with_limit(reader, limit=len)
+            }
+          }
+        (24, _) =>
+          msg.f_nested = {
+            let len = reader |> @protobuf.async_read_int32()
+            if len == 0 {
+              BazMessage_Nested::default()
+            } else {
+              BazMessage_Nested::async_read_with_limit(reader, limit=len)
+            }
+          }
+        (25, _) =>
+          msg.f_nested_enum = reader
+            |> @protobuf.async_read_enum()
+            |> BazMessage_Nested_NestedEnum::from_enum
+        (26, _) => {
+          let { key, value } = {
+            let len = reader |> @protobuf.async_read_int32()
+            if len == 0 {
+              FooMessage_FMapEntry::default()
+            } else {
+              FooMessage_FMapEntry::async_read_with_limit(reader, limit=len)
+            }
+          }
+          msg.f_map[key] = value
+        }
+        (30, _) =>
+          msg.f_repeated_string.push(reader |> @protobuf.async_read_string())
+        (31, _) =>
+          msg.f_repeated_baz_message.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                BazMessage::default()
+              } else {
+                BazMessage::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (32, _) =>
+          msg.f_optional_string = reader
+            |> @protobuf.async_read_string()
+            |> Some
+        (27, _) =>
+          msg.test_oneof = reader
+            |> @protobuf.async_read_int32()
+            |> FooMessage_TestOneof::F1
+        (28, _) =>
+          msg.test_oneof = reader
+            |> @protobuf.async_read_bool()
+            |> FooMessage_TestOneof::F2
+        (29, _) =>
+          msg.test_oneof = reader
+            |> @protobuf.async_read_string()
+            |> FooMessage_TestOneof::F3
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] FooMessage::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(8UL)
+  writer |> @protobuf.async_write_int32(self.f_int32)
+  writer |> @protobuf.async_write_varint(16UL)
+  writer |> @protobuf.async_write_int64(self.f_int64)
+  writer |> @protobuf.async_write_varint(24UL)
+  writer |> @protobuf.async_write_uint32(self.f_uint32)
+  writer |> @protobuf.async_write_varint(32UL)
+  writer |> @protobuf.async_write_uint64(self.f_uint64)
+  writer |> @protobuf.async_write_varint(40UL)
+  writer |> @protobuf.async_write_sint32(self.f_sint32)
+  writer |> @protobuf.async_write_varint(48UL)
+  writer |> @protobuf.async_write_sint64(self.f_sint64)
+  writer |> @protobuf.async_write_varint(56UL)
+  writer |> @protobuf.async_write_bool(self.f_bool)
+  writer |> @protobuf.async_write_varint(64UL)
+  writer |> @protobuf.async_write_enum(self.f_foo_enum.to_enum())
+  writer |> @protobuf.async_write_varint(73UL)
+  writer |> @protobuf.async_write_fixed64(self.f_fixed64)
+  writer |> @protobuf.async_write_varint(81UL)
+  writer |> @protobuf.async_write_sfixed64(self.f_sfixed64)
+  writer |> @protobuf.async_write_varint(93UL)
+  writer |> @protobuf.async_write_fixed32(self.f_fixed32)
+  writer |> @protobuf.async_write_varint(101UL)
+  writer |> @protobuf.async_write_sfixed32(self.f_sfixed32)
+  writer |> @protobuf.async_write_varint(105UL)
+  writer |> @protobuf.async_write_double(self.f_double)
+  writer |> @protobuf.async_write_varint(117UL)
+  writer |> @protobuf.async_write_float(self.f_float)
+  writer |> @protobuf.async_write_varint(122UL)
+  writer |> @protobuf.async_write_bytes(self.f_bytes)
+  writer |> @protobuf.async_write_varint(130UL)
+  writer |> @protobuf.async_write_string(self.f_string)
+  writer |> @protobuf.async_write_varint(146UL)
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_bar_message))
+  self.f_bar_message.async_write(writer)
+  writer |> @protobuf.async_write_varint(154UL)
+  let size = self.f_repeated_int32
+    .iter()
+    .map(@protobuf.size_of)
+    .fold(init=0U, UInt::op_add)
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.f_repeated_int32 {
+    writer |> @protobuf.async_write_int32(item)
+  }
+  writer |> @protobuf.async_write_varint(162UL)
+  let size = self.f_repeated_packed_int32
+    .iter()
+    .map(@protobuf.size_of)
+    .fold(init=0U, UInt::op_add)
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.f_repeated_packed_int32 {
+    writer |> @protobuf.async_write_int32(item)
+  }
+  writer |> @protobuf.async_write_varint(170UL)
+  let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.f_repeated_packed_float {
+    writer |> @protobuf.async_write_float(item)
+  }
+  writer |> @protobuf.async_write_varint(186UL)
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_baz))
+  self.f_baz.async_write(writer)
+  writer |> @protobuf.async_write_varint(194UL)
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_nested))
+  self.f_nested.async_write(writer)
+  writer |> @protobuf.async_write_varint(200UL)
+  writer |> @protobuf.async_write_enum(self.f_nested_enum.to_enum())
+  let keys = self.f_map.keys().collect()
+  for i in 0..<keys.length() {
+    let k = keys[i]
+    let v = self.f_map.get(k).unwrap()
+    writer |> @protobuf.async_write_varint(210UL)
+    let key_size = 1U +
+      {
+        let size = @protobuf.size_of(k)
+        @protobuf.size_of(size) + size
+      }
+    let value_size = 1U + @protobuf.size_of(v)
+    writer |> @protobuf.async_write_uint32(key_size + value_size)
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_string(k)
+    writer |> @protobuf.async_write_varint(16UL)
+    writer |> @protobuf.async_write_int32(v)
+  }
+  for item in self.f_repeated_string {
+    writer |> @protobuf.async_write_varint(242UL)
+    writer |> @protobuf.async_write_string(item)
+  }
+  for item in self.f_repeated_baz_message {
+    writer |> @protobuf.async_write_varint(250UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+  match self.f_optional_string {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(258UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    None => ()
+  }
+  match self.test_oneof {
+    FooMessage_TestOneof::F1(v) => {
+      writer |> @protobuf.async_write_varint(216UL)
+      writer |> @protobuf.async_write_int32(v)
+    }
+    FooMessage_TestOneof::F2(v) => {
+      writer |> @protobuf.async_write_varint(224UL)
+      writer |> @protobuf.async_write_bool(v)
+    }
+    FooMessage_TestOneof::F3(v) => {
+      writer |> @protobuf.async_write_varint(234UL)
+      writer |> @protobuf.async_write_string(v)
+    }
+    FooMessage_TestOneof::NotSet => ()
+  }
+}
+
+///|
 pub(all) enum BazMessage_Nested_NestedEnum {
   Foo
   Bar
@@ -980,7 +1329,7 @@ pub impl Default for BazMessage_Nested_NestedMessage with default() -> BazMessag
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::read(
+pub fn[R : @protobuf.Reader] BazMessage_Nested_NestedMessage::read(
   reader : R,
 ) -> BazMessage_Nested_NestedMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -988,7 +1337,7 @@ pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::read_with_limit(
+pub fn[R : @protobuf.Reader] BazMessage_Nested_NestedMessage::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> BazMessage_Nested_NestedMessage raise {
@@ -1004,9 +1353,9 @@ pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::read_wi
   let msg = BazMessage_Nested_NestedMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.f_nested = reader |> @protobuf.async_read_int32()
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.f_nested = reader |> @protobuf.read_int32()
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1018,12 +1367,12 @@ pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::read_wi
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] BazMessage_Nested_NestedMessage::write(
+pub fn[W : @protobuf.Writer] BazMessage_Nested_NestedMessage::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(8UL)
-  writer |> @protobuf.async_write_int32(self.f_nested)
+  writer |> @protobuf.write_varint(8UL)
+  writer |> @protobuf.write_int32(self.f_nested)
 }
 
 ///|
@@ -1056,6 +1405,53 @@ pub impl @json.FromJson for BazMessage_Nested_NestedMessage with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::async_read(
+  reader : R,
+) -> BazMessage_Nested_NestedMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BazMessage_Nested_NestedMessage::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> BazMessage_Nested_NestedMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = BazMessage_Nested_NestedMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.f_nested = reader |> @protobuf.async_read_int32()
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] BazMessage_Nested_NestedMessage::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(8UL)
+  writer |> @protobuf.async_write_int32(self.f_nested)
+}
+
+///|
 pub(all) struct BazMessage_Nested {
   mut f_nested : BazMessage_Nested_NestedMessage
 } derive(Eq, Show)
@@ -1077,7 +1473,7 @@ pub impl Default for BazMessage_Nested with default() -> BazMessage_Nested {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested::read(
+pub fn[R : @protobuf.Reader] BazMessage_Nested::read(
   reader : R,
 ) -> BazMessage_Nested raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -1085,7 +1481,7 @@ pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested::read_with_limit(
+pub fn[R : @protobuf.Reader] BazMessage_Nested::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> BazMessage_Nested raise {
@@ -1101,10 +1497,10 @@ pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested::read_with_limit(
   let msg = BazMessage_Nested::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.f_nested = {
-            let len = reader |> @protobuf.async_read_int32()
+            let len = reader |> @protobuf.read_int32()
             if len == 0 {
               BazMessage_Nested_NestedMessage::default()
             } else {
@@ -1114,7 +1510,7 @@ pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested::read_with_limit(
               )
             }
           }
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1126,12 +1522,12 @@ pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] BazMessage_Nested::write(
+pub fn[W : @protobuf.Writer] BazMessage_Nested::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL)
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_nested))
+  writer |> @protobuf.write_varint(10UL)
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.f_nested))
   self.f_nested.write(writer)
 }
 
@@ -1162,6 +1558,65 @@ pub impl @json.FromJson for BazMessage_Nested with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested::async_read(
+  reader : R,
+) -> BazMessage_Nested raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BazMessage_Nested::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] BazMessage_Nested::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> BazMessage_Nested raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = BazMessage_Nested::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.f_nested = {
+            let len = reader |> @protobuf.async_read_int32()
+            if len == 0 {
+              BazMessage_Nested_NestedMessage::default()
+            } else {
+              BazMessage_Nested_NestedMessage::async_read_with_limit(
+                reader,
+                limit=len,
+              )
+            }
+          }
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] BazMessage_Nested::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL)
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_nested))
+  self.f_nested.async_write(writer)
 }
 
 ///|
@@ -1198,15 +1653,13 @@ pub impl Default for BazMessage with default() -> BazMessage {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessage::read(
-  reader : R,
-) -> BazMessage raise {
+pub fn[R : @protobuf.Reader] BazMessage::read(reader : R) -> BazMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
   BazMessage::read_with_limit(reader)
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] BazMessage::read_with_limit(
+pub fn[R : @protobuf.Reader] BazMessage::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> BazMessage raise {
@@ -1222,19 +1675,19 @@ pub async fn[R : @protobuf.AsyncReader] BazMessage::read_with_limit(
   let msg = BazMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.nested = {
-            let len = reader |> @protobuf.async_read_int32()
+            let len = reader |> @protobuf.read_int32()
             if len == 0 {
               BazMessage_Nested::default()
             } else {
               BazMessage_Nested::read_with_limit(reader, limit=len)
             }
           }
-        (2, _) => msg.b_int64 = reader |> @protobuf.async_read_int64()
-        (3, _) => msg.b_string = reader |> @protobuf.async_read_string()
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (2, _) => msg.b_int64 = reader |> @protobuf.read_int64()
+        (3, _) => msg.b_string = reader |> @protobuf.read_string()
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1246,17 +1699,17 @@ pub async fn[R : @protobuf.AsyncReader] BazMessage::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] BazMessage::write(
+pub fn[W : @protobuf.Writer] BazMessage::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL)
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.nested))
+  writer |> @protobuf.write_varint(10UL)
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.nested))
   self.nested.write(writer)
-  writer |> @protobuf.async_write_varint(16UL)
-  writer |> @protobuf.async_write_int64(self.b_int64)
-  writer |> @protobuf.async_write_varint(26UL)
-  writer |> @protobuf.async_write_string(self.b_string)
+  writer |> @protobuf.write_varint(16UL)
+  writer |> @protobuf.write_int64(self.b_int64)
+  writer |> @protobuf.write_varint(26UL)
+  writer |> @protobuf.write_string(self.b_string)
 }
 
 ///|
@@ -1295,6 +1748,68 @@ pub impl @json.FromJson for BazMessage with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] BazMessage::async_read(
+  reader : R,
+) -> BazMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BazMessage::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] BazMessage::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> BazMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = BazMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.nested = {
+            let len = reader |> @protobuf.async_read_int32()
+            if len == 0 {
+              BazMessage_Nested::default()
+            } else {
+              BazMessage_Nested::async_read_with_limit(reader, limit=len)
+            }
+          }
+        (2, _) => msg.b_int64 = reader |> @protobuf.async_read_int64()
+        (3, _) => msg.b_string = reader |> @protobuf.async_read_string()
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] BazMessage::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL)
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.nested))
+  self.nested.async_write(writer)
+  writer |> @protobuf.async_write_varint(16UL)
+  writer |> @protobuf.async_write_int64(self.b_int64)
+  writer |> @protobuf.async_write_varint(26UL)
+  writer |> @protobuf.async_write_string(self.b_string)
+}
+
+///|
 pub(all) struct RepeatedMessage {
   mut bar_message : Array[BarMessage]
 } derive(Eq, Show)
@@ -1316,7 +1831,7 @@ pub impl Default for RepeatedMessage with default() -> RepeatedMessage {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] RepeatedMessage::read(
+pub fn[R : @protobuf.Reader] RepeatedMessage::read(
   reader : R,
 ) -> RepeatedMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -1324,7 +1839,7 @@ pub async fn[R : @protobuf.AsyncReader] RepeatedMessage::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] RepeatedMessage::read_with_limit(
+pub fn[R : @protobuf.Reader] RepeatedMessage::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> RepeatedMessage raise {
@@ -1340,11 +1855,11 @@ pub async fn[R : @protobuf.AsyncReader] RepeatedMessage::read_with_limit(
   let msg = RepeatedMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.bar_message.push(
             {
-              let len = reader |> @protobuf.async_read_int32()
+              let len = reader |> @protobuf.read_int32()
               if len == 0 {
                 BarMessage::default()
               } else {
@@ -1352,7 +1867,7 @@ pub async fn[R : @protobuf.AsyncReader] RepeatedMessage::read_with_limit(
               }
             },
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1364,13 +1879,13 @@ pub async fn[R : @protobuf.AsyncReader] RepeatedMessage::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] RepeatedMessage::write(
+pub fn[W : @protobuf.Writer] RepeatedMessage::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
   for item in self.bar_message {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
     item.write(writer)
   }
 }
@@ -1406,6 +1921,66 @@ pub impl @json.FromJson for RepeatedMessage with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] RepeatedMessage::async_read(
+  reader : R,
+) -> RepeatedMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  RepeatedMessage::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] RepeatedMessage::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> RepeatedMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = RepeatedMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.bar_message.push(
+            {
+              let len = reader |> @protobuf.async_read_int32()
+              if len == 0 {
+                BarMessage::default()
+              } else {
+                BarMessage::async_read_with_limit(reader, limit=len)
+              }
+            },
+          )
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] RepeatedMessage::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  for item in self.bar_message {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
+    item.async_write(writer)
+  }
+}
+
+///|
 pub(all) struct EmptyMessage {
   mut field : Int
 } derive(Eq, Show)
@@ -1423,7 +1998,7 @@ pub impl Default for EmptyMessage with default() -> EmptyMessage {
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EmptyMessage::read(
+pub fn[R : @protobuf.Reader] EmptyMessage::read(
   reader : R,
 ) -> EmptyMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -1431,7 +2006,7 @@ pub async fn[R : @protobuf.AsyncReader] EmptyMessage::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EmptyMessage::read_with_limit(
+pub fn[R : @protobuf.Reader] EmptyMessage::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> EmptyMessage raise {
@@ -1447,9 +2022,9 @@ pub async fn[R : @protobuf.AsyncReader] EmptyMessage::read_with_limit(
   let msg = EmptyMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.field = reader |> @protobuf.async_read_int32()
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+        (1, _) => msg.field = reader |> @protobuf.read_int32()
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1461,12 +2036,12 @@ pub async fn[R : @protobuf.AsyncReader] EmptyMessage::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] EmptyMessage::write(
+pub fn[W : @protobuf.Writer] EmptyMessage::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(8UL)
-  writer |> @protobuf.async_write_int32(self.field)
+  writer |> @protobuf.write_varint(8UL)
+  writer |> @protobuf.write_int32(self.field)
 }
 
 ///|
@@ -1497,6 +2072,53 @@ pub impl @json.FromJson for EmptyMessage with from_json(
 }
 
 ///|
+pub async fn[R : @protobuf.AsyncReader] EmptyMessage::async_read(
+  reader : R,
+) -> EmptyMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EmptyMessage::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] EmptyMessage::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> EmptyMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = EmptyMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) => msg.field = reader |> @protobuf.async_read_int32()
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] EmptyMessage::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(8UL)
+  writer |> @protobuf.async_write_int32(self.field)
+}
+
+///|
 pub(all) struct EmptyMessageWithField {
   mut empty_message : EmptyMessage
 } derive(Eq, Show)
@@ -1518,7 +2140,7 @@ pub impl Default for EmptyMessageWithField with default() -> EmptyMessageWithFie
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EmptyMessageWithField::read(
+pub fn[R : @protobuf.Reader] EmptyMessageWithField::read(
   reader : R,
 ) -> EmptyMessageWithField raise {
   let reader = @protobuf.LimitedReader::new(reader)
@@ -1526,7 +2148,7 @@ pub async fn[R : @protobuf.AsyncReader] EmptyMessageWithField::read(
 }
 
 ///|
-pub async fn[R : @protobuf.AsyncReader] EmptyMessageWithField::read_with_limit(
+pub fn[R : @protobuf.Reader] EmptyMessageWithField::read_with_limit(
   reader : @protobuf.LimitedReader[R],
   limit? : Int,
 ) -> EmptyMessageWithField raise {
@@ -1542,17 +2164,17 @@ pub async fn[R : @protobuf.AsyncReader] EmptyMessageWithField::read_with_limit(
   let msg = EmptyMessageWithField::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
         (1, _) =>
           msg.empty_message = {
-            let len = reader |> @protobuf.async_read_int32()
+            let len = reader |> @protobuf.read_int32()
             if len == 0 {
               EmptyMessage::default()
             } else {
               EmptyMessage::read_with_limit(reader, limit=len)
             }
           }
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1564,12 +2186,12 @@ pub async fn[R : @protobuf.AsyncReader] EmptyMessageWithField::read_with_limit(
 }
 
 ///|
-pub async fn[W : @protobuf.AsyncWriter] EmptyMessageWithField::write(
+pub fn[W : @protobuf.Writer] EmptyMessageWithField::write(
   self : Self,
   writer : W,
 ) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL)
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.empty_message))
+  writer |> @protobuf.write_varint(10UL)
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.empty_message))
   self.empty_message.write(writer)
 }
 
@@ -1601,4 +2223,60 @@ pub impl @json.FromJson for EmptyMessageWithField with from_json(
     }
   }
   message
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] EmptyMessageWithField::async_read(
+  reader : R,
+) -> EmptyMessageWithField raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EmptyMessageWithField::async_read_with_limit(reader)
+}
+
+///|
+pub async fn[R : @protobuf.AsyncReader] EmptyMessageWithField::async_read_with_limit(
+  reader : @protobuf.LimitedReader[R],
+  limit? : Int,
+) -> EmptyMessageWithField raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit {
+      raise @protobuf.EndOfStream
+    }
+    Some(l - limit)
+  } else {
+    None
+  }
+  reader.limit = limit
+  let msg = EmptyMessageWithField::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+        (1, _) =>
+          msg.empty_message = {
+            let len = reader |> @protobuf.async_read_int32()
+            if len == 0 {
+              EmptyMessage::default()
+            } else {
+              EmptyMessage::async_read_with_limit(reader, limit=len)
+            }
+          }
+        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+
+///|
+pub async fn[W : @protobuf.AsyncWriter] EmptyMessageWithField::async_write(
+  self : Self,
+  writer : W,
+) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL)
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.empty_message))
+  self.empty_message.async_write(writer)
 }

--- a/test/reader/runner/moon.mod.json
+++ b/test/reader/runner/moon.mod.json
@@ -12,7 +12,8 @@
     },
     "username/gen_proto2": {
       "path": "../gen_proto2"
-    }
+    },
+    "moonbitlang/async": "0.2.2"
   },
   "readme": "",
   "repository": "",

--- a/test/reader/runner/moon.mod.json
+++ b/test/reader/runner/moon.mod.json
@@ -12,8 +12,7 @@
     },
     "username/gen_proto2": {
       "path": "../gen_proto2"
-    },
-    "moonbitlang/async": "0.2.2"
+    }
   },
   "readme": "",
   "repository": "",

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -49,11 +49,11 @@ pub impl Default for BarMessage with default() -> BarMessage {
     b_int32 : Int::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] BarMessage::read(reader : R) -> BarMessage raise {
+pub  fn[R: @protobuf.Reader] BarMessage::read(reader : R) -> BarMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
   BarMessage::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] BarMessage::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BarMessage raise {
+pub  fn[R: @protobuf.Reader] BarMessage::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BarMessage raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -62,9 +62,9 @@ pub async fn[R: @protobuf.AsyncReader] BarMessage::read_with_limit(reader : @pro
   let msg = BarMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.b_int32 = reader |> @protobuf.async_read_int32()
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.b_int32 = reader |> @protobuf.read_int32()
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -74,9 +74,9 @@ pub async fn[R: @protobuf.AsyncReader] BarMessage::read_with_limit(reader : @pro
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] BarMessage::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(8UL);
-  writer |> @protobuf.async_write_int32(self.b_int32)
+pub  fn[W: @protobuf.Writer] BarMessage::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(8UL);
+  writer |> @protobuf.write_int32(self.b_int32)
 }
 pub impl ToJson for BarMessage with to_json(self) {
   let json: Map[String, Json] = {}
@@ -98,6 +98,35 @@ pub impl @json.FromJson for BarMessage with from_json(json: Json, path: @json.Js
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] BarMessage::async_read(reader : R) -> BarMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BarMessage::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] BarMessage::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BarMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = BarMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.b_int32 = reader |> @protobuf.async_read_int32()
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] BarMessage::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(8UL);
+  writer |> @protobuf.async_write_int32(self.b_int32)
+}
 pub(all) struct FooMessage_FMapEntry {
   mut key : String
   mut value : Int
@@ -114,11 +143,11 @@ pub impl Default for FooMessage_FMapEntry with default() -> FooMessage_FMapEntry
     value : Int::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FooMessage_FMapEntry::read(reader : R) -> FooMessage_FMapEntry raise {
+pub  fn[R: @protobuf.Reader] FooMessage_FMapEntry::read(reader : R) -> FooMessage_FMapEntry raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FooMessage_FMapEntry::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FooMessage_FMapEntry::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FooMessage_FMapEntry raise {
+pub  fn[R: @protobuf.Reader] FooMessage_FMapEntry::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FooMessage_FMapEntry raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -127,10 +156,10 @@ pub async fn[R: @protobuf.AsyncReader] FooMessage_FMapEntry::read_with_limit(rea
   let msg = FooMessage_FMapEntry::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.key = reader |> @protobuf.async_read_string()
-      (2, _) => msg.value = reader |> @protobuf.async_read_int32()
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.key = reader |> @protobuf.read_string()
+      (2, _) => msg.value = reader |> @protobuf.read_int32()
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -140,11 +169,11 @@ pub async fn[R: @protobuf.AsyncReader] FooMessage_FMapEntry::read_with_limit(rea
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FooMessage_FMapEntry::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.key)
-  writer |> @protobuf.async_write_varint(16UL);
-  writer |> @protobuf.async_write_int32(self.value)
+pub  fn[W: @protobuf.Writer] FooMessage_FMapEntry::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.key)
+  writer |> @protobuf.write_varint(16UL);
+  writer |> @protobuf.write_int32(self.value)
 }
 pub impl ToJson for FooMessage_FMapEntry with to_json(self) {
   let json: Map[String, Json] = {}
@@ -169,6 +198,38 @@ pub impl @json.FromJson for FooMessage_FMapEntry with from_json(json: Json, path
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] FooMessage_FMapEntry::async_read(reader : R) -> FooMessage_FMapEntry raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FooMessage_FMapEntry::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FooMessage_FMapEntry::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FooMessage_FMapEntry raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FooMessage_FMapEntry::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.key = reader |> @protobuf.async_read_string()
+      (2, _) => msg.value = reader |> @protobuf.async_read_int32()
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] FooMessage_FMapEntry::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.key)
+  writer |> @protobuf.async_write_varint(16UL);
+  writer |> @protobuf.async_write_int32(self.value)
 }
 pub(all) struct FooMessage {
   mut f_int32 : Int
@@ -306,11 +367,11 @@ pub impl Default for FooMessage with default() -> FooMessage {
     test_oneof : FooMessage_TestOneof::NotSet,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FooMessage::read(reader : R) -> FooMessage raise {
+pub  fn[R: @protobuf.Reader] FooMessage::read(reader : R) -> FooMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FooMessage::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FooMessage::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FooMessage raise {
+pub  fn[R: @protobuf.Reader] FooMessage::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FooMessage raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -319,36 +380,36 @@ pub async fn[R: @protobuf.AsyncReader] FooMessage::read_with_limit(reader : @pro
   let msg = FooMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.f_int32 = reader |> @protobuf.async_read_int32()
-      (2, _) => msg.f_int64 = reader |> @protobuf.async_read_int64()
-      (3, _) => msg.f_uint32 = reader |> @protobuf.async_read_uint32()
-      (4, _) => msg.f_uint64 = reader |> @protobuf.async_read_uint64()
-      (5, _) => msg.f_sint32 = (reader |> @protobuf.async_read_sint32()).inner()
-      (6, _) => msg.f_sint64 = (reader |> @protobuf.async_read_sint64()).inner()
-      (7, _) => msg.f_bool = reader |> @protobuf.async_read_bool()
-      (8, _) => msg.f_foo_enum = reader |> @protobuf.async_read_enum() |> FooEnum::from_enum
-      (9, _) => msg.f_fixed64 = reader |> @protobuf.async_read_fixed64()
-      (10, _) => msg.f_sfixed64 = reader |> @protobuf.async_read_sfixed64()
-      (11, _) => msg.f_fixed32 = reader |> @protobuf.async_read_fixed32()
-      (12, _) => msg.f_sfixed32 = reader |> @protobuf.async_read_sfixed32()
-      (13, _) => msg.f_double = reader |> @protobuf.async_read_double()
-      (14, _) => msg.f_float = reader |> @protobuf.async_read_float()
-      (15, _) => msg.f_bytes = reader |> @protobuf.async_read_bytes()
-      (16, _) => msg.f_string = reader |> @protobuf.async_read_string()
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.f_int32 = reader |> @protobuf.read_int32()
+      (2, _) => msg.f_int64 = reader |> @protobuf.read_int64()
+      (3, _) => msg.f_uint32 = reader |> @protobuf.read_uint32()
+      (4, _) => msg.f_uint64 = reader |> @protobuf.read_uint64()
+      (5, _) => msg.f_sint32 = (reader |> @protobuf.read_sint32()).inner()
+      (6, _) => msg.f_sint64 = (reader |> @protobuf.read_sint64()).inner()
+      (7, _) => msg.f_bool = reader |> @protobuf.read_bool()
+      (8, _) => msg.f_foo_enum = reader |> @protobuf.read_enum() |> FooEnum::from_enum
+      (9, _) => msg.f_fixed64 = reader |> @protobuf.read_fixed64()
+      (10, _) => msg.f_sfixed64 = reader |> @protobuf.read_sfixed64()
+      (11, _) => msg.f_fixed32 = reader |> @protobuf.read_fixed32()
+      (12, _) => msg.f_sfixed32 = reader |> @protobuf.read_sfixed32()
+      (13, _) => msg.f_double = reader |> @protobuf.read_double()
+      (14, _) => msg.f_float = reader |> @protobuf.read_float()
+      (15, _) => msg.f_bytes = reader |> @protobuf.read_bytes()
+      (16, _) => msg.f_string = reader |> @protobuf.read_string()
       (18, _) => msg.f_bar_message =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       BarMessage::default()
     } else {
       BarMessage::read_with_limit(reader, limit=len)
     }
   }
-      (19, _) => { msg.f_repeated_int32.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter()) }
-      (20, _) => { msg.f_repeated_packed_int32.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter()) }
-      (21, _) => { msg.f_repeated_packed_float.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_float, Some(4))).iter()) }
+      (19, _) => { msg.f_repeated_int32.push_iter((reader |> @protobuf.read_packed(@protobuf.read_int32, None)).iter()) }
+      (20, _) => { msg.f_repeated_packed_int32.push_iter((reader |> @protobuf.read_packed(@protobuf.read_int32, None)).iter()) }
+      (21, _) => { msg.f_repeated_packed_float.push_iter((reader |> @protobuf.read_packed(@protobuf.read_float, Some(4))).iter()) }
       (23, _) => msg.f_baz =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       BazMessage::default()
     } else {
@@ -356,36 +417,36 @@ pub async fn[R: @protobuf.AsyncReader] FooMessage::read_with_limit(reader : @pro
     }
   }
       (24, _) => msg.f_nested =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       BazMessage_Nested::default()
     } else {
       BazMessage_Nested::read_with_limit(reader, limit=len)
     }
   }
-      (25, _) => msg.f_nested_enum = reader |> @protobuf.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum
+      (25, _) => msg.f_nested_enum = reader |> @protobuf.read_enum() |> BazMessage_Nested_NestedEnum::from_enum
       (26, _) => { let {key, value} =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FooMessage_FMapEntry::default()
     } else {
       FooMessage_FMapEntry::read_with_limit(reader, limit=len)
     }
   }; msg.f_map[key] = value }
-      (30, _) => msg.f_repeated_string.push(reader |> @protobuf.async_read_string())
+      (30, _) => msg.f_repeated_string.push(reader |> @protobuf.read_string())
       (31, _) => msg.f_repeated_baz_message.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       BazMessage::default()
     } else {
       BazMessage::read_with_limit(reader, limit=len)
     }
   })
-      (32, _) => msg.f_optional_string = reader |> @protobuf.async_read_string() |> Some
-        (27, _) => msg.test_oneof = reader |> @protobuf.async_read_int32() |> FooMessage_TestOneof::F1
-        (28, _) => msg.test_oneof = reader |> @protobuf.async_read_bool() |> FooMessage_TestOneof::F2
-        (29, _) => msg.test_oneof = reader |> @protobuf.async_read_string() |> FooMessage_TestOneof::F3
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      (32, _) => msg.f_optional_string = reader |> @protobuf.read_string() |> Some
+        (27, _) => msg.test_oneof = reader |> @protobuf.read_int32() |> FooMessage_TestOneof::F1
+        (28, _) => msg.test_oneof = reader |> @protobuf.read_bool() |> FooMessage_TestOneof::F2
+        (29, _) => msg.test_oneof = reader |> @protobuf.read_string() |> FooMessage_TestOneof::F3
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -395,115 +456,115 @@ pub async fn[R: @protobuf.AsyncReader] FooMessage::read_with_limit(reader : @pro
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FooMessage::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(8UL);
-  writer |> @protobuf.async_write_int32(self.f_int32)
-  writer |> @protobuf.async_write_varint(16UL);
-  writer |> @protobuf.async_write_int64(self.f_int64)
-  writer |> @protobuf.async_write_varint(24UL);
-  writer |> @protobuf.async_write_uint32(self.f_uint32)
-  writer |> @protobuf.async_write_varint(32UL);
-  writer |> @protobuf.async_write_uint64(self.f_uint64)
-  writer |> @protobuf.async_write_varint(40UL);
-  writer |> @protobuf.async_write_sint32(self.f_sint32)
-  writer |> @protobuf.async_write_varint(48UL);
-  writer |> @protobuf.async_write_sint64(self.f_sint64)
-  writer |> @protobuf.async_write_varint(56UL);
-  writer |> @protobuf.async_write_bool(self.f_bool)
-  writer |> @protobuf.async_write_varint(64UL);
-  writer |> @protobuf.async_write_enum(self.f_foo_enum.to_enum())
-  writer |> @protobuf.async_write_varint(73UL);
-  writer |> @protobuf.async_write_fixed64(self.f_fixed64)
-  writer |> @protobuf.async_write_varint(81UL);
-  writer |> @protobuf.async_write_sfixed64(self.f_sfixed64)
-  writer |> @protobuf.async_write_varint(93UL);
-  writer |> @protobuf.async_write_fixed32(self.f_fixed32)
-  writer |> @protobuf.async_write_varint(101UL);
-  writer |> @protobuf.async_write_sfixed32(self.f_sfixed32)
-  writer |> @protobuf.async_write_varint(105UL);
-  writer |> @protobuf.async_write_double(self.f_double)
-  writer |> @protobuf.async_write_varint(117UL);
-  writer |> @protobuf.async_write_float(self.f_float)
-  writer |> @protobuf.async_write_varint(122UL);
-  writer |> @protobuf.async_write_bytes(self.f_bytes)
-  writer |> @protobuf.async_write_varint(130UL);
-  writer |> @protobuf.async_write_string(self.f_string)
-  writer |> @protobuf.async_write_varint(146UL);
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_bar_message)); self.f_bar_message.write(writer)
-  writer |> @protobuf.async_write_varint(154UL)
+pub  fn[W: @protobuf.Writer] FooMessage::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(8UL);
+  writer |> @protobuf.write_int32(self.f_int32)
+  writer |> @protobuf.write_varint(16UL);
+  writer |> @protobuf.write_int64(self.f_int64)
+  writer |> @protobuf.write_varint(24UL);
+  writer |> @protobuf.write_uint32(self.f_uint32)
+  writer |> @protobuf.write_varint(32UL);
+  writer |> @protobuf.write_uint64(self.f_uint64)
+  writer |> @protobuf.write_varint(40UL);
+  writer |> @protobuf.write_sint32(self.f_sint32)
+  writer |> @protobuf.write_varint(48UL);
+  writer |> @protobuf.write_sint64(self.f_sint64)
+  writer |> @protobuf.write_varint(56UL);
+  writer |> @protobuf.write_bool(self.f_bool)
+  writer |> @protobuf.write_varint(64UL);
+  writer |> @protobuf.write_enum(self.f_foo_enum.to_enum())
+  writer |> @protobuf.write_varint(73UL);
+  writer |> @protobuf.write_fixed64(self.f_fixed64)
+  writer |> @protobuf.write_varint(81UL);
+  writer |> @protobuf.write_sfixed64(self.f_sfixed64)
+  writer |> @protobuf.write_varint(93UL);
+  writer |> @protobuf.write_fixed32(self.f_fixed32)
+  writer |> @protobuf.write_varint(101UL);
+  writer |> @protobuf.write_sfixed32(self.f_sfixed32)
+  writer |> @protobuf.write_varint(105UL);
+  writer |> @protobuf.write_double(self.f_double)
+  writer |> @protobuf.write_varint(117UL);
+  writer |> @protobuf.write_float(self.f_float)
+  writer |> @protobuf.write_varint(122UL);
+  writer |> @protobuf.write_bytes(self.f_bytes)
+  writer |> @protobuf.write_varint(130UL);
+  writer |> @protobuf.write_string(self.f_string)
+  writer |> @protobuf.write_varint(146UL);
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.f_bar_message)); self.f_bar_message.write(writer)
+  writer |> @protobuf.write_varint(154UL)
   let size = self.f_repeated_int32.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.f_repeated_int32 {
-      writer |> @protobuf.async_write_int32(item)
+      writer |> @protobuf.write_int32(item)
 
   }
-  writer |> @protobuf.async_write_varint(162UL)
+  writer |> @protobuf.write_varint(162UL)
   let size = self.f_repeated_packed_int32.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.f_repeated_packed_int32 {
-      writer |> @protobuf.async_write_int32(item)
+      writer |> @protobuf.write_int32(item)
 
   }
-  writer |> @protobuf.async_write_varint(170UL)
+  writer |> @protobuf.write_varint(170UL)
   let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.f_repeated_packed_float {
-      writer |> @protobuf.async_write_float(item)
+      writer |> @protobuf.write_float(item)
 
   }
-  writer |> @protobuf.async_write_varint(186UL);
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_baz)); self.f_baz.write(writer)
-  writer |> @protobuf.async_write_varint(194UL);
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_nested)); self.f_nested.write(writer)
-  writer |> @protobuf.async_write_varint(200UL);
-  writer |> @protobuf.async_write_enum(self.f_nested_enum.to_enum())
+  writer |> @protobuf.write_varint(186UL);
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.f_baz)); self.f_baz.write(writer)
+  writer |> @protobuf.write_varint(194UL);
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.f_nested)); self.f_nested.write(writer)
+  writer |> @protobuf.write_varint(200UL);
+  writer |> @protobuf.write_enum(self.f_nested_enum.to_enum())
   let keys = self.f_map.keys().collect()
   for i in 0..<keys.length() {
     let k = keys[i]
     let v = self.f_map.get(k).unwrap()
-    writer |> @protobuf.async_write_varint(210UL)
+    writer |> @protobuf.write_varint(210UL)
     let key_size = 1U + { let size = @protobuf.size_of(k); @protobuf.size_of(size) + size }
     let value_size = 1U + @protobuf.size_of(v)
-    writer |> @protobuf.async_write_uint32(key_size + value_size)
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_string(k)
+    writer |> @protobuf.write_uint32(key_size + value_size)
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_string(k)
 
-    writer |> @protobuf.async_write_varint(16UL);
-    writer |> @protobuf.async_write_int32(v)
+    writer |> @protobuf.write_varint(16UL);
+    writer |> @protobuf.write_int32(v)
 
   }
    for item in self.f_repeated_string {
-    writer |> @protobuf.async_write_varint(242UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(242UL)
+    writer |> @protobuf.write_string(item)
 
   }
   for item in self.f_repeated_baz_message {
-    writer |> @protobuf.async_write_varint(250UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(250UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.f_optional_string {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(258UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(258UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.test_oneof {
     FooMessage_TestOneof::F1(v) => {
-      writer |> @protobuf.async_write_varint(216UL)
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(216UL)
+      writer |> @protobuf.write_int32(v)
 
      }
     FooMessage_TestOneof::F2(v) => {
-      writer |> @protobuf.async_write_varint(224UL)
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(224UL)
+      writer |> @protobuf.write_bool(v)
 
      }
     FooMessage_TestOneof::F3(v) => {
-      writer |> @protobuf.async_write_varint(234UL)
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(234UL)
+      writer |> @protobuf.write_string(v)
 
      }
     FooMessage_TestOneof::NotSet => ()
@@ -639,6 +700,209 @@ v.as_number().unwrap().to_float())
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] FooMessage::async_read(reader : R) -> FooMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FooMessage::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FooMessage::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FooMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FooMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.f_int32 = reader |> @protobuf.async_read_int32()
+      (2, _) => msg.f_int64 = reader |> @protobuf.async_read_int64()
+      (3, _) => msg.f_uint32 = reader |> @protobuf.async_read_uint32()
+      (4, _) => msg.f_uint64 = reader |> @protobuf.async_read_uint64()
+      (5, _) => msg.f_sint32 = (reader |> @protobuf.async_read_sint32()).inner()
+      (6, _) => msg.f_sint64 = (reader |> @protobuf.async_read_sint64()).inner()
+      (7, _) => msg.f_bool = reader |> @protobuf.async_read_bool()
+      (8, _) => msg.f_foo_enum = reader |> @protobuf.async_read_enum() |> FooEnum::from_enum
+      (9, _) => msg.f_fixed64 = reader |> @protobuf.async_read_fixed64()
+      (10, _) => msg.f_sfixed64 = reader |> @protobuf.async_read_sfixed64()
+      (11, _) => msg.f_fixed32 = reader |> @protobuf.async_read_fixed32()
+      (12, _) => msg.f_sfixed32 = reader |> @protobuf.async_read_sfixed32()
+      (13, _) => msg.f_double = reader |> @protobuf.async_read_double()
+      (14, _) => msg.f_float = reader |> @protobuf.async_read_float()
+      (15, _) => msg.f_bytes = reader |> @protobuf.async_read_bytes()
+      (16, _) => msg.f_string = reader |> @protobuf.async_read_string()
+      (18, _) => msg.f_bar_message =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      BarMessage::default()
+    } else {
+      BarMessage::async_read_with_limit(reader, limit=len)
+    }
+  }
+      (19, _) => { msg.f_repeated_int32.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter()) }
+      (20, _) => { msg.f_repeated_packed_int32.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter()) }
+      (21, _) => { msg.f_repeated_packed_float.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_float, Some(4))).iter()) }
+      (23, _) => msg.f_baz =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      BazMessage::default()
+    } else {
+      BazMessage::async_read_with_limit(reader, limit=len)
+    }
+  }
+      (24, _) => msg.f_nested =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      BazMessage_Nested::default()
+    } else {
+      BazMessage_Nested::async_read_with_limit(reader, limit=len)
+    }
+  }
+      (25, _) => msg.f_nested_enum = reader |> @protobuf.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum
+      (26, _) => { let {key, value} =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FooMessage_FMapEntry::default()
+    } else {
+      FooMessage_FMapEntry::async_read_with_limit(reader, limit=len)
+    }
+  }; msg.f_map[key] = value }
+      (30, _) => msg.f_repeated_string.push(reader |> @protobuf.async_read_string())
+      (31, _) => msg.f_repeated_baz_message.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      BazMessage::default()
+    } else {
+      BazMessage::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (32, _) => msg.f_optional_string = reader |> @protobuf.async_read_string() |> Some
+        (27, _) => msg.test_oneof = reader |> @protobuf.async_read_int32() |> FooMessage_TestOneof::F1
+        (28, _) => msg.test_oneof = reader |> @protobuf.async_read_bool() |> FooMessage_TestOneof::F2
+        (29, _) => msg.test_oneof = reader |> @protobuf.async_read_string() |> FooMessage_TestOneof::F3
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] FooMessage::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(8UL);
+  writer |> @protobuf.async_write_int32(self.f_int32)
+  writer |> @protobuf.async_write_varint(16UL);
+  writer |> @protobuf.async_write_int64(self.f_int64)
+  writer |> @protobuf.async_write_varint(24UL);
+  writer |> @protobuf.async_write_uint32(self.f_uint32)
+  writer |> @protobuf.async_write_varint(32UL);
+  writer |> @protobuf.async_write_uint64(self.f_uint64)
+  writer |> @protobuf.async_write_varint(40UL);
+  writer |> @protobuf.async_write_sint32(self.f_sint32)
+  writer |> @protobuf.async_write_varint(48UL);
+  writer |> @protobuf.async_write_sint64(self.f_sint64)
+  writer |> @protobuf.async_write_varint(56UL);
+  writer |> @protobuf.async_write_bool(self.f_bool)
+  writer |> @protobuf.async_write_varint(64UL);
+  writer |> @protobuf.async_write_enum(self.f_foo_enum.to_enum())
+  writer |> @protobuf.async_write_varint(73UL);
+  writer |> @protobuf.async_write_fixed64(self.f_fixed64)
+  writer |> @protobuf.async_write_varint(81UL);
+  writer |> @protobuf.async_write_sfixed64(self.f_sfixed64)
+  writer |> @protobuf.async_write_varint(93UL);
+  writer |> @protobuf.async_write_fixed32(self.f_fixed32)
+  writer |> @protobuf.async_write_varint(101UL);
+  writer |> @protobuf.async_write_sfixed32(self.f_sfixed32)
+  writer |> @protobuf.async_write_varint(105UL);
+  writer |> @protobuf.async_write_double(self.f_double)
+  writer |> @protobuf.async_write_varint(117UL);
+  writer |> @protobuf.async_write_float(self.f_float)
+  writer |> @protobuf.async_write_varint(122UL);
+  writer |> @protobuf.async_write_bytes(self.f_bytes)
+  writer |> @protobuf.async_write_varint(130UL);
+  writer |> @protobuf.async_write_string(self.f_string)
+  writer |> @protobuf.async_write_varint(146UL);
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_bar_message)); self.f_bar_message.async_write(writer)
+  writer |> @protobuf.async_write_varint(154UL)
+  let size = self.f_repeated_int32.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.f_repeated_int32 {
+      writer |> @protobuf.async_write_int32(item)
+
+  }
+  writer |> @protobuf.async_write_varint(162UL)
+  let size = self.f_repeated_packed_int32.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.f_repeated_packed_int32 {
+      writer |> @protobuf.async_write_int32(item)
+
+  }
+  writer |> @protobuf.async_write_varint(170UL)
+  let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.f_repeated_packed_float {
+      writer |> @protobuf.async_write_float(item)
+
+  }
+  writer |> @protobuf.async_write_varint(186UL);
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_baz)); self.f_baz.async_write(writer)
+  writer |> @protobuf.async_write_varint(194UL);
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_nested)); self.f_nested.async_write(writer)
+  writer |> @protobuf.async_write_varint(200UL);
+  writer |> @protobuf.async_write_enum(self.f_nested_enum.to_enum())
+  let keys = self.f_map.keys().collect()
+  for i in 0..<keys.length() {
+    let k = keys[i]
+    let v = self.f_map.get(k).unwrap()
+    writer |> @protobuf.async_write_varint(210UL)
+    let key_size = 1U + { let size = @protobuf.size_of(k); @protobuf.size_of(size) + size }
+    let value_size = 1U + @protobuf.size_of(v)
+    writer |> @protobuf.async_write_uint32(key_size + value_size)
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_string(k)
+
+    writer |> @protobuf.async_write_varint(16UL);
+    writer |> @protobuf.async_write_int32(v)
+
+  }
+   for item in self.f_repeated_string {
+    writer |> @protobuf.async_write_varint(242UL)
+    writer |> @protobuf.async_write_string(item)
+
+  }
+  for item in self.f_repeated_baz_message {
+    writer |> @protobuf.async_write_varint(250UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.f_optional_string {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(258UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.test_oneof {
+    FooMessage_TestOneof::F1(v) => {
+      writer |> @protobuf.async_write_varint(216UL)
+      writer |> @protobuf.async_write_int32(v)
+
+     }
+    FooMessage_TestOneof::F2(v) => {
+      writer |> @protobuf.async_write_varint(224UL)
+      writer |> @protobuf.async_write_bool(v)
+
+     }
+    FooMessage_TestOneof::F3(v) => {
+      writer |> @protobuf.async_write_varint(234UL)
+      writer |> @protobuf.async_write_string(v)
+
+     }
+    FooMessage_TestOneof::NotSet => ()
+  }
+}
 pub(all) enum BazMessage_Nested_NestedEnum {
   Foo
   Bar
@@ -696,11 +960,11 @@ pub impl Default for BazMessage_Nested_NestedMessage with default() -> BazMessag
     f_nested : Int::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::read(reader : R) -> BazMessage_Nested_NestedMessage raise {
+pub  fn[R: @protobuf.Reader] BazMessage_Nested_NestedMessage::read(reader : R) -> BazMessage_Nested_NestedMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
   BazMessage_Nested_NestedMessage::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BazMessage_Nested_NestedMessage raise {
+pub  fn[R: @protobuf.Reader] BazMessage_Nested_NestedMessage::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BazMessage_Nested_NestedMessage raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -709,9 +973,9 @@ pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::read_wit
   let msg = BazMessage_Nested_NestedMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.f_nested = reader |> @protobuf.async_read_int32()
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.f_nested = reader |> @protobuf.read_int32()
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -721,9 +985,9 @@ pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::read_wit
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] BazMessage_Nested_NestedMessage::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(8UL);
-  writer |> @protobuf.async_write_int32(self.f_nested)
+pub  fn[W: @protobuf.Writer] BazMessage_Nested_NestedMessage::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(8UL);
+  writer |> @protobuf.write_int32(self.f_nested)
 }
 pub impl ToJson for BazMessage_Nested_NestedMessage with to_json(self) {
   let json: Map[String, Json] = {}
@@ -745,6 +1009,35 @@ pub impl @json.FromJson for BazMessage_Nested_NestedMessage with from_json(json:
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::async_read(reader : R) -> BazMessage_Nested_NestedMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BazMessage_Nested_NestedMessage::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested_NestedMessage::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BazMessage_Nested_NestedMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = BazMessage_Nested_NestedMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.f_nested = reader |> @protobuf.async_read_int32()
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] BazMessage_Nested_NestedMessage::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(8UL);
+  writer |> @protobuf.async_write_int32(self.f_nested)
+}
 pub(all) struct BazMessage_Nested {
   mut f_nested :  BazMessage_Nested_NestedMessage 
 } derive(Eq, Show)
@@ -758,11 +1051,11 @@ pub impl Default for BazMessage_Nested with default() -> BazMessage_Nested {
     f_nested : BazMessage_Nested_NestedMessage::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested::read(reader : R) -> BazMessage_Nested raise {
+pub  fn[R: @protobuf.Reader] BazMessage_Nested::read(reader : R) -> BazMessage_Nested raise {
   let reader = @protobuf.LimitedReader::new(reader)
   BazMessage_Nested::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BazMessage_Nested raise {
+pub  fn[R: @protobuf.Reader] BazMessage_Nested::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BazMessage_Nested raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -771,16 +1064,16 @@ pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested::read_with_limit(reader
   let msg = BazMessage_Nested::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (1, _) => msg.f_nested =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       BazMessage_Nested_NestedMessage::default()
     } else {
       BazMessage_Nested_NestedMessage::read_with_limit(reader, limit=len)
     }
   }
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -790,9 +1083,9 @@ pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested::read_with_limit(reader
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] BazMessage_Nested::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_nested)); self.f_nested.write(writer)
+pub  fn[W: @protobuf.Writer] BazMessage_Nested::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.f_nested)); self.f_nested.write(writer)
 }
 pub impl ToJson for BazMessage_Nested with to_json(self) {
   let json: Map[String, Json] = {}
@@ -814,6 +1107,42 @@ pub impl @json.FromJson for BazMessage_Nested with from_json(json: Json, path: @
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested::async_read(reader : R) -> BazMessage_Nested raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BazMessage_Nested::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] BazMessage_Nested::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BazMessage_Nested raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = BazMessage_Nested::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.f_nested =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      BazMessage_Nested_NestedMessage::default()
+    } else {
+      BazMessage_Nested_NestedMessage::async_read_with_limit(reader, limit=len)
+    }
+  }
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] BazMessage_Nested::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.f_nested)); self.f_nested.async_write(writer)
+}
 pub(all) struct BazMessage {
   mut nested :  BazMessage_Nested 
   mut b_int64 : Int64
@@ -833,11 +1162,11 @@ pub impl Default for BazMessage with default() -> BazMessage {
     b_string : String::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] BazMessage::read(reader : R) -> BazMessage raise {
+pub  fn[R: @protobuf.Reader] BazMessage::read(reader : R) -> BazMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
   BazMessage::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] BazMessage::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BazMessage raise {
+pub  fn[R: @protobuf.Reader] BazMessage::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BazMessage raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -846,18 +1175,18 @@ pub async fn[R: @protobuf.AsyncReader] BazMessage::read_with_limit(reader : @pro
   let msg = BazMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (1, _) => msg.nested =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       BazMessage_Nested::default()
     } else {
       BazMessage_Nested::read_with_limit(reader, limit=len)
     }
   }
-      (2, _) => msg.b_int64 = reader |> @protobuf.async_read_int64()
-      (3, _) => msg.b_string = reader |> @protobuf.async_read_string()
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      (2, _) => msg.b_int64 = reader |> @protobuf.read_int64()
+      (3, _) => msg.b_string = reader |> @protobuf.read_string()
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -867,13 +1196,13 @@ pub async fn[R: @protobuf.AsyncReader] BazMessage::read_with_limit(reader : @pro
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] BazMessage::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.nested)); self.nested.write(writer)
-  writer |> @protobuf.async_write_varint(16UL);
-  writer |> @protobuf.async_write_int64(self.b_int64)
-  writer |> @protobuf.async_write_varint(26UL);
-  writer |> @protobuf.async_write_string(self.b_string)
+pub  fn[W: @protobuf.Writer] BazMessage::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.nested)); self.nested.write(writer)
+  writer |> @protobuf.write_varint(16UL);
+  writer |> @protobuf.write_int64(self.b_int64)
+  writer |> @protobuf.write_varint(26UL);
+  writer |> @protobuf.write_string(self.b_string)
 }
 pub impl ToJson for BazMessage with to_json(self) {
   let json: Map[String, Json] = {}
@@ -903,6 +1232,48 @@ pub impl @json.FromJson for BazMessage with from_json(json: Json, path: @json.Js
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] BazMessage::async_read(reader : R) -> BazMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  BazMessage::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] BazMessage::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> BazMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = BazMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.nested =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      BazMessage_Nested::default()
+    } else {
+      BazMessage_Nested::async_read_with_limit(reader, limit=len)
+    }
+  }
+      (2, _) => msg.b_int64 = reader |> @protobuf.async_read_int64()
+      (3, _) => msg.b_string = reader |> @protobuf.async_read_string()
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] BazMessage::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.nested)); self.nested.async_write(writer)
+  writer |> @protobuf.async_write_varint(16UL);
+  writer |> @protobuf.async_write_int64(self.b_int64)
+  writer |> @protobuf.async_write_varint(26UL);
+  writer |> @protobuf.async_write_string(self.b_string)
+}
 pub(all) struct RepeatedMessage {
   mut bar_message : Array[BarMessage]
 } derive(Eq, Show)
@@ -916,11 +1287,11 @@ pub impl Default for RepeatedMessage with default() -> RepeatedMessage {
     bar_message : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] RepeatedMessage::read(reader : R) -> RepeatedMessage raise {
+pub  fn[R: @protobuf.Reader] RepeatedMessage::read(reader : R) -> RepeatedMessage raise {
   let reader = @protobuf.LimitedReader::new(reader)
   RepeatedMessage::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] RepeatedMessage::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> RepeatedMessage raise {
+pub  fn[R: @protobuf.Reader] RepeatedMessage::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> RepeatedMessage raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -929,16 +1300,16 @@ pub async fn[R: @protobuf.AsyncReader] RepeatedMessage::read_with_limit(reader :
   let msg = RepeatedMessage::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (1, _) => msg.bar_message.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       BarMessage::default()
     } else {
       BarMessage::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -948,10 +1319,10 @@ pub async fn[R: @protobuf.AsyncReader] RepeatedMessage::read_with_limit(reader :
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] RepeatedMessage::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] RepeatedMessage::write(self:Self, writer : W) -> Unit raise {
   for item in self.bar_message {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -975,4 +1346,43 @@ pub impl @json.FromJson for RepeatedMessage with from_json(json: Json, path: @js
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] RepeatedMessage::async_read(reader : R) -> RepeatedMessage raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  RepeatedMessage::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] RepeatedMessage::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> RepeatedMessage raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = RepeatedMessage::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.bar_message.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      BarMessage::default()
+    } else {
+      BarMessage::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] RepeatedMessage::async_write(self:Self, writer : W) -> Unit raise {
+  for item in self.bar_message {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
 }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -14,11 +14,11 @@ pub impl Default for Hello_MetadataEntry with default() -> Hello_MetadataEntry {
     value : String::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::read(reader : R) -> Hello_MetadataEntry raise {
+pub  fn[R: @protobuf.Reader] Hello_MetadataEntry::read(reader : R) -> Hello_MetadataEntry raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Hello_MetadataEntry::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello_MetadataEntry raise {
+pub  fn[R: @protobuf.Reader] Hello_MetadataEntry::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello_MetadataEntry raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -27,10 +27,10 @@ pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::read_with_limit(read
   let msg = Hello_MetadataEntry::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.key = reader |> @protobuf.async_read_string()
-      (2, _) => msg.value = reader |> @protobuf.async_read_string()
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.key = reader |> @protobuf.read_string()
+      (2, _) => msg.value = reader |> @protobuf.read_string()
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -40,11 +40,11 @@ pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::read_with_limit(read
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Hello_MetadataEntry::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.key)
-  writer |> @protobuf.async_write_varint(18UL);
-  writer |> @protobuf.async_write_string(self.value)
+pub  fn[W: @protobuf.Writer] Hello_MetadataEntry::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.key)
+  writer |> @protobuf.write_varint(18UL);
+  writer |> @protobuf.write_string(self.value)
 }
 pub impl ToJson for Hello_MetadataEntry with to_json(self) {
   let json: Map[String, Json] = {}
@@ -69,6 +69,38 @@ pub impl @json.FromJson for Hello_MetadataEntry with from_json(json: Json, path:
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::async_read(reader : R) -> Hello_MetadataEntry raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Hello_MetadataEntry::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello_MetadataEntry raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Hello_MetadataEntry::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.key = reader |> @protobuf.async_read_string()
+      (2, _) => msg.value = reader |> @protobuf.async_read_string()
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Hello_MetadataEntry::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.key)
+  writer |> @protobuf.async_write_varint(18UL);
+  writer |> @protobuf.async_write_string(self.value)
 }
 pub(all) struct Hello {
   mut name : String
@@ -103,11 +135,11 @@ pub impl Default for Hello with default() -> Hello {
     friend : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Hello::read(reader : R) -> Hello raise {
+pub  fn[R: @protobuf.Reader] Hello::read(reader : R) -> Hello raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Hello::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Hello::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello raise {
+pub  fn[R: @protobuf.Reader] Hello::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -116,12 +148,12 @@ pub async fn[R: @protobuf.AsyncReader] Hello::read_with_limit(reader : @protobuf
   let msg = Hello::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string()
-      (2, _) => msg.age = reader |> @protobuf.async_read_int32()
-      (3, _) => msg.hobbies.push(reader |> @protobuf.async_read_string())
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string()
+      (2, _) => msg.age = reader |> @protobuf.read_int32()
+      (3, _) => msg.hobbies.push(reader |> @protobuf.read_string())
       (4, _) => { let {key, value} =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Hello_MetadataEntry::default()
     } else {
@@ -129,14 +161,14 @@ pub async fn[R: @protobuf.AsyncReader] Hello::read_with_limit(reader : @protobuf
     }
   }; msg.metadata[key] = value }
       (5, _) => msg.friend =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Hello::default()
     } else {
       Hello::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -146,35 +178,35 @@ pub async fn[R: @protobuf.AsyncReader] Hello::read_with_limit(reader : @protobuf
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Hello::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.name)
-  writer |> @protobuf.async_write_varint(16UL);
-  writer |> @protobuf.async_write_int32(self.age)
+pub  fn[W: @protobuf.Writer] Hello::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.name)
+  writer |> @protobuf.write_varint(16UL);
+  writer |> @protobuf.write_int32(self.age)
   for item in self.hobbies {
-    writer |> @protobuf.async_write_varint(26UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(26UL)
+    writer |> @protobuf.write_string(item)
 
   }
   let keys = self.metadata.keys().collect()
   for i in 0..<keys.length() {
     let k = keys[i]
     let v = self.metadata.get(k).unwrap()
-    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.write_varint(34UL)
     let key_size = 1U + { let size = @protobuf.size_of(k); @protobuf.size_of(size) + size }
     let value_size = 1U + { let size = @protobuf.size_of(v); @protobuf.size_of(size) + size }
-    writer |> @protobuf.async_write_uint32(key_size + value_size)
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_string(k)
+    writer |> @protobuf.write_uint32(key_size + value_size)
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_string(k)
 
-    writer |> @protobuf.async_write_varint(18UL);
-    writer |> @protobuf.async_write_string(v)
+    writer |> @protobuf.write_varint(18UL);
+    writer |> @protobuf.write_string(v)
 
   }
    match self.friend {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(42UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(42UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -217,4 +249,81 @@ pub impl @json.FromJson for Hello with from_json(json: Json, path: @json.JsonPat
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] Hello::async_read(reader : R) -> Hello raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Hello::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Hello::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Hello::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string()
+      (2, _) => msg.age = reader |> @protobuf.async_read_int32()
+      (3, _) => msg.hobbies.push(reader |> @protobuf.async_read_string())
+      (4, _) => { let {key, value} =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Hello_MetadataEntry::default()
+    } else {
+      Hello_MetadataEntry::async_read_with_limit(reader, limit=len)
+    }
+  }; msg.metadata[key] = value }
+      (5, _) => msg.friend =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Hello::default()
+    } else {
+      Hello::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Hello::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.name)
+  writer |> @protobuf.async_write_varint(16UL);
+  writer |> @protobuf.async_write_int32(self.age)
+  for item in self.hobbies {
+    writer |> @protobuf.async_write_varint(26UL)
+    writer |> @protobuf.async_write_string(item)
+
+  }
+  let keys = self.metadata.keys().collect()
+  for i in 0..<keys.length() {
+    let k = keys[i]
+    let v = self.metadata.get(k).unwrap()
+    writer |> @protobuf.async_write_varint(34UL)
+    let key_size = 1U + { let size = @protobuf.size_of(k); @protobuf.size_of(size) + size }
+    let value_size = 1U + { let size = @protobuf.size_of(v); @protobuf.size_of(size) + size }
+    writer |> @protobuf.async_write_uint32(key_size + value_size)
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_string(k)
+
+    writer |> @protobuf.async_write_varint(18UL);
+    writer |> @protobuf.async_write_string(v)
+
+  }
+   match self.friend {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(42UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
 }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
@@ -11,11 +11,11 @@ pub impl Default for Test with default() -> Test {
     test_hello : @lib.Hello::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Test::read(reader : R) -> Test raise {
+pub  fn[R: @protobuf.Reader] Test::read(reader : R) -> Test raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Test::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Test::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Test raise {
+pub  fn[R: @protobuf.Reader] Test::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Test raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -24,16 +24,16 @@ pub async fn[R: @protobuf.AsyncReader] Test::read_with_limit(reader : @protobuf.
   let msg = Test::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (1, _) => msg.test_hello =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       @lib.Hello::default()
     } else {
       @lib.Hello::read_with_limit(reader, limit=len)
     }
   }
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -43,9 +43,9 @@ pub async fn[R: @protobuf.AsyncReader] Test::read_with_limit(reader : @protobuf.
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Test::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.test_hello)); self.test_hello.write(writer)
+pub  fn[W: @protobuf.Writer] Test::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.test_hello)); self.test_hello.write(writer)
 }
 pub impl ToJson for Test with to_json(self) {
   let json: Map[String, Json] = {}
@@ -66,4 +66,40 @@ pub impl @json.FromJson for Test with from_json(json: Json, path: @json.JsonPath
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] Test::async_read(reader : R) -> Test raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Test::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Test::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Test raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Test::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.test_hello =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      @lib.Hello::default()
+    } else {
+      @lib.Hello::async_read_with_limit(reader, limit=len)
+    }
+  }
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Test::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.test_hello)); self.test_hello.async_write(writer)
 }

--- a/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
@@ -11,11 +11,11 @@ pub impl Default for Test with default() -> Test {
     created_at : @protobuf1.Timestamp::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Test::read(reader : R) -> Test raise {
+pub  fn[R: @protobuf.Reader] Test::read(reader : R) -> Test raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Test::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Test::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Test raise {
+pub  fn[R: @protobuf.Reader] Test::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Test raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -24,16 +24,16 @@ pub async fn[R: @protobuf.AsyncReader] Test::read_with_limit(reader : @protobuf.
   let msg = Test::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (1, _) => msg.created_at =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       @protobuf1.Timestamp::default()
     } else {
       @protobuf1.Timestamp::read_with_limit(reader, limit=len)
     }
   }
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -43,9 +43,9 @@ pub async fn[R: @protobuf.AsyncReader] Test::read_with_limit(reader : @protobuf.
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Test::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.created_at)); self.created_at.write(writer)
+pub  fn[W: @protobuf.Writer] Test::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.created_at)); self.created_at.write(writer)
 }
 pub impl ToJson for Test with to_json(self) {
   let json: Map[String, Json] = {}
@@ -66,4 +66,40 @@ pub impl @json.FromJson for Test with from_json(json: Json, path: @json.JsonPath
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] Test::async_read(reader : R) -> Test raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Test::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Test::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Test raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Test::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.created_at =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      @protobuf1.Timestamp::default()
+    } else {
+      @protobuf1.Timestamp::async_read_with_limit(reader, limit=len)
+    }
+  }
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Test::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.created_at)); self.created_at.async_write(writer)
 }

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -14,11 +14,11 @@ pub impl Default for Hello_MetadataEntry with default() -> Hello_MetadataEntry {
     value : String::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::read(reader : R) -> Hello_MetadataEntry raise {
+pub  fn[R: @protobuf.Reader] Hello_MetadataEntry::read(reader : R) -> Hello_MetadataEntry raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Hello_MetadataEntry::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello_MetadataEntry raise {
+pub  fn[R: @protobuf.Reader] Hello_MetadataEntry::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello_MetadataEntry raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -27,10 +27,10 @@ pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::read_with_limit(read
   let msg = Hello_MetadataEntry::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.key = reader |> @protobuf.async_read_string()
-      (2, _) => msg.value = reader |> @protobuf.async_read_string()
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.key = reader |> @protobuf.read_string()
+      (2, _) => msg.value = reader |> @protobuf.read_string()
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -40,11 +40,11 @@ pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::read_with_limit(read
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Hello_MetadataEntry::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.key)
-  writer |> @protobuf.async_write_varint(18UL);
-  writer |> @protobuf.async_write_string(self.value)
+pub  fn[W: @protobuf.Writer] Hello_MetadataEntry::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.key)
+  writer |> @protobuf.write_varint(18UL);
+  writer |> @protobuf.write_string(self.value)
 }
 pub impl ToJson for Hello_MetadataEntry with to_json(self) {
   let json: Map[String, Json] = {}
@@ -69,6 +69,38 @@ pub impl @json.FromJson for Hello_MetadataEntry with from_json(json: Json, path:
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::async_read(reader : R) -> Hello_MetadataEntry raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Hello_MetadataEntry::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Hello_MetadataEntry::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello_MetadataEntry raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Hello_MetadataEntry::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.key = reader |> @protobuf.async_read_string()
+      (2, _) => msg.value = reader |> @protobuf.async_read_string()
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Hello_MetadataEntry::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.key)
+  writer |> @protobuf.async_write_varint(18UL);
+  writer |> @protobuf.async_write_string(self.value)
 }
 pub(all) struct Hello {
   mut name : String
@@ -103,11 +135,11 @@ pub impl Default for Hello with default() -> Hello {
     friend : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Hello::read(reader : R) -> Hello raise {
+pub  fn[R: @protobuf.Reader] Hello::read(reader : R) -> Hello raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Hello::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Hello::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello raise {
+pub  fn[R: @protobuf.Reader] Hello::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -116,12 +148,12 @@ pub async fn[R: @protobuf.AsyncReader] Hello::read_with_limit(reader : @protobuf
   let msg = Hello::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string()
-      (2, _) => msg.age = reader |> @protobuf.async_read_int32()
-      (3, _) => msg.hobbies.push(reader |> @protobuf.async_read_string())
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string()
+      (2, _) => msg.age = reader |> @protobuf.read_int32()
+      (3, _) => msg.hobbies.push(reader |> @protobuf.read_string())
       (4, _) => { let {key, value} =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Hello_MetadataEntry::default()
     } else {
@@ -129,14 +161,14 @@ pub async fn[R: @protobuf.AsyncReader] Hello::read_with_limit(reader : @protobuf
     }
   }; msg.metadata[key] = value }
       (5, _) => msg.friend =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Hello::default()
     } else {
       Hello::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -146,35 +178,35 @@ pub async fn[R: @protobuf.AsyncReader] Hello::read_with_limit(reader : @protobuf
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Hello::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.name)
-  writer |> @protobuf.async_write_varint(16UL);
-  writer |> @protobuf.async_write_int32(self.age)
+pub  fn[W: @protobuf.Writer] Hello::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.name)
+  writer |> @protobuf.write_varint(16UL);
+  writer |> @protobuf.write_int32(self.age)
   for item in self.hobbies {
-    writer |> @protobuf.async_write_varint(26UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(26UL)
+    writer |> @protobuf.write_string(item)
 
   }
   let keys = self.metadata.keys().collect()
   for i in 0..<keys.length() {
     let k = keys[i]
     let v = self.metadata.get(k).unwrap()
-    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.write_varint(34UL)
     let key_size = 1U + { let size = @protobuf.size_of(k); @protobuf.size_of(size) + size }
     let value_size = 1U + { let size = @protobuf.size_of(v); @protobuf.size_of(size) + size }
-    writer |> @protobuf.async_write_uint32(key_size + value_size)
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_string(k)
+    writer |> @protobuf.write_uint32(key_size + value_size)
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_string(k)
 
-    writer |> @protobuf.async_write_varint(18UL);
-    writer |> @protobuf.async_write_string(v)
+    writer |> @protobuf.write_varint(18UL);
+    writer |> @protobuf.write_string(v)
 
   }
    match self.friend {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(42UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(42UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -217,4 +249,81 @@ pub impl @json.FromJson for Hello with from_json(json: Json, path: @json.JsonPat
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] Hello::async_read(reader : R) -> Hello raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Hello::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Hello::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Hello raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Hello::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string()
+      (2, _) => msg.age = reader |> @protobuf.async_read_int32()
+      (3, _) => msg.hobbies.push(reader |> @protobuf.async_read_string())
+      (4, _) => { let {key, value} =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Hello_MetadataEntry::default()
+    } else {
+      Hello_MetadataEntry::async_read_with_limit(reader, limit=len)
+    }
+  }; msg.metadata[key] = value }
+      (5, _) => msg.friend =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Hello::default()
+    } else {
+      Hello::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Hello::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.name)
+  writer |> @protobuf.async_write_varint(16UL);
+  writer |> @protobuf.async_write_int32(self.age)
+  for item in self.hobbies {
+    writer |> @protobuf.async_write_varint(26UL)
+    writer |> @protobuf.async_write_string(item)
+
+  }
+  let keys = self.metadata.keys().collect()
+  for i in 0..<keys.length() {
+    let k = keys[i]
+    let v = self.metadata.get(k).unwrap()
+    writer |> @protobuf.async_write_varint(34UL)
+    let key_size = 1U + { let size = @protobuf.size_of(k); @protobuf.size_of(size) + size }
+    let value_size = 1U + { let size = @protobuf.size_of(v); @protobuf.size_of(size) + size }
+    writer |> @protobuf.async_write_uint32(key_size + value_size)
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_string(k)
+
+    writer |> @protobuf.async_write_varint(18UL);
+    writer |> @protobuf.async_write_string(v)
+
+  }
+   match self.friend {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(42UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
 }

--- a/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
@@ -11,11 +11,11 @@ pub impl Default for Test with default() -> Test {
     created_at : @test2.Hello::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Test::read(reader : R) -> Test raise {
+pub  fn[R: @protobuf.Reader] Test::read(reader : R) -> Test raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Test::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Test::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Test raise {
+pub  fn[R: @protobuf.Reader] Test::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Test raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -24,16 +24,16 @@ pub async fn[R: @protobuf.AsyncReader] Test::read_with_limit(reader : @protobuf.
   let msg = Test::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (1, _) => msg.created_at =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       @test2.Hello::default()
     } else {
       @test2.Hello::read_with_limit(reader, limit=len)
     }
   }
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -43,9 +43,9 @@ pub async fn[R: @protobuf.AsyncReader] Test::read_with_limit(reader : @protobuf.
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Test::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.created_at)); self.created_at.write(writer)
+pub  fn[W: @protobuf.Writer] Test::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_uint32(@protobuf.size_of(self.created_at)); self.created_at.write(writer)
 }
 pub impl ToJson for Test with to_json(self) {
   let json: Map[String, Json] = {}
@@ -66,4 +66,40 @@ pub impl @json.FromJson for Test with from_json(json: Json, path: @json.JsonPath
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] Test::async_read(reader : R) -> Test raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Test::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Test::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Test raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Test::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.created_at =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      @test2.Hello::default()
+    } else {
+      @test2.Hello::async_read_with_limit(reader, limit=len)
+    }
+  }
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Test::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_uint32(@protobuf.size_of(self.created_at)); self.created_at.async_write(writer)
 }

--- a/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
+++ b/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
@@ -32,11 +32,11 @@ pub impl Default for Version with default() -> Version {
     suffix : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Version::read(reader : R) -> Version raise {
+pub  fn[R: @protobuf.Reader] Version::read(reader : R) -> Version raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Version::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Version::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Version raise {
+pub  fn[R: @protobuf.Reader] Version::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Version raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -45,12 +45,12 @@ pub async fn[R: @protobuf.AsyncReader] Version::read_with_limit(reader : @protob
   let msg = Version::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.major = reader |> @protobuf.async_read_int32() |> Some
-      (2, _) => msg.minor = reader |> @protobuf.async_read_int32() |> Some
-      (3, _) => msg.patch = reader |> @protobuf.async_read_int32() |> Some
-      (4, _) => msg.suffix = reader |> @protobuf.async_read_string() |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.major = reader |> @protobuf.read_int32() |> Some
+      (2, _) => msg.minor = reader |> @protobuf.read_int32() |> Some
+      (3, _) => msg.patch = reader |> @protobuf.read_int32() |> Some
+      (4, _) => msg.suffix = reader |> @protobuf.read_string() |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -60,35 +60,35 @@ pub async fn[R: @protobuf.AsyncReader] Version::read_with_limit(reader : @protob
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Version::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] Version::write(self:Self, writer : W) -> Unit raise {
   match self.major {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(8UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.minor {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.patch {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.suffix {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(34UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
@@ -130,6 +130,68 @@ pub impl @json.FromJson for Version with from_json(json: Json, path: @json.JsonP
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] Version::async_read(reader : R) -> Version raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Version::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Version::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Version raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Version::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.major = reader |> @protobuf.async_read_int32() |> Some
+      (2, _) => msg.minor = reader |> @protobuf.async_read_int32() |> Some
+      (3, _) => msg.patch = reader |> @protobuf.async_read_int32() |> Some
+      (4, _) => msg.suffix = reader |> @protobuf.async_read_string() |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Version::async_write(self:Self, writer : W) -> Unit raise {
+  match self.major {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.minor {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.patch {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.suffix {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct CodeGeneratorRequest {
   mut file_to_generate : Array[String]
   mut parameter : String?
@@ -161,11 +223,11 @@ pub impl Default for CodeGeneratorRequest with default() -> CodeGeneratorRequest
     compiler_version : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] CodeGeneratorRequest::read(reader : R) -> CodeGeneratorRequest raise {
+pub  fn[R: @protobuf.Reader] CodeGeneratorRequest::read(reader : R) -> CodeGeneratorRequest raise {
   let reader = @protobuf.LimitedReader::new(reader)
   CodeGeneratorRequest::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> CodeGeneratorRequest raise {
+pub  fn[R: @protobuf.Reader] CodeGeneratorRequest::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> CodeGeneratorRequest raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -174,11 +236,11 @@ pub async fn[R: @protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(rea
   let msg = CodeGeneratorRequest::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.file_to_generate.push(reader |> @protobuf.async_read_string())
-      (2, _) => msg.parameter = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.file_to_generate.push(reader |> @protobuf.read_string())
+      (2, _) => msg.parameter = reader |> @protobuf.read_string() |> Some
       (15, _) => msg.proto_file.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       @protobuf1.FileDescriptorProto::default()
     } else {
@@ -186,7 +248,7 @@ pub async fn[R: @protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(rea
     }
   })
       (17, _) => msg.source_file_descriptors.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       @protobuf1.FileDescriptorProto::default()
     } else {
@@ -194,14 +256,14 @@ pub async fn[R: @protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(rea
     }
   })
       (3, _) => msg.compiler_version =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Version::default()
     } else {
       Version::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -211,34 +273,34 @@ pub async fn[R: @protobuf.AsyncReader] CodeGeneratorRequest::read_with_limit(rea
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] CodeGeneratorRequest::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] CodeGeneratorRequest::write(self:Self, writer : W) -> Unit raise {
   for item in self.file_to_generate {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_string(item)
 
   }
   match self.parameter {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   for item in self.proto_file {
-    writer |> @protobuf.async_write_varint(122UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(122UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.source_file_descriptors {
-    writer |> @protobuf.async_write_varint(138UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(138UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.compiler_version {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -284,6 +346,89 @@ pub impl @json.FromJson for CodeGeneratorRequest with from_json(json: Json, path
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] CodeGeneratorRequest::async_read(reader : R) -> CodeGeneratorRequest raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  CodeGeneratorRequest::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] CodeGeneratorRequest::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> CodeGeneratorRequest raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = CodeGeneratorRequest::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.file_to_generate.push(reader |> @protobuf.async_read_string())
+      (2, _) => msg.parameter = reader |> @protobuf.async_read_string() |> Some
+      (15, _) => msg.proto_file.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      @protobuf1.FileDescriptorProto::default()
+    } else {
+      @protobuf1.FileDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (17, _) => msg.source_file_descriptors.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      @protobuf1.FileDescriptorProto::default()
+    } else {
+      @protobuf1.FileDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (3, _) => msg.compiler_version =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Version::default()
+    } else {
+      Version::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] CodeGeneratorRequest::async_write(self:Self, writer : W) -> Unit raise {
+  for item in self.file_to_generate {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_string(item)
+
+  }
+  match self.parameter {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  for item in self.proto_file {
+    writer |> @protobuf.async_write_varint(122UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.source_file_descriptors {
+    writer |> @protobuf.async_write_varint(138UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.compiler_version {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
 }
 pub(all) enum CodeGeneratorResponse_Feature {
   FEATURE_NONE
@@ -363,11 +508,11 @@ pub impl Default for CodeGeneratorResponse_File with default() -> CodeGeneratorR
     generated_code_info : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse_File::read(reader : R) -> CodeGeneratorResponse_File raise {
+pub  fn[R: @protobuf.Reader] CodeGeneratorResponse_File::read(reader : R) -> CodeGeneratorResponse_File raise {
   let reader = @protobuf.LimitedReader::new(reader)
   CodeGeneratorResponse_File::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse_File::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> CodeGeneratorResponse_File raise {
+pub  fn[R: @protobuf.Reader] CodeGeneratorResponse_File::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> CodeGeneratorResponse_File raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -376,19 +521,19 @@ pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse_File::read_with_lim
   let msg = CodeGeneratorResponse_File::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
-      (2, _) => msg.insertion_point = reader |> @protobuf.async_read_string() |> Some
-      (15, _) => msg.content = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
+      (2, _) => msg.insertion_point = reader |> @protobuf.read_string() |> Some
+      (15, _) => msg.content = reader |> @protobuf.read_string() |> Some
       (16, _) => msg.generated_code_info =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       @protobuf1.GeneratedCodeInfo::default()
     } else {
       @protobuf1.GeneratedCodeInfo::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -398,35 +543,35 @@ pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse_File::read_with_lim
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] CodeGeneratorResponse_File::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] CodeGeneratorResponse_File::write(self:Self, writer : W) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.insertion_point {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.content {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(122UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(122UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.generated_code_info {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(130UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(130UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -468,6 +613,75 @@ pub impl @json.FromJson for CodeGeneratorResponse_File with from_json(json: Json
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse_File::async_read(reader : R) -> CodeGeneratorResponse_File raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  CodeGeneratorResponse_File::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse_File::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> CodeGeneratorResponse_File raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = CodeGeneratorResponse_File::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      (2, _) => msg.insertion_point = reader |> @protobuf.async_read_string() |> Some
+      (15, _) => msg.content = reader |> @protobuf.async_read_string() |> Some
+      (16, _) => msg.generated_code_info =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      @protobuf1.GeneratedCodeInfo::default()
+    } else {
+      @protobuf1.GeneratedCodeInfo::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] CodeGeneratorResponse_File::async_write(self:Self, writer : W) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.insertion_point {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.content {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(122UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.generated_code_info {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(130UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct CodeGeneratorResponse {
   mut error : String?
   mut supported_features : UInt64?
@@ -505,11 +719,11 @@ pub impl Default for CodeGeneratorResponse with default() -> CodeGeneratorRespon
     file : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse::read(reader : R) -> CodeGeneratorResponse raise {
+pub  fn[R: @protobuf.Reader] CodeGeneratorResponse::read(reader : R) -> CodeGeneratorResponse raise {
   let reader = @protobuf.LimitedReader::new(reader)
   CodeGeneratorResponse::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> CodeGeneratorResponse raise {
+pub  fn[R: @protobuf.Reader] CodeGeneratorResponse::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> CodeGeneratorResponse raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -518,20 +732,20 @@ pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse::read_with_limit(re
   let msg = CodeGeneratorResponse::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.error = reader |> @protobuf.async_read_string() |> Some
-      (2, _) => msg.supported_features = reader |> @protobuf.async_read_uint64() |> Some
-      (3, _) => msg.minimum_edition = reader |> @protobuf.async_read_int32() |> Some
-      (4, _) => msg.maximum_edition = reader |> @protobuf.async_read_int32() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.error = reader |> @protobuf.read_string() |> Some
+      (2, _) => msg.supported_features = reader |> @protobuf.read_uint64() |> Some
+      (3, _) => msg.minimum_edition = reader |> @protobuf.read_int32() |> Some
+      (4, _) => msg.maximum_edition = reader |> @protobuf.read_int32() |> Some
       (15, _) => msg.file.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       CodeGeneratorResponse_File::default()
     } else {
       CodeGeneratorResponse_File::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -541,42 +755,42 @@ pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse::read_with_limit(re
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] CodeGeneratorResponse::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] CodeGeneratorResponse::write(self:Self, writer : W) -> Unit raise {
   match self.error {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.supported_features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL);
-      writer |> @protobuf.async_write_uint64(v)
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_uint64(v)
 
     }
     None => ()
   }
   match self.minimum_edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.maximum_edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(32UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   for item in self.file {
-    writer |> @protobuf.async_write_varint(122UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(122UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -620,4 +834,79 @@ pub impl @json.FromJson for CodeGeneratorResponse with from_json(json: Json, pat
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse::async_read(reader : R) -> CodeGeneratorResponse raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  CodeGeneratorResponse::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] CodeGeneratorResponse::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> CodeGeneratorResponse raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = CodeGeneratorResponse::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.error = reader |> @protobuf.async_read_string() |> Some
+      (2, _) => msg.supported_features = reader |> @protobuf.async_read_uint64() |> Some
+      (3, _) => msg.minimum_edition = reader |> @protobuf.async_read_int32() |> Some
+      (4, _) => msg.maximum_edition = reader |> @protobuf.async_read_int32() |> Some
+      (15, _) => msg.file.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      CodeGeneratorResponse_File::default()
+    } else {
+      CodeGeneratorResponse_File::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] CodeGeneratorResponse::async_write(self:Self, writer : W) -> Unit raise {
+  match self.error {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.supported_features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL);
+      writer |> @protobuf.async_write_uint64(v)
+
+    }
+    None => ()
+  }
+  match self.minimum_edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.maximum_edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  for item in self.file {
+    writer |> @protobuf.async_write_varint(122UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
 }

--- a/test/snapshots/test_case5/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case5/__snapshot/src/top.mbt
@@ -7,18 +7,27 @@ pub impl Default for EmptyMessage with default() -> EmptyMessage {
   EmptyMessage::{
   }
 }
-pub async fn[R] EmptyMessage::read(reader : R) -> EmptyMessage noraise {
+pub  fn[R] EmptyMessage::read(reader : R) -> EmptyMessage noraise {
   let reader = @protobuf.LimitedReader::new(reader)
   EmptyMessage::read_with_limit(reader)
 }
-pub async fn[R] EmptyMessage::read_with_limit(_ : @protobuf.LimitedReader[R], _limit ?: Int) -> EmptyMessage noraise {
+pub  fn[R] EmptyMessage::read_with_limit(_ : @protobuf.LimitedReader[R], _limit ?: Int) -> EmptyMessage noraise {
   EmptyMessage::default()
 }
-pub async fn[W] EmptyMessage::write(_: Self, _ : W) -> Unit noraise {
+pub  fn[W: @protobuf.Writer] EmptyMessage::write(_: Self, _ : W) -> Unit noraise {
 }
 pub impl ToJson for EmptyMessage with to_json(_) {
   {}
 }
 pub impl @json.FromJson for EmptyMessage with from_json(json: Json, path: @json.JsonPath) -> EmptyMessage noraise {
   EmptyMessage::default()
+}
+pub async fn[R] EmptyMessage::async_read(reader : R) -> EmptyMessage noraise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EmptyMessage::async_read_with_limit(reader)
+}
+pub async fn[R] EmptyMessage::async_read_with_limit(_ : @protobuf.LimitedReader[R], _limit ?: Int) -> EmptyMessage noraise {
+  EmptyMessage::default()
+}
+pub async fn[W: @protobuf.AsyncWriter] EmptyMessage::async_write(_: Self, _ : W) -> Unit noraise {
 }

--- a/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
@@ -14,11 +14,11 @@ pub impl Default for Timestamp with default() -> Timestamp {
     nanos : Int::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Timestamp::read(reader : R) -> Timestamp raise {
+pub  fn[R: @protobuf.Reader] Timestamp::read(reader : R) -> Timestamp raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Timestamp::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Timestamp::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Timestamp raise {
+pub  fn[R: @protobuf.Reader] Timestamp::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Timestamp raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -27,10 +27,10 @@ pub async fn[R: @protobuf.AsyncReader] Timestamp::read_with_limit(reader : @prot
   let msg = Timestamp::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.seconds = reader |> @protobuf.async_read_int64()
-      (2, _) => msg.nanos = reader |> @protobuf.async_read_int32()
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.seconds = reader |> @protobuf.read_int64()
+      (2, _) => msg.nanos = reader |> @protobuf.read_int32()
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -40,11 +40,11 @@ pub async fn[R: @protobuf.AsyncReader] Timestamp::read_with_limit(reader : @prot
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Timestamp::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(8UL);
-  writer |> @protobuf.async_write_int64(self.seconds)
-  writer |> @protobuf.async_write_varint(16UL);
-  writer |> @protobuf.async_write_int32(self.nanos)
+pub  fn[W: @protobuf.Writer] Timestamp::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(8UL);
+  writer |> @protobuf.write_int64(self.seconds)
+  writer |> @protobuf.write_varint(16UL);
+  writer |> @protobuf.write_int32(self.nanos)
 }
 pub impl ToJson for Timestamp with to_json(self) {
   let json: Map[String, Json] = {}
@@ -69,4 +69,36 @@ pub impl @json.FromJson for Timestamp with from_json(json: Json, path: @json.Jso
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] Timestamp::async_read(reader : R) -> Timestamp raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Timestamp::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Timestamp::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Timestamp raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Timestamp::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.seconds = reader |> @protobuf.async_read_int64()
+      (2, _) => msg.nanos = reader |> @protobuf.async_read_int32()
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Timestamp::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(8UL);
+  writer |> @protobuf.async_write_int64(self.seconds)
+  writer |> @protobuf.async_write_varint(16UL);
+  writer |> @protobuf.async_write_int32(self.nanos)
 }

--- a/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
+++ b/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
@@ -32,11 +32,11 @@ pub impl Default for TreeNode with default() -> TreeNode {
     sibling : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] TreeNode::read(reader : R) -> TreeNode raise {
+pub  fn[R: @protobuf.Reader] TreeNode::read(reader : R) -> TreeNode raise {
   let reader = @protobuf.LimitedReader::new(reader)
   TreeNode::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] TreeNode::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> TreeNode raise {
+pub  fn[R: @protobuf.Reader] TreeNode::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> TreeNode raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -45,11 +45,11 @@ pub async fn[R: @protobuf.AsyncReader] TreeNode::read_with_limit(reader : @proto
   let msg = TreeNode::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string()
-      (2, _) => msg.value = reader |> @protobuf.async_read_int32() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string()
+      (2, _) => msg.value = reader |> @protobuf.read_int32() |> Some
       (3, _) => msg.parent =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       TreeNode::default()
     } else {
@@ -57,7 +57,7 @@ pub async fn[R: @protobuf.AsyncReader] TreeNode::read_with_limit(reader : @proto
     }
   } |> Some
       (4, _) => msg.children.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       TreeNode::default()
     } else {
@@ -65,14 +65,14 @@ pub async fn[R: @protobuf.AsyncReader] TreeNode::read_with_limit(reader : @proto
     }
   })
       (5, _) => msg.sibling =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       TreeNode::default()
     } else {
       TreeNode::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -82,34 +82,34 @@ pub async fn[R: @protobuf.AsyncReader] TreeNode::read_with_limit(reader : @proto
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] TreeNode::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.name)
+pub  fn[W: @protobuf.Writer] TreeNode::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.name)
   match self.value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.parent {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.children {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.sibling {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(42UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(42UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -155,6 +155,89 @@ pub impl @json.FromJson for TreeNode with from_json(json: Json, path: @json.Json
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] TreeNode::async_read(reader : R) -> TreeNode raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  TreeNode::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] TreeNode::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> TreeNode raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = TreeNode::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string()
+      (2, _) => msg.value = reader |> @protobuf.async_read_int32() |> Some
+      (3, _) => msg.parent =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      TreeNode::default()
+    } else {
+      TreeNode::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (4, _) => msg.children.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      TreeNode::default()
+    } else {
+      TreeNode::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (5, _) => msg.sibling =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      TreeNode::default()
+    } else {
+      TreeNode::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] TreeNode::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.name)
+  match self.value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.parent {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.children {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.sibling {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(42UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct ListNode {
   mut data : String
   mut next : ListNode?
@@ -180,11 +263,11 @@ pub impl Default for ListNode with default() -> ListNode {
     prev : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] ListNode::read(reader : R) -> ListNode raise {
+pub  fn[R: @protobuf.Reader] ListNode::read(reader : R) -> ListNode raise {
   let reader = @protobuf.LimitedReader::new(reader)
   ListNode::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] ListNode::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ListNode raise {
+pub  fn[R: @protobuf.Reader] ListNode::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ListNode raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -193,10 +276,10 @@ pub async fn[R: @protobuf.AsyncReader] ListNode::read_with_limit(reader : @proto
   let msg = ListNode::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.data = reader |> @protobuf.async_read_string()
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.data = reader |> @protobuf.read_string()
       (2, _) => msg.next =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       ListNode::default()
     } else {
@@ -204,14 +287,14 @@ pub async fn[R: @protobuf.AsyncReader] ListNode::read_with_limit(reader : @proto
     }
   } |> Some
       (3, _) => msg.prev =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       ListNode::default()
     } else {
       ListNode::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -221,21 +304,21 @@ pub async fn[R: @protobuf.AsyncReader] ListNode::read_with_limit(reader : @proto
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] ListNode::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.data)
+pub  fn[W: @protobuf.Writer] ListNode::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.data)
   match self.next {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.prev {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -271,6 +354,67 @@ pub impl @json.FromJson for ListNode with from_json(json: Json, path: @json.Json
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] ListNode::async_read(reader : R) -> ListNode raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  ListNode::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] ListNode::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ListNode raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = ListNode::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.data = reader |> @protobuf.async_read_string()
+      (2, _) => msg.next =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      ListNode::default()
+    } else {
+      ListNode::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (3, _) => msg.prev =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      ListNode::default()
+    } else {
+      ListNode::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] ListNode::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.data)
+  match self.next {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.prev {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct GraphNode {
   mut id : String
   mut label : String?
@@ -299,11 +443,11 @@ pub impl Default for GraphNode with default() -> GraphNode {
     visited : Some(false),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] GraphNode::read(reader : R) -> GraphNode raise {
+pub  fn[R: @protobuf.Reader] GraphNode::read(reader : R) -> GraphNode raise {
   let reader = @protobuf.LimitedReader::new(reader)
   GraphNode::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] GraphNode::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> GraphNode raise {
+pub  fn[R: @protobuf.Reader] GraphNode::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> GraphNode raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -312,19 +456,19 @@ pub async fn[R: @protobuf.AsyncReader] GraphNode::read_with_limit(reader : @prot
   let msg = GraphNode::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.id = reader |> @protobuf.async_read_string()
-      (2, _) => msg.label = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.id = reader |> @protobuf.read_string()
+      (2, _) => msg.label = reader |> @protobuf.read_string() |> Some
       (3, _) => msg.neighbors.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       GraphNode::default()
     } else {
       GraphNode::read_with_limit(reader, limit=len)
     }
   })
-      (4, _) => msg.visited = reader |> @protobuf.async_read_bool() |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      (4, _) => msg.visited = reader |> @protobuf.read_bool() |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -334,26 +478,26 @@ pub async fn[R: @protobuf.AsyncReader] GraphNode::read_with_limit(reader : @prot
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] GraphNode::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.id)
+pub  fn[W: @protobuf.Writer] GraphNode::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.id)
   match self.label {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   for item in self.neighbors {
-    writer |> @protobuf.async_write_varint(26UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(26UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.visited {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(32UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
@@ -394,6 +538,66 @@ pub impl @json.FromJson for GraphNode with from_json(json: Json, path: @json.Jso
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] GraphNode::async_read(reader : R) -> GraphNode raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  GraphNode::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] GraphNode::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> GraphNode raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = GraphNode::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.id = reader |> @protobuf.async_read_string()
+      (2, _) => msg.label = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.neighbors.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      GraphNode::default()
+    } else {
+      GraphNode::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (4, _) => msg.visited = reader |> @protobuf.async_read_bool() |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] GraphNode::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.id)
+  match self.label {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  for item in self.neighbors {
+    writer |> @protobuf.async_write_varint(26UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.visited {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct NestedSelfRef_Inner {
   mut inner_name : String?
   mut outer_ref : NestedSelfRef?
@@ -422,11 +626,11 @@ pub impl Default for NestedSelfRef_Inner with default() -> NestedSelfRef_Inner {
     inner_ref : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] NestedSelfRef_Inner::read(reader : R) -> NestedSelfRef_Inner raise {
+pub  fn[R: @protobuf.Reader] NestedSelfRef_Inner::read(reader : R) -> NestedSelfRef_Inner raise {
   let reader = @protobuf.LimitedReader::new(reader)
   NestedSelfRef_Inner::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] NestedSelfRef_Inner::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> NestedSelfRef_Inner raise {
+pub  fn[R: @protobuf.Reader] NestedSelfRef_Inner::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> NestedSelfRef_Inner raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -435,10 +639,10 @@ pub async fn[R: @protobuf.AsyncReader] NestedSelfRef_Inner::read_with_limit(read
   let msg = NestedSelfRef_Inner::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.inner_name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.inner_name = reader |> @protobuf.read_string() |> Some
       (2, _) => msg.outer_ref =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       NestedSelfRef::default()
     } else {
@@ -446,14 +650,14 @@ pub async fn[R: @protobuf.AsyncReader] NestedSelfRef_Inner::read_with_limit(read
     }
   } |> Some
       (3, _) => msg.inner_ref =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       NestedSelfRef_Inner::default()
     } else {
       NestedSelfRef_Inner::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -463,27 +667,27 @@ pub async fn[R: @protobuf.AsyncReader] NestedSelfRef_Inner::read_with_limit(read
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] NestedSelfRef_Inner::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] NestedSelfRef_Inner::write(self:Self, writer : W) -> Unit raise {
   match self.inner_name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.outer_ref {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.inner_ref {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -520,6 +724,73 @@ pub impl @json.FromJson for NestedSelfRef_Inner with from_json(json: Json, path:
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] NestedSelfRef_Inner::async_read(reader : R) -> NestedSelfRef_Inner raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  NestedSelfRef_Inner::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] NestedSelfRef_Inner::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> NestedSelfRef_Inner raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = NestedSelfRef_Inner::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.inner_name = reader |> @protobuf.async_read_string() |> Some
+      (2, _) => msg.outer_ref =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      NestedSelfRef::default()
+    } else {
+      NestedSelfRef::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (3, _) => msg.inner_ref =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      NestedSelfRef_Inner::default()
+    } else {
+      NestedSelfRef_Inner::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] NestedSelfRef_Inner::async_write(self:Self, writer : W) -> Unit raise {
+  match self.inner_name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.outer_ref {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.inner_ref {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct NestedSelfRef {
   mut name : String
   mut inner : NestedSelfRef_Inner?
@@ -545,11 +816,11 @@ pub impl Default for NestedSelfRef with default() -> NestedSelfRef {
     self_ref : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] NestedSelfRef::read(reader : R) -> NestedSelfRef raise {
+pub  fn[R: @protobuf.Reader] NestedSelfRef::read(reader : R) -> NestedSelfRef raise {
   let reader = @protobuf.LimitedReader::new(reader)
   NestedSelfRef::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] NestedSelfRef::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> NestedSelfRef raise {
+pub  fn[R: @protobuf.Reader] NestedSelfRef::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> NestedSelfRef raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -558,10 +829,10 @@ pub async fn[R: @protobuf.AsyncReader] NestedSelfRef::read_with_limit(reader : @
   let msg = NestedSelfRef::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string()
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string()
       (2, _) => msg.inner =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       NestedSelfRef_Inner::default()
     } else {
@@ -569,14 +840,14 @@ pub async fn[R: @protobuf.AsyncReader] NestedSelfRef::read_with_limit(reader : @
     }
   } |> Some
       (3, _) => msg.self_ref =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       NestedSelfRef::default()
     } else {
       NestedSelfRef::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -586,21 +857,21 @@ pub async fn[R: @protobuf.AsyncReader] NestedSelfRef::read_with_limit(reader : @
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] NestedSelfRef::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.name)
+pub  fn[W: @protobuf.Writer] NestedSelfRef::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.name)
   match self.inner {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.self_ref {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -636,6 +907,67 @@ pub impl @json.FromJson for NestedSelfRef with from_json(json: Json, path: @json
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] NestedSelfRef::async_read(reader : R) -> NestedSelfRef raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  NestedSelfRef::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] NestedSelfRef::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> NestedSelfRef raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = NestedSelfRef::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string()
+      (2, _) => msg.inner =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      NestedSelfRef_Inner::default()
+    } else {
+      NestedSelfRef_Inner::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (3, _) => msg.self_ref =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      NestedSelfRef::default()
+    } else {
+      NestedSelfRef::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] NestedSelfRef::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.name)
+  match self.inner {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.self_ref {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct Organization {
   mut name : String
   mut description : String?
@@ -667,11 +999,11 @@ pub impl Default for Organization with default() -> Organization {
     employees : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Organization::read(reader : R) -> Organization raise {
+pub  fn[R: @protobuf.Reader] Organization::read(reader : R) -> Organization raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Organization::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Organization::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Organization raise {
+pub  fn[R: @protobuf.Reader] Organization::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Organization raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -680,11 +1012,11 @@ pub async fn[R: @protobuf.AsyncReader] Organization::read_with_limit(reader : @p
   let msg = Organization::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string()
-      (2, _) => msg.description = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string()
+      (2, _) => msg.description = reader |> @protobuf.read_string() |> Some
       (3, _) => msg.parent_org =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Organization::default()
     } else {
@@ -692,7 +1024,7 @@ pub async fn[R: @protobuf.AsyncReader] Organization::read_with_limit(reader : @p
     }
   } |> Some
       (4, _) => msg.sub_orgs.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Organization::default()
     } else {
@@ -700,14 +1032,14 @@ pub async fn[R: @protobuf.AsyncReader] Organization::read_with_limit(reader : @p
     }
   })
       (5, _) => msg.employees.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Employee::default()
     } else {
       Employee::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -717,33 +1049,33 @@ pub async fn[R: @protobuf.AsyncReader] Organization::read_with_limit(reader : @p
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Organization::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.name)
+pub  fn[W: @protobuf.Writer] Organization::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.name)
   match self.description {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.parent_org {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.sub_orgs {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.employees {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -787,6 +1119,86 @@ pub impl @json.FromJson for Organization with from_json(json: Json, path: @json.
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] Organization::async_read(reader : R) -> Organization raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Organization::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Organization::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Organization raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Organization::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string()
+      (2, _) => msg.description = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.parent_org =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Organization::default()
+    } else {
+      Organization::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (4, _) => msg.sub_orgs.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Organization::default()
+    } else {
+      Organization::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (5, _) => msg.employees.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Employee::default()
+    } else {
+      Employee::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Organization::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.name)
+  match self.description {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.parent_org {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.sub_orgs {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.employees {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct Employee {
   mut name : String
   mut id : String
@@ -818,11 +1230,11 @@ pub impl Default for Employee with default() -> Employee {
     subordinates : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Employee::read(reader : R) -> Employee raise {
+pub  fn[R: @protobuf.Reader] Employee::read(reader : R) -> Employee raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Employee::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Employee::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Employee raise {
+pub  fn[R: @protobuf.Reader] Employee::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Employee raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -831,11 +1243,11 @@ pub async fn[R: @protobuf.AsyncReader] Employee::read_with_limit(reader : @proto
   let msg = Employee::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string()
-      (2, _) => msg.id = reader |> @protobuf.async_read_string()
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string()
+      (2, _) => msg.id = reader |> @protobuf.read_string()
       (3, _) => msg.organization =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Organization::default()
     } else {
@@ -843,7 +1255,7 @@ pub async fn[R: @protobuf.AsyncReader] Employee::read_with_limit(reader : @proto
     }
   } |> Some
       (4, _) => msg.manager =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Employee::default()
     } else {
@@ -851,14 +1263,14 @@ pub async fn[R: @protobuf.AsyncReader] Employee::read_with_limit(reader : @proto
     }
   } |> Some
       (5, _) => msg.subordinates.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Employee::default()
     } else {
       Employee::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -868,30 +1280,30 @@ pub async fn[R: @protobuf.AsyncReader] Employee::read_with_limit(reader : @proto
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Employee::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.name)
-  writer |> @protobuf.async_write_varint(18UL);
-  writer |> @protobuf.async_write_string(self.id)
+pub  fn[W: @protobuf.Writer] Employee::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.name)
+  writer |> @protobuf.write_varint(18UL);
+  writer |> @protobuf.write_string(self.id)
   match self.organization {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.manager {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(34UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.subordinates {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -933,4 +1345,81 @@ pub impl @json.FromJson for Employee with from_json(json: Json, path: @json.Json
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] Employee::async_read(reader : R) -> Employee raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Employee::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Employee::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Employee raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Employee::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string()
+      (2, _) => msg.id = reader |> @protobuf.async_read_string()
+      (3, _) => msg.organization =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Organization::default()
+    } else {
+      Organization::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (4, _) => msg.manager =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Employee::default()
+    } else {
+      Employee::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (5, _) => msg.subordinates.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Employee::default()
+    } else {
+      Employee::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Employee::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.name)
+  writer |> @protobuf.async_write_varint(18UL);
+  writer |> @protobuf.async_write_string(self.id)
+  match self.organization {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.manager {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.subordinates {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
 }

--- a/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
+++ b/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
@@ -26,11 +26,11 @@ pub impl Default for User with default() -> User {
     friends : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] User::read(reader : R) -> User raise {
+pub  fn[R: @protobuf.Reader] User::read(reader : R) -> User raise {
   let reader = @protobuf.LimitedReader::new(reader)
   User::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] User::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> User raise {
+pub  fn[R: @protobuf.Reader] User::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> User raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -39,12 +39,12 @@ pub async fn[R: @protobuf.AsyncReader] User::read_with_limit(reader : @protobuf.
   let msg = User::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.user_id = reader |> @protobuf.async_read_string()
-      (2, _) => msg.name = reader |> @protobuf.async_read_string()
-      (3, _) => msg.email = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.user_id = reader |> @protobuf.read_string()
+      (2, _) => msg.name = reader |> @protobuf.read_string()
+      (3, _) => msg.email = reader |> @protobuf.read_string() |> Some
       (4, _) => msg.orders.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Order::default()
     } else {
@@ -52,14 +52,14 @@ pub async fn[R: @protobuf.AsyncReader] User::read_with_limit(reader : @protobuf.
     }
   })
       (5, _) => msg.friends.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       User::default()
     } else {
       User::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -69,27 +69,27 @@ pub async fn[R: @protobuf.AsyncReader] User::read_with_limit(reader : @protobuf.
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] User::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.user_id)
-  writer |> @protobuf.async_write_varint(18UL);
-  writer |> @protobuf.async_write_string(self.name)
+pub  fn[W: @protobuf.Writer] User::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.user_id)
+  writer |> @protobuf.write_varint(18UL);
+  writer |> @protobuf.write_string(self.name)
   match self.email {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   for item in self.orders {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.friends {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -132,6 +132,73 @@ pub impl @json.FromJson for User with from_json(json: Json, path: @json.JsonPath
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] User::async_read(reader : R) -> User raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  User::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] User::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> User raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = User::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.user_id = reader |> @protobuf.async_read_string()
+      (2, _) => msg.name = reader |> @protobuf.async_read_string()
+      (3, _) => msg.email = reader |> @protobuf.async_read_string() |> Some
+      (4, _) => msg.orders.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Order::default()
+    } else {
+      Order::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (5, _) => msg.friends.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      User::default()
+    } else {
+      User::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] User::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.user_id)
+  writer |> @protobuf.async_write_varint(18UL);
+  writer |> @protobuf.async_write_string(self.name)
+  match self.email {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  for item in self.orders {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.friends {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct Order {
   mut order_id : String
   mut product_name : String
@@ -163,11 +230,11 @@ pub impl Default for Order with default() -> Order {
     related_orders : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Order::read(reader : R) -> Order raise {
+pub  fn[R: @protobuf.Reader] Order::read(reader : R) -> Order raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Order::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Order::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Order raise {
+pub  fn[R: @protobuf.Reader] Order::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Order raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -176,12 +243,12 @@ pub async fn[R: @protobuf.AsyncReader] Order::read_with_limit(reader : @protobuf
   let msg = Order::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.order_id = reader |> @protobuf.async_read_string()
-      (2, _) => msg.product_name = reader |> @protobuf.async_read_string()
-      (3, _) => msg.amount = reader |> @protobuf.async_read_double() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.order_id = reader |> @protobuf.read_string()
+      (2, _) => msg.product_name = reader |> @protobuf.read_string()
+      (3, _) => msg.amount = reader |> @protobuf.read_double() |> Some
       (4, _) => msg.customer =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       User::default()
     } else {
@@ -189,14 +256,14 @@ pub async fn[R: @protobuf.AsyncReader] Order::read_with_limit(reader : @protobuf
     }
   } |> Some
       (5, _) => msg.related_orders.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Order::default()
     } else {
       Order::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -206,30 +273,30 @@ pub async fn[R: @protobuf.AsyncReader] Order::read_with_limit(reader : @protobuf
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Order::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.order_id)
-  writer |> @protobuf.async_write_varint(18UL);
-  writer |> @protobuf.async_write_string(self.product_name)
+pub  fn[W: @protobuf.Writer] Order::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.order_id)
+  writer |> @protobuf.write_varint(18UL);
+  writer |> @protobuf.write_string(self.product_name)
   match self.amount {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(25UL);
-      writer |> @protobuf.async_write_double(v)
+      writer |> @protobuf.write_varint(25UL);
+      writer |> @protobuf.write_double(v)
 
     }
     None => ()
   }
   match self.customer {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(34UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.related_orders {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -272,6 +339,76 @@ pub impl @json.FromJson for Order with from_json(json: Json, path: @json.JsonPat
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] Order::async_read(reader : R) -> Order raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Order::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Order::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Order raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Order::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.order_id = reader |> @protobuf.async_read_string()
+      (2, _) => msg.product_name = reader |> @protobuf.async_read_string()
+      (3, _) => msg.amount = reader |> @protobuf.async_read_double() |> Some
+      (4, _) => msg.customer =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      User::default()
+    } else {
+      User::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (5, _) => msg.related_orders.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Order::default()
+    } else {
+      Order::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Order::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.order_id)
+  writer |> @protobuf.async_write_varint(18UL);
+  writer |> @protobuf.async_write_string(self.product_name)
+  match self.amount {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(25UL);
+      writer |> @protobuf.async_write_double(v)
+
+    }
+    None => ()
+  }
+  match self.customer {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.related_orders {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct Department {
   mut dept_id : String
   mut name : String
@@ -300,11 +437,11 @@ pub impl Default for Department with default() -> Department {
     parent_dept : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Department::read(reader : R) -> Department raise {
+pub  fn[R: @protobuf.Reader] Department::read(reader : R) -> Department raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Department::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Department::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Department raise {
+pub  fn[R: @protobuf.Reader] Department::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Department raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -313,11 +450,11 @@ pub async fn[R: @protobuf.AsyncReader] Department::read_with_limit(reader : @pro
   let msg = Department::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.dept_id = reader |> @protobuf.async_read_string()
-      (2, _) => msg.name = reader |> @protobuf.async_read_string()
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.dept_id = reader |> @protobuf.read_string()
+      (2, _) => msg.name = reader |> @protobuf.read_string()
       (3, _) => msg.employees.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Employee::default()
     } else {
@@ -325,7 +462,7 @@ pub async fn[R: @protobuf.AsyncReader] Department::read_with_limit(reader : @pro
     }
   })
       (4, _) => msg.projects.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Project::default()
     } else {
@@ -333,14 +470,14 @@ pub async fn[R: @protobuf.AsyncReader] Department::read_with_limit(reader : @pro
     }
   })
       (5, _) => msg.parent_dept =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Department::default()
     } else {
       Department::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -350,25 +487,25 @@ pub async fn[R: @protobuf.AsyncReader] Department::read_with_limit(reader : @pro
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Department::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.dept_id)
-  writer |> @protobuf.async_write_varint(18UL);
-  writer |> @protobuf.async_write_string(self.name)
+pub  fn[W: @protobuf.Writer] Department::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.dept_id)
+  writer |> @protobuf.write_varint(18UL);
+  writer |> @protobuf.write_string(self.name)
   for item in self.employees {
-    writer |> @protobuf.async_write_varint(26UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(26UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.projects {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.parent_dept {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(42UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(42UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -413,6 +550,80 @@ pub impl @json.FromJson for Department with from_json(json: Json, path: @json.Js
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] Department::async_read(reader : R) -> Department raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Department::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Department::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Department raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Department::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.dept_id = reader |> @protobuf.async_read_string()
+      (2, _) => msg.name = reader |> @protobuf.async_read_string()
+      (3, _) => msg.employees.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Employee::default()
+    } else {
+      Employee::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (4, _) => msg.projects.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Project::default()
+    } else {
+      Project::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (5, _) => msg.parent_dept =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Department::default()
+    } else {
+      Department::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Department::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.dept_id)
+  writer |> @protobuf.async_write_varint(18UL);
+  writer |> @protobuf.async_write_string(self.name)
+  for item in self.employees {
+    writer |> @protobuf.async_write_varint(26UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.projects {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.parent_dept {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(42UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct Employee {
   mut emp_id : String
   mut name : String
@@ -447,11 +658,11 @@ pub impl Default for Employee with default() -> Employee {
     subordinates : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Employee::read(reader : R) -> Employee raise {
+pub  fn[R: @protobuf.Reader] Employee::read(reader : R) -> Employee raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Employee::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Employee::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Employee raise {
+pub  fn[R: @protobuf.Reader] Employee::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Employee raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -460,11 +671,11 @@ pub async fn[R: @protobuf.AsyncReader] Employee::read_with_limit(reader : @proto
   let msg = Employee::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.emp_id = reader |> @protobuf.async_read_string()
-      (2, _) => msg.name = reader |> @protobuf.async_read_string()
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.emp_id = reader |> @protobuf.read_string()
+      (2, _) => msg.name = reader |> @protobuf.read_string()
       (3, _) => msg.department =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Department::default()
     } else {
@@ -472,7 +683,7 @@ pub async fn[R: @protobuf.AsyncReader] Employee::read_with_limit(reader : @proto
     }
   } |> Some
       (4, _) => msg.projects.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Project::default()
     } else {
@@ -480,7 +691,7 @@ pub async fn[R: @protobuf.AsyncReader] Employee::read_with_limit(reader : @proto
     }
   })
       (5, _) => msg.supervisor =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Employee::default()
     } else {
@@ -488,14 +699,14 @@ pub async fn[R: @protobuf.AsyncReader] Employee::read_with_limit(reader : @proto
     }
   } |> Some
       (6, _) => msg.subordinates.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Employee::default()
     } else {
       Employee::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -505,35 +716,35 @@ pub async fn[R: @protobuf.AsyncReader] Employee::read_with_limit(reader : @proto
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Employee::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.emp_id)
-  writer |> @protobuf.async_write_varint(18UL);
-  writer |> @protobuf.async_write_string(self.name)
+pub  fn[W: @protobuf.Writer] Employee::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.emp_id)
+  writer |> @protobuf.write_varint(18UL);
+  writer |> @protobuf.write_string(self.name)
   match self.department {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.projects {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.supervisor {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(42UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(42UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.subordinates {
-    writer |> @protobuf.async_write_varint(50UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(50UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -581,6 +792,96 @@ pub impl @json.FromJson for Employee with from_json(json: Json, path: @json.Json
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] Employee::async_read(reader : R) -> Employee raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Employee::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Employee::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Employee raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Employee::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.emp_id = reader |> @protobuf.async_read_string()
+      (2, _) => msg.name = reader |> @protobuf.async_read_string()
+      (3, _) => msg.department =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Department::default()
+    } else {
+      Department::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (4, _) => msg.projects.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Project::default()
+    } else {
+      Project::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (5, _) => msg.supervisor =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Employee::default()
+    } else {
+      Employee::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (6, _) => msg.subordinates.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Employee::default()
+    } else {
+      Employee::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Employee::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.emp_id)
+  writer |> @protobuf.async_write_varint(18UL);
+  writer |> @protobuf.async_write_string(self.name)
+  match self.department {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.projects {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.supervisor {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(42UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.subordinates {
+    writer |> @protobuf.async_write_varint(50UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct Project {
   mut project_id : String
   mut title : String
@@ -618,11 +919,11 @@ pub impl Default for Project with default() -> Project {
     dependents : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Project::read(reader : R) -> Project raise {
+pub  fn[R: @protobuf.Reader] Project::read(reader : R) -> Project raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Project::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Project::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Project raise {
+pub  fn[R: @protobuf.Reader] Project::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Project raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -631,12 +932,12 @@ pub async fn[R: @protobuf.AsyncReader] Project::read_with_limit(reader : @protob
   let msg = Project::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.project_id = reader |> @protobuf.async_read_string()
-      (2, _) => msg.title = reader |> @protobuf.async_read_string()
-      (3, _) => msg.description = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.project_id = reader |> @protobuf.read_string()
+      (2, _) => msg.title = reader |> @protobuf.read_string()
+      (3, _) => msg.description = reader |> @protobuf.read_string() |> Some
       (4, _) => msg.department =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Department::default()
     } else {
@@ -644,7 +945,7 @@ pub async fn[R: @protobuf.AsyncReader] Project::read_with_limit(reader : @protob
     }
   } |> Some
       (5, _) => msg.members.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Employee::default()
     } else {
@@ -652,7 +953,7 @@ pub async fn[R: @protobuf.AsyncReader] Project::read_with_limit(reader : @protob
     }
   })
       (6, _) => msg.dependencies.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Project::default()
     } else {
@@ -660,14 +961,14 @@ pub async fn[R: @protobuf.AsyncReader] Project::read_with_limit(reader : @protob
     }
   })
       (7, _) => msg.dependents.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Project::default()
     } else {
       Project::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -677,40 +978,40 @@ pub async fn[R: @protobuf.AsyncReader] Project::read_with_limit(reader : @protob
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Project::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.project_id)
-  writer |> @protobuf.async_write_varint(18UL);
-  writer |> @protobuf.async_write_string(self.title)
+pub  fn[W: @protobuf.Writer] Project::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.project_id)
+  writer |> @protobuf.write_varint(18UL);
+  writer |> @protobuf.write_string(self.title)
   match self.description {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.department {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(34UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.members {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.dependencies {
-    writer |> @protobuf.async_write_varint(50UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(50UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.dependents {
-    writer |> @protobuf.async_write_varint(58UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(58UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -763,6 +1064,102 @@ pub impl @json.FromJson for Project with from_json(json: Json, path: @json.JsonP
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] Project::async_read(reader : R) -> Project raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Project::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Project::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Project raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Project::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.project_id = reader |> @protobuf.async_read_string()
+      (2, _) => msg.title = reader |> @protobuf.async_read_string()
+      (3, _) => msg.description = reader |> @protobuf.async_read_string() |> Some
+      (4, _) => msg.department =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Department::default()
+    } else {
+      Department::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (5, _) => msg.members.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Employee::default()
+    } else {
+      Employee::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (6, _) => msg.dependencies.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Project::default()
+    } else {
+      Project::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (7, _) => msg.dependents.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Project::default()
+    } else {
+      Project::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Project::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.project_id)
+  writer |> @protobuf.async_write_varint(18UL);
+  writer |> @protobuf.async_write_string(self.title)
+  match self.description {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.department {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.members {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.dependencies {
+    writer |> @protobuf.async_write_varint(50UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.dependents {
+    writer |> @protobuf.async_write_varint(58UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct Node_Connection {
   mut connection_id : String
   mut type_ : String?
@@ -800,11 +1197,11 @@ pub impl Default for Node_Connection with default() -> Node_Connection {
     weight : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Node_Connection::read(reader : R) -> Node_Connection raise {
+pub  fn[R: @protobuf.Reader] Node_Connection::read(reader : R) -> Node_Connection raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Node_Connection::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Node_Connection::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Node_Connection raise {
+pub  fn[R: @protobuf.Reader] Node_Connection::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Node_Connection raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -813,11 +1210,11 @@ pub async fn[R: @protobuf.AsyncReader] Node_Connection::read_with_limit(reader :
   let msg = Node_Connection::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.connection_id = reader |> @protobuf.async_read_string()
-      (2, _) => msg.type_ = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.connection_id = reader |> @protobuf.read_string()
+      (2, _) => msg.type_ = reader |> @protobuf.read_string() |> Some
       (3, _) => msg.source =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Node::default()
     } else {
@@ -825,7 +1222,7 @@ pub async fn[R: @protobuf.AsyncReader] Node_Connection::read_with_limit(reader :
     }
   } |> Some
       (4, _) => msg.target =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Node::default()
     } else {
@@ -833,14 +1230,14 @@ pub async fn[R: @protobuf.AsyncReader] Node_Connection::read_with_limit(reader :
     }
   } |> Some
       (5, _) => msg.weight =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Weight::default()
     } else {
       Weight::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -850,37 +1247,37 @@ pub async fn[R: @protobuf.AsyncReader] Node_Connection::read_with_limit(reader :
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Node_Connection::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.connection_id)
+pub  fn[W: @protobuf.Writer] Node_Connection::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.connection_id)
   match self.type_ {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.source {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.target {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(34UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.weight {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(42UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(42UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -926,6 +1323,92 @@ pub impl @json.FromJson for Node_Connection with from_json(json: Json, path: @js
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] Node_Connection::async_read(reader : R) -> Node_Connection raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Node_Connection::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Node_Connection::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Node_Connection raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Node_Connection::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.connection_id = reader |> @protobuf.async_read_string()
+      (2, _) => msg.type_ = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.source =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Node::default()
+    } else {
+      Node::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (4, _) => msg.target =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Node::default()
+    } else {
+      Node::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (5, _) => msg.weight =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Weight::default()
+    } else {
+      Weight::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Node_Connection::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.connection_id)
+  match self.type_ {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.source {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.target {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.weight {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(42UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct Node {
   mut id : String
   mut data : String?
@@ -951,11 +1434,11 @@ pub impl Default for Node with default() -> Node {
     neighbors : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Node::read(reader : R) -> Node raise {
+pub  fn[R: @protobuf.Reader] Node::read(reader : R) -> Node raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Node::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Node::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Node raise {
+pub  fn[R: @protobuf.Reader] Node::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Node raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -964,11 +1447,11 @@ pub async fn[R: @protobuf.AsyncReader] Node::read_with_limit(reader : @protobuf.
   let msg = Node::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.id = reader |> @protobuf.async_read_string()
-      (2, _) => msg.data = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.id = reader |> @protobuf.read_string()
+      (2, _) => msg.data = reader |> @protobuf.read_string() |> Some
       (3, _) => msg.connections.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Node_Connection::default()
     } else {
@@ -976,14 +1459,14 @@ pub async fn[R: @protobuf.AsyncReader] Node::read_with_limit(reader : @protobuf.
     }
   })
       (4, _) => msg.neighbors.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Node::default()
     } else {
       Node::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -993,25 +1476,25 @@ pub async fn[R: @protobuf.AsyncReader] Node::read_with_limit(reader : @protobuf.
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Node::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.id)
+pub  fn[W: @protobuf.Writer] Node::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.id)
   match self.data {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   for item in self.connections {
-    writer |> @protobuf.async_write_varint(26UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(26UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.neighbors {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -1050,6 +1533,70 @@ pub impl @json.FromJson for Node with from_json(json: Json, path: @json.JsonPath
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] Node::async_read(reader : R) -> Node raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Node::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Node::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Node raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Node::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.id = reader |> @protobuf.async_read_string()
+      (2, _) => msg.data = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.connections.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Node_Connection::default()
+    } else {
+      Node_Connection::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (4, _) => msg.neighbors.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Node::default()
+    } else {
+      Node::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Node::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.id)
+  match self.data {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  for item in self.connections {
+    writer |> @protobuf.async_write_varint(26UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.neighbors {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct Weight {
   mut value : Double
   mut unit : String?
@@ -1078,11 +1625,11 @@ pub impl Default for Weight with default() -> Weight {
     related_nodes : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Weight::read(reader : R) -> Weight raise {
+pub  fn[R: @protobuf.Reader] Weight::read(reader : R) -> Weight raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Weight::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Weight::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Weight raise {
+pub  fn[R: @protobuf.Reader] Weight::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Weight raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -1091,11 +1638,11 @@ pub async fn[R: @protobuf.AsyncReader] Weight::read_with_limit(reader : @protobu
   let msg = Weight::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.value = reader |> @protobuf.async_read_double()
-      (2, _) => msg.unit = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.value = reader |> @protobuf.read_double()
+      (2, _) => msg.unit = reader |> @protobuf.read_string() |> Some
       (3, _) => msg.connection =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Node_Connection::default()
     } else {
@@ -1103,14 +1650,14 @@ pub async fn[R: @protobuf.AsyncReader] Weight::read_with_limit(reader : @protobu
     }
   } |> Some
       (4, _) => msg.related_nodes.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Node::default()
     } else {
       Node::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1120,28 +1667,28 @@ pub async fn[R: @protobuf.AsyncReader] Weight::read_with_limit(reader : @protobu
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Weight::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(9UL);
-  writer |> @protobuf.async_write_double(self.value)
+pub  fn[W: @protobuf.Writer] Weight::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(9UL);
+  writer |> @protobuf.write_double(self.value)
   match self.unit {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.connection {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.related_nodes {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -1180,6 +1727,73 @@ pub impl @json.FromJson for Weight with from_json(json: Json, path: @json.JsonPa
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] Weight::async_read(reader : R) -> Weight raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Weight::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Weight::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Weight raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Weight::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.value = reader |> @protobuf.async_read_double()
+      (2, _) => msg.unit = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.connection =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Node_Connection::default()
+    } else {
+      Node_Connection::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (4, _) => msg.related_nodes.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Node::default()
+    } else {
+      Node::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Weight::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(9UL);
+  writer |> @protobuf.async_write_double(self.value)
+  match self.unit {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.connection {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.related_nodes {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct Graph {
   mut graph_id : String
   mut name : String?
@@ -1205,11 +1819,11 @@ pub impl Default for Graph with default() -> Graph {
     edges : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Graph::read(reader : R) -> Graph raise {
+pub  fn[R: @protobuf.Reader] Graph::read(reader : R) -> Graph raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Graph::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Graph::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Graph raise {
+pub  fn[R: @protobuf.Reader] Graph::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Graph raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -1218,11 +1832,11 @@ pub async fn[R: @protobuf.AsyncReader] Graph::read_with_limit(reader : @protobuf
   let msg = Graph::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.graph_id = reader |> @protobuf.async_read_string()
-      (2, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.graph_id = reader |> @protobuf.read_string()
+      (2, _) => msg.name = reader |> @protobuf.read_string() |> Some
       (3, _) => msg.vertices.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Vertex::default()
     } else {
@@ -1230,14 +1844,14 @@ pub async fn[R: @protobuf.AsyncReader] Graph::read_with_limit(reader : @protobuf
     }
   })
       (4, _) => msg.edges.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Edge::default()
     } else {
       Edge::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1247,25 +1861,25 @@ pub async fn[R: @protobuf.AsyncReader] Graph::read_with_limit(reader : @protobuf
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Graph::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.graph_id)
+pub  fn[W: @protobuf.Writer] Graph::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.graph_id)
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   for item in self.vertices {
-    writer |> @protobuf.async_write_varint(26UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(26UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.edges {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -1304,6 +1918,70 @@ pub impl @json.FromJson for Graph with from_json(json: Json, path: @json.JsonPat
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] Graph::async_read(reader : R) -> Graph raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Graph::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Graph::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Graph raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Graph::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.graph_id = reader |> @protobuf.async_read_string()
+      (2, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.vertices.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Vertex::default()
+    } else {
+      Vertex::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (4, _) => msg.edges.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Edge::default()
+    } else {
+      Edge::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Graph::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.graph_id)
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  for item in self.vertices {
+    writer |> @protobuf.async_write_varint(26UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.edges {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct Vertex {
   mut vertex_id : String
   mut label : String?
@@ -1338,11 +2016,11 @@ pub impl Default for Vertex with default() -> Vertex {
     adjacent_vertices : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Vertex::read(reader : R) -> Vertex raise {
+pub  fn[R: @protobuf.Reader] Vertex::read(reader : R) -> Vertex raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Vertex::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Vertex::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Vertex raise {
+pub  fn[R: @protobuf.Reader] Vertex::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Vertex raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -1351,11 +2029,11 @@ pub async fn[R: @protobuf.AsyncReader] Vertex::read_with_limit(reader : @protobu
   let msg = Vertex::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.vertex_id = reader |> @protobuf.async_read_string()
-      (2, _) => msg.label = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.vertex_id = reader |> @protobuf.read_string()
+      (2, _) => msg.label = reader |> @protobuf.read_string() |> Some
       (3, _) => msg.graph =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Graph::default()
     } else {
@@ -1363,7 +2041,7 @@ pub async fn[R: @protobuf.AsyncReader] Vertex::read_with_limit(reader : @protobu
     }
   } |> Some
       (4, _) => msg.incoming_edges.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Edge::default()
     } else {
@@ -1371,7 +2049,7 @@ pub async fn[R: @protobuf.AsyncReader] Vertex::read_with_limit(reader : @protobu
     }
   })
       (5, _) => msg.outgoing_edges.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Edge::default()
     } else {
@@ -1379,14 +2057,14 @@ pub async fn[R: @protobuf.AsyncReader] Vertex::read_with_limit(reader : @protobu
     }
   })
       (6, _) => msg.adjacent_vertices.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Vertex::default()
     } else {
       Vertex::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1396,38 +2074,38 @@ pub async fn[R: @protobuf.AsyncReader] Vertex::read_with_limit(reader : @protobu
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Vertex::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.vertex_id)
+pub  fn[W: @protobuf.Writer] Vertex::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.vertex_id)
   match self.label {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.graph {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.incoming_edges {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.outgoing_edges {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.adjacent_vertices {
-    writer |> @protobuf.async_write_varint(50UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(50UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -1476,6 +2154,99 @@ pub impl @json.FromJson for Vertex with from_json(json: Json, path: @json.JsonPa
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] Vertex::async_read(reader : R) -> Vertex raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Vertex::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Vertex::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Vertex raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Vertex::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.vertex_id = reader |> @protobuf.async_read_string()
+      (2, _) => msg.label = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.graph =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Graph::default()
+    } else {
+      Graph::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (4, _) => msg.incoming_edges.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Edge::default()
+    } else {
+      Edge::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (5, _) => msg.outgoing_edges.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Edge::default()
+    } else {
+      Edge::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (6, _) => msg.adjacent_vertices.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Vertex::default()
+    } else {
+      Vertex::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Vertex::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.vertex_id)
+  match self.label {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.graph {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.incoming_edges {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.outgoing_edges {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.adjacent_vertices {
+    writer |> @protobuf.async_write_varint(50UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct Edge {
   mut edge_id : String
   mut weight : Double?
@@ -1516,11 +2287,11 @@ pub impl Default for Edge with default() -> Edge {
     parallel_edges : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] Edge::read(reader : R) -> Edge raise {
+pub  fn[R: @protobuf.Reader] Edge::read(reader : R) -> Edge raise {
   let reader = @protobuf.LimitedReader::new(reader)
   Edge::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] Edge::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Edge raise {
+pub  fn[R: @protobuf.Reader] Edge::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Edge raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -1529,11 +2300,11 @@ pub async fn[R: @protobuf.AsyncReader] Edge::read_with_limit(reader : @protobuf.
   let msg = Edge::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.edge_id = reader |> @protobuf.async_read_string()
-      (2, _) => msg.weight = reader |> @protobuf.async_read_double() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.edge_id = reader |> @protobuf.read_string()
+      (2, _) => msg.weight = reader |> @protobuf.read_double() |> Some
       (3, _) => msg.graph =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Graph::default()
     } else {
@@ -1541,7 +2312,7 @@ pub async fn[R: @protobuf.AsyncReader] Edge::read_with_limit(reader : @protobuf.
     }
   } |> Some
       (4, _) => msg.source_vertex =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Vertex::default()
     } else {
@@ -1549,7 +2320,7 @@ pub async fn[R: @protobuf.AsyncReader] Edge::read_with_limit(reader : @protobuf.
     }
   } |> Some
       (5, _) => msg.target_vertex =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Vertex::default()
     } else {
@@ -1557,14 +2328,14 @@ pub async fn[R: @protobuf.AsyncReader] Edge::read_with_limit(reader : @protobuf.
     }
   } |> Some
       (6, _) => msg.parallel_edges.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       Edge::default()
     } else {
       Edge::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1574,44 +2345,44 @@ pub async fn[R: @protobuf.AsyncReader] Edge::read_with_limit(reader : @protobuf.
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] Edge::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.edge_id)
+pub  fn[W: @protobuf.Writer] Edge::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.edge_id)
   match self.weight {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(17UL);
-      writer |> @protobuf.async_write_double(v)
+      writer |> @protobuf.write_varint(17UL);
+      writer |> @protobuf.write_double(v)
 
     }
     None => ()
   }
   match self.graph {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.source_vertex {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(34UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.target_vertex {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(42UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(42UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.parallel_edges {
-    writer |> @protobuf.async_write_varint(50UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(50UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -1659,4 +2430,103 @@ pub impl @json.FromJson for Edge with from_json(json: Json, path: @json.JsonPath
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] Edge::async_read(reader : R) -> Edge raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  Edge::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] Edge::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> Edge raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = Edge::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.edge_id = reader |> @protobuf.async_read_string()
+      (2, _) => msg.weight = reader |> @protobuf.async_read_double() |> Some
+      (3, _) => msg.graph =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Graph::default()
+    } else {
+      Graph::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (4, _) => msg.source_vertex =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Vertex::default()
+    } else {
+      Vertex::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (5, _) => msg.target_vertex =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Vertex::default()
+    } else {
+      Vertex::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (6, _) => msg.parallel_edges.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      Edge::default()
+    } else {
+      Edge::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] Edge::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.edge_id)
+  match self.weight {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(17UL);
+      writer |> @protobuf.async_write_double(v)
+
+    }
+    None => ()
+  }
+  match self.graph {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.source_vertex {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.target_vertex {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(42UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.parallel_edges {
+    writer |> @protobuf.async_write_varint(50UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
 }

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -153,11 +153,11 @@ pub impl Default for FileDescriptorSet with default() -> FileDescriptorSet {
     file : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FileDescriptorSet::read(reader : R) -> FileDescriptorSet raise {
+pub  fn[R: @protobuf.Reader] FileDescriptorSet::read(reader : R) -> FileDescriptorSet raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FileDescriptorSet::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FileDescriptorSet::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FileDescriptorSet raise {
+pub  fn[R: @protobuf.Reader] FileDescriptorSet::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FileDescriptorSet raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -166,16 +166,16 @@ pub async fn[R: @protobuf.AsyncReader] FileDescriptorSet::read_with_limit(reader
   let msg = FileDescriptorSet::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (1, _) => msg.file.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FileDescriptorProto::default()
     } else {
       FileDescriptorProto::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -185,10 +185,10 @@ pub async fn[R: @protobuf.AsyncReader] FileDescriptorSet::read_with_limit(reader
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FileDescriptorSet::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] FileDescriptorSet::write(self:Self, writer : W) -> Unit raise {
   for item in self.file {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -212,6 +212,45 @@ pub impl @json.FromJson for FileDescriptorSet with from_json(json: Json, path: @
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] FileDescriptorSet::async_read(reader : R) -> FileDescriptorSet raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FileDescriptorSet::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FileDescriptorSet::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FileDescriptorSet raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FileDescriptorSet::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.file.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FileDescriptorProto::default()
+    } else {
+      FileDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] FileDescriptorSet::async_write(self:Self, writer : W) -> Unit raise {
+  for item in self.file {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
 }
 pub(all) struct FileDescriptorProto {
   mut name : String?
@@ -283,11 +322,11 @@ pub impl Default for FileDescriptorProto with default() -> FileDescriptorProto {
     edition : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FileDescriptorProto::read(reader : R) -> FileDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] FileDescriptorProto::read(reader : R) -> FileDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FileDescriptorProto::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FileDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] FileDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FileDescriptorProto raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -296,15 +335,15 @@ pub async fn[R: @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(read
   let msg = FileDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
-      (2, _) => msg.package_ = reader |> @protobuf.async_read_string() |> Some
-      (3, _) => msg.dependency.push(reader |> @protobuf.async_read_string())
-      (10, _) => msg.public_dependency.push(reader |> @protobuf.async_read_int32())
-      (11, _) => msg.weak_dependency.push(reader |> @protobuf.async_read_int32())
-      (15, _) => msg.option_dependency.push(reader |> @protobuf.async_read_string())
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
+      (2, _) => msg.package_ = reader |> @protobuf.read_string() |> Some
+      (3, _) => msg.dependency.push(reader |> @protobuf.read_string())
+      (10, _) => msg.public_dependency.push(reader |> @protobuf.read_int32())
+      (11, _) => msg.weak_dependency.push(reader |> @protobuf.read_int32())
+      (15, _) => msg.option_dependency.push(reader |> @protobuf.read_string())
       (4, _) => msg.message_type.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       DescriptorProto::default()
     } else {
@@ -312,7 +351,7 @@ pub async fn[R: @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(read
     }
   })
       (5, _) => msg.enum_type.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       EnumDescriptorProto::default()
     } else {
@@ -320,7 +359,7 @@ pub async fn[R: @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(read
     }
   })
       (6, _) => msg.service.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       ServiceDescriptorProto::default()
     } else {
@@ -328,7 +367,7 @@ pub async fn[R: @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(read
     }
   })
       (7, _) => msg.extension.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FieldDescriptorProto::default()
     } else {
@@ -336,7 +375,7 @@ pub async fn[R: @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(read
     }
   })
       (8, _) => msg.options =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FileOptions::default()
     } else {
@@ -344,16 +383,16 @@ pub async fn[R: @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(read
     }
   } |> Some
       (9, _) => msg.source_code_info =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       SourceCodeInfo::default()
     } else {
       SourceCodeInfo::read_with_limit(reader, limit=len)
     }
   } |> Some
-      (12, _) => msg.syntax = reader |> @protobuf.async_read_string() |> Some
-      (14, _) => msg.edition = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      (12, _) => msg.syntax = reader |> @protobuf.read_string() |> Some
+      (14, _) => msg.edition = reader |> @protobuf.read_enum() |> Edition::from_enum |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -363,91 +402,91 @@ pub async fn[R: @protobuf.AsyncReader] FileDescriptorProto::read_with_limit(read
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FileDescriptorProto::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] FileDescriptorProto::write(self:Self, writer : W) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.package_ {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   for item in self.dependency {
-    writer |> @protobuf.async_write_varint(26UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(26UL)
+    writer |> @protobuf.write_string(item)
 
   }
   for item in self.public_dependency {
-    writer |> @protobuf.async_write_varint(80UL)
-    writer |> @protobuf.async_write_int32(item)
+    writer |> @protobuf.write_varint(80UL)
+    writer |> @protobuf.write_int32(item)
 
   }
   for item in self.weak_dependency {
-    writer |> @protobuf.async_write_varint(88UL)
-    writer |> @protobuf.async_write_int32(item)
+    writer |> @protobuf.write_varint(88UL)
+    writer |> @protobuf.write_int32(item)
 
   }
   for item in self.option_dependency {
-    writer |> @protobuf.async_write_varint(122UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(122UL)
+    writer |> @protobuf.write_string(item)
 
   }
   for item in self.message_type {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.enum_type {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.service {
-    writer |> @protobuf.async_write_varint(50UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(50UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.extension {
-    writer |> @protobuf.async_write_varint(58UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(58UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(66UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(66UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.source_code_info {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(74UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(74UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.syntax {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(98UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(98UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(112UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(112UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
@@ -539,6 +578,176 @@ pub impl @json.FromJson for FileDescriptorProto with from_json(json: Json, path:
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] FileDescriptorProto::async_read(reader : R) -> FileDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FileDescriptorProto::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FileDescriptorProto::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FileDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FileDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      (2, _) => msg.package_ = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.dependency.push(reader |> @protobuf.async_read_string())
+      (10, _) => msg.public_dependency.push(reader |> @protobuf.async_read_int32())
+      (11, _) => msg.weak_dependency.push(reader |> @protobuf.async_read_int32())
+      (15, _) => msg.option_dependency.push(reader |> @protobuf.async_read_string())
+      (4, _) => msg.message_type.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      DescriptorProto::default()
+    } else {
+      DescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (5, _) => msg.enum_type.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      EnumDescriptorProto::default()
+    } else {
+      EnumDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (6, _) => msg.service.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      ServiceDescriptorProto::default()
+    } else {
+      ServiceDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (7, _) => msg.extension.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FieldDescriptorProto::default()
+    } else {
+      FieldDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (8, _) => msg.options =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FileOptions::default()
+    } else {
+      FileOptions::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (9, _) => msg.source_code_info =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      SourceCodeInfo::default()
+    } else {
+      SourceCodeInfo::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (12, _) => msg.syntax = reader |> @protobuf.async_read_string() |> Some
+      (14, _) => msg.edition = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] FileDescriptorProto::async_write(self:Self, writer : W) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.package_ {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  for item in self.dependency {
+    writer |> @protobuf.async_write_varint(26UL)
+    writer |> @protobuf.async_write_string(item)
+
+  }
+  for item in self.public_dependency {
+    writer |> @protobuf.async_write_varint(80UL)
+    writer |> @protobuf.async_write_int32(item)
+
+  }
+  for item in self.weak_dependency {
+    writer |> @protobuf.async_write_varint(88UL)
+    writer |> @protobuf.async_write_int32(item)
+
+  }
+  for item in self.option_dependency {
+    writer |> @protobuf.async_write_varint(122UL)
+    writer |> @protobuf.async_write_string(item)
+
+  }
+  for item in self.message_type {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.enum_type {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.service {
+    writer |> @protobuf.async_write_varint(50UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.extension {
+    writer |> @protobuf.async_write_varint(58UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(66UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.source_code_info {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(74UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.syntax {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(98UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(112UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+}
 pub(all) struct DescriptorProto_ExtensionRange {
   mut start : Int?
   mut end : Int?
@@ -567,11 +776,11 @@ pub impl Default for DescriptorProto_ExtensionRange with default() -> Descriptor
     options : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ExtensionRange::read(reader : R) -> DescriptorProto_ExtensionRange raise {
+pub  fn[R: @protobuf.Reader] DescriptorProto_ExtensionRange::read(reader : R) -> DescriptorProto_ExtensionRange raise {
   let reader = @protobuf.LimitedReader::new(reader)
   DescriptorProto_ExtensionRange::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ExtensionRange::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> DescriptorProto_ExtensionRange raise {
+pub  fn[R: @protobuf.Reader] DescriptorProto_ExtensionRange::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> DescriptorProto_ExtensionRange raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -580,18 +789,18 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ExtensionRange::read_with
   let msg = DescriptorProto_ExtensionRange::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
-      (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.start = reader |> @protobuf.read_int32() |> Some
+      (2, _) => msg.end = reader |> @protobuf.read_int32() |> Some
       (3, _) => msg.options =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       ExtensionRangeOptions::default()
     } else {
       ExtensionRangeOptions::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -601,27 +810,27 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ExtensionRange::read_with
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] DescriptorProto_ExtensionRange::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] DescriptorProto_ExtensionRange::write(self:Self, writer : W) -> Unit raise {
   match self.start {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(8UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.end {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -658,6 +867,66 @@ pub impl @json.FromJson for DescriptorProto_ExtensionRange with from_json(json: 
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ExtensionRange::async_read(reader : R) -> DescriptorProto_ExtensionRange raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  DescriptorProto_ExtensionRange::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ExtensionRange::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> DescriptorProto_ExtensionRange raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = DescriptorProto_ExtensionRange::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
+      (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
+      (3, _) => msg.options =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      ExtensionRangeOptions::default()
+    } else {
+      ExtensionRangeOptions::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] DescriptorProto_ExtensionRange::async_write(self:Self, writer : W) -> Unit raise {
+  match self.start {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.end {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct DescriptorProto_ReservedRange {
   mut start : Int?
   mut end : Int?
@@ -680,11 +949,11 @@ pub impl Default for DescriptorProto_ReservedRange with default() -> DescriptorP
     end : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ReservedRange::read(reader : R) -> DescriptorProto_ReservedRange raise {
+pub  fn[R: @protobuf.Reader] DescriptorProto_ReservedRange::read(reader : R) -> DescriptorProto_ReservedRange raise {
   let reader = @protobuf.LimitedReader::new(reader)
   DescriptorProto_ReservedRange::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ReservedRange::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> DescriptorProto_ReservedRange raise {
+pub  fn[R: @protobuf.Reader] DescriptorProto_ReservedRange::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> DescriptorProto_ReservedRange raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -693,10 +962,10 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ReservedRange::read_with_
   let msg = DescriptorProto_ReservedRange::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
-      (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.start = reader |> @protobuf.read_int32() |> Some
+      (2, _) => msg.end = reader |> @protobuf.read_int32() |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -706,19 +975,19 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ReservedRange::read_with_
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] DescriptorProto_ReservedRange::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] DescriptorProto_ReservedRange::write(self:Self, writer : W) -> Unit raise {
   match self.start {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(8UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.end {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
@@ -749,6 +1018,50 @@ pub impl @json.FromJson for DescriptorProto_ReservedRange with from_json(json: J
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ReservedRange::async_read(reader : R) -> DescriptorProto_ReservedRange raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  DescriptorProto_ReservedRange::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] DescriptorProto_ReservedRange::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> DescriptorProto_ReservedRange raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = DescriptorProto_ReservedRange::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
+      (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] DescriptorProto_ReservedRange::async_write(self:Self, writer : W) -> Unit raise {
+  match self.start {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.end {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
 }
 pub(all) struct DescriptorProto {
   mut name : String?
@@ -802,11 +1115,11 @@ pub impl Default for DescriptorProto with default() -> DescriptorProto {
     visibility : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] DescriptorProto::read(reader : R) -> DescriptorProto raise {
+pub  fn[R: @protobuf.Reader] DescriptorProto::read(reader : R) -> DescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
   DescriptorProto::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] DescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> DescriptorProto raise {
+pub  fn[R: @protobuf.Reader] DescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> DescriptorProto raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -815,10 +1128,10 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto::read_with_limit(reader :
   let msg = DescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
       (2, _) => msg.field.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FieldDescriptorProto::default()
     } else {
@@ -826,7 +1139,7 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto::read_with_limit(reader :
     }
   })
       (6, _) => msg.extension.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FieldDescriptorProto::default()
     } else {
@@ -834,7 +1147,7 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto::read_with_limit(reader :
     }
   })
       (3, _) => msg.nested_type.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       DescriptorProto::default()
     } else {
@@ -842,7 +1155,7 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto::read_with_limit(reader :
     }
   })
       (4, _) => msg.enum_type.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       EnumDescriptorProto::default()
     } else {
@@ -850,7 +1163,7 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto::read_with_limit(reader :
     }
   })
       (5, _) => msg.extension_range.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       DescriptorProto_ExtensionRange::default()
     } else {
@@ -858,7 +1171,7 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto::read_with_limit(reader :
     }
   })
       (8, _) => msg.oneof_decl.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       OneofDescriptorProto::default()
     } else {
@@ -866,7 +1179,7 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto::read_with_limit(reader :
     }
   })
       (7, _) => msg.options =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       MessageOptions::default()
     } else {
@@ -874,16 +1187,16 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto::read_with_limit(reader :
     }
   } |> Some
       (9, _) => msg.reserved_range.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       DescriptorProto_ReservedRange::default()
     } else {
       DescriptorProto_ReservedRange::read_with_limit(reader, limit=len)
     }
   })
-      (10, _) => msg.reserved_name.push(reader |> @protobuf.async_read_string())
-      (11, _) => msg.visibility = reader |> @protobuf.async_read_enum() |> SymbolVisibility::from_enum |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      (10, _) => msg.reserved_name.push(reader |> @protobuf.read_string())
+      (11, _) => msg.visibility = reader |> @protobuf.read_enum() |> SymbolVisibility::from_enum |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -893,67 +1206,67 @@ pub async fn[R: @protobuf.AsyncReader] DescriptorProto::read_with_limit(reader :
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] DescriptorProto::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] DescriptorProto::write(self:Self, writer : W) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   for item in self.field {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(18UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.extension {
-    writer |> @protobuf.async_write_varint(50UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(50UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.nested_type {
-    writer |> @protobuf.async_write_varint(26UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(26UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.enum_type {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.extension_range {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.oneof_decl {
-    writer |> @protobuf.async_write_varint(66UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(66UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(58UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(58UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.reserved_range {
-    writer |> @protobuf.async_write_varint(74UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(74UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.reserved_name {
-    writer |> @protobuf.async_write_varint(82UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(82UL)
+    writer |> @protobuf.write_string(item)
 
   }
   match self.visibility {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(88UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(88UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
@@ -1029,6 +1342,163 @@ pub impl @json.FromJson for DescriptorProto with from_json(json: Json, path: @js
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] DescriptorProto::async_read(reader : R) -> DescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  DescriptorProto::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] DescriptorProto::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> DescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = DescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      (2, _) => msg.field.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FieldDescriptorProto::default()
+    } else {
+      FieldDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (6, _) => msg.extension.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FieldDescriptorProto::default()
+    } else {
+      FieldDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (3, _) => msg.nested_type.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      DescriptorProto::default()
+    } else {
+      DescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (4, _) => msg.enum_type.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      EnumDescriptorProto::default()
+    } else {
+      EnumDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (5, _) => msg.extension_range.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      DescriptorProto_ExtensionRange::default()
+    } else {
+      DescriptorProto_ExtensionRange::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (8, _) => msg.oneof_decl.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      OneofDescriptorProto::default()
+    } else {
+      OneofDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (7, _) => msg.options =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      MessageOptions::default()
+    } else {
+      MessageOptions::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (9, _) => msg.reserved_range.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      DescriptorProto_ReservedRange::default()
+    } else {
+      DescriptorProto_ReservedRange::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (10, _) => msg.reserved_name.push(reader |> @protobuf.async_read_string())
+      (11, _) => msg.visibility = reader |> @protobuf.async_read_enum() |> SymbolVisibility::from_enum |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] DescriptorProto::async_write(self:Self, writer : W) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  for item in self.field {
+    writer |> @protobuf.async_write_varint(18UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.extension {
+    writer |> @protobuf.async_write_varint(50UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.nested_type {
+    writer |> @protobuf.async_write_varint(26UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.enum_type {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.extension_range {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.oneof_decl {
+    writer |> @protobuf.async_write_varint(66UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(58UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.reserved_range {
+    writer |> @protobuf.async_write_varint(74UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.reserved_name {
+    writer |> @protobuf.async_write_varint(82UL)
+    writer |> @protobuf.async_write_string(item)
+
+  }
+  match self.visibility {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(88UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
 }
 pub(all) enum ExtensionRangeOptions_VerificationState {
   DECLARATION
@@ -1108,11 +1578,11 @@ pub impl Default for ExtensionRangeOptions_Declaration with default() -> Extensi
     repeated : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::read(reader : R) -> ExtensionRangeOptions_Declaration raise {
+pub  fn[R: @protobuf.Reader] ExtensionRangeOptions_Declaration::read(reader : R) -> ExtensionRangeOptions_Declaration raise {
   let reader = @protobuf.LimitedReader::new(reader)
   ExtensionRangeOptions_Declaration::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ExtensionRangeOptions_Declaration raise {
+pub  fn[R: @protobuf.Reader] ExtensionRangeOptions_Declaration::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ExtensionRangeOptions_Declaration raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -1121,13 +1591,13 @@ pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::read_w
   let msg = ExtensionRangeOptions_Declaration::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
-      (2, _) => msg.full_name = reader |> @protobuf.async_read_string() |> Some
-      (3, _) => msg.type_ = reader |> @protobuf.async_read_string() |> Some
-      (5, _) => msg.reserved = reader |> @protobuf.async_read_bool() |> Some
-      (6, _) => msg.repeated = reader |> @protobuf.async_read_bool() |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.number = reader |> @protobuf.read_int32() |> Some
+      (2, _) => msg.full_name = reader |> @protobuf.read_string() |> Some
+      (3, _) => msg.type_ = reader |> @protobuf.read_string() |> Some
+      (5, _) => msg.reserved = reader |> @protobuf.read_bool() |> Some
+      (6, _) => msg.repeated = reader |> @protobuf.read_bool() |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1137,43 +1607,43 @@ pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::read_w
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] ExtensionRangeOptions_Declaration::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] ExtensionRangeOptions_Declaration::write(self:Self, writer : W) -> Unit raise {
   match self.number {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(8UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.full_name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.type_ {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.reserved {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(40UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.repeated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(48UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(48UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
@@ -1220,6 +1690,77 @@ pub impl @json.FromJson for ExtensionRangeOptions_Declaration with from_json(jso
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::async_read(reader : R) -> ExtensionRangeOptions_Declaration raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  ExtensionRangeOptions_Declaration::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions_Declaration::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ExtensionRangeOptions_Declaration raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = ExtensionRangeOptions_Declaration::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
+      (2, _) => msg.full_name = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.type_ = reader |> @protobuf.async_read_string() |> Some
+      (5, _) => msg.reserved = reader |> @protobuf.async_read_bool() |> Some
+      (6, _) => msg.repeated = reader |> @protobuf.async_read_bool() |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] ExtensionRangeOptions_Declaration::async_write(self:Self, writer : W) -> Unit raise {
+  match self.number {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.full_name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.type_ {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.reserved {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.repeated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(48UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct ExtensionRangeOptions {
   mut uninterpreted_option : Array[UninterpretedOption]
   mut declaration : Array[ExtensionRangeOptions_Declaration]
@@ -1248,11 +1789,11 @@ pub impl Default for ExtensionRangeOptions with default() -> ExtensionRangeOptio
     verification : Some(ExtensionRangeOptions_VerificationState::UNVERIFIED),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions::read(reader : R) -> ExtensionRangeOptions raise {
+pub  fn[R: @protobuf.Reader] ExtensionRangeOptions::read(reader : R) -> ExtensionRangeOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
   ExtensionRangeOptions::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ExtensionRangeOptions raise {
+pub  fn[R: @protobuf.Reader] ExtensionRangeOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ExtensionRangeOptions raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -1261,9 +1802,9 @@ pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(re
   let msg = ExtensionRangeOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (999, _) => msg.uninterpreted_option.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       UninterpretedOption::default()
     } else {
@@ -1271,7 +1812,7 @@ pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(re
     }
   })
       (2, _) => msg.declaration.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       ExtensionRangeOptions_Declaration::default()
     } else {
@@ -1279,15 +1820,15 @@ pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(re
     }
   })
       (50, _) => msg.features =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FeatureSet::default()
     } else {
       FeatureSet::read_with_limit(reader, limit=len)
     }
   } |> Some
-      (3, _) => msg.verification = reader |> @protobuf.async_read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      (3, _) => msg.verification = reader |> @protobuf.read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1297,29 +1838,29 @@ pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions::read_with_limit(re
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] ExtensionRangeOptions::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] ExtensionRangeOptions::write(self:Self, writer : W) -> Unit raise {
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.declaration {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(18UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(402UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(402UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.verification {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
@@ -1360,6 +1901,83 @@ pub impl @json.FromJson for ExtensionRangeOptions with from_json(json: Json, pat
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions::async_read(reader : R) -> ExtensionRangeOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  ExtensionRangeOptions::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] ExtensionRangeOptions::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ExtensionRangeOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = ExtensionRangeOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (999, _) => msg.uninterpreted_option.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      UninterpretedOption::default()
+    } else {
+      UninterpretedOption::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (2, _) => msg.declaration.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      ExtensionRangeOptions_Declaration::default()
+    } else {
+      ExtensionRangeOptions_Declaration::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (50, _) => msg.features =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FeatureSet::default()
+    } else {
+      FeatureSet::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (3, _) => msg.verification = reader |> @protobuf.async_read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] ExtensionRangeOptions::async_write(self:Self, writer : W) -> Unit raise {
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.declaration {
+    writer |> @protobuf.async_write_varint(18UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(402UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.verification {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
 }
 pub(all) enum FieldDescriptorProto_Type {
   TYPE_DOUBLE
@@ -1615,11 +2233,11 @@ pub impl Default for FieldDescriptorProto with default() -> FieldDescriptorProto
     proto3_optional : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FieldDescriptorProto::read(reader : R) -> FieldDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] FieldDescriptorProto::read(reader : R) -> FieldDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FieldDescriptorProto::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FieldDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] FieldDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldDescriptorProto raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -1628,26 +2246,26 @@ pub async fn[R: @protobuf.AsyncReader] FieldDescriptorProto::read_with_limit(rea
   let msg = FieldDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
-      (3, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
-      (4, _) => msg.label = reader |> @protobuf.async_read_enum() |> FieldDescriptorProto_Label::from_enum |> Some
-      (5, _) => msg.type_ = reader |> @protobuf.async_read_enum() |> FieldDescriptorProto_Type::from_enum |> Some
-      (6, _) => msg.type_name = reader |> @protobuf.async_read_string() |> Some
-      (2, _) => msg.extendee = reader |> @protobuf.async_read_string() |> Some
-      (7, _) => msg.default_value = reader |> @protobuf.async_read_string() |> Some
-      (9, _) => msg.oneof_index = reader |> @protobuf.async_read_int32() |> Some
-      (10, _) => msg.json_name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
+      (3, _) => msg.number = reader |> @protobuf.read_int32() |> Some
+      (4, _) => msg.label = reader |> @protobuf.read_enum() |> FieldDescriptorProto_Label::from_enum |> Some
+      (5, _) => msg.type_ = reader |> @protobuf.read_enum() |> FieldDescriptorProto_Type::from_enum |> Some
+      (6, _) => msg.type_name = reader |> @protobuf.read_string() |> Some
+      (2, _) => msg.extendee = reader |> @protobuf.read_string() |> Some
+      (7, _) => msg.default_value = reader |> @protobuf.read_string() |> Some
+      (9, _) => msg.oneof_index = reader |> @protobuf.read_int32() |> Some
+      (10, _) => msg.json_name = reader |> @protobuf.read_string() |> Some
       (8, _) => msg.options =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FieldOptions::default()
     } else {
       FieldOptions::read_with_limit(reader, limit=len)
     }
   } |> Some
-      (17, _) => msg.proto3_optional = reader |> @protobuf.async_read_bool() |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      (17, _) => msg.proto3_optional = reader |> @protobuf.read_bool() |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1657,91 +2275,91 @@ pub async fn[R: @protobuf.AsyncReader] FieldDescriptorProto::read_with_limit(rea
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FieldDescriptorProto::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] FieldDescriptorProto::write(self:Self, writer : W) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.number {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.label {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(32UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
   }
   match self.type_ {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(40UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
   }
   match self.type_name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(50UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(50UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.extendee {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.default_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(58UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(58UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.oneof_index {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(72UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(72UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.json_name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(82UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(82UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(66UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(66UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.proto3_optional {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(136UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(136UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
@@ -1818,6 +2436,138 @@ pub impl @json.FromJson for FieldDescriptorProto with from_json(json: Json, path
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] FieldDescriptorProto::async_read(reader : R) -> FieldDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FieldDescriptorProto::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FieldDescriptorProto::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FieldDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
+      (4, _) => msg.label = reader |> @protobuf.async_read_enum() |> FieldDescriptorProto_Label::from_enum |> Some
+      (5, _) => msg.type_ = reader |> @protobuf.async_read_enum() |> FieldDescriptorProto_Type::from_enum |> Some
+      (6, _) => msg.type_name = reader |> @protobuf.async_read_string() |> Some
+      (2, _) => msg.extendee = reader |> @protobuf.async_read_string() |> Some
+      (7, _) => msg.default_value = reader |> @protobuf.async_read_string() |> Some
+      (9, _) => msg.oneof_index = reader |> @protobuf.async_read_int32() |> Some
+      (10, _) => msg.json_name = reader |> @protobuf.async_read_string() |> Some
+      (8, _) => msg.options =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FieldOptions::default()
+    } else {
+      FieldOptions::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (17, _) => msg.proto3_optional = reader |> @protobuf.async_read_bool() |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] FieldDescriptorProto::async_write(self:Self, writer : W) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.number {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.label {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.type_ {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.type_name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(50UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.extendee {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.default_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(58UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.oneof_index {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(72UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.json_name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(82UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(66UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.proto3_optional {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(136UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct OneofDescriptorProto {
   mut name : String?
   mut options : OneofOptions?
@@ -1840,11 +2590,11 @@ pub impl Default for OneofDescriptorProto with default() -> OneofDescriptorProto
     options : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] OneofDescriptorProto::read(reader : R) -> OneofDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] OneofDescriptorProto::read(reader : R) -> OneofDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
   OneofDescriptorProto::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] OneofDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> OneofDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] OneofDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> OneofDescriptorProto raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -1853,17 +2603,17 @@ pub async fn[R: @protobuf.AsyncReader] OneofDescriptorProto::read_with_limit(rea
   let msg = OneofDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
       (2, _) => msg.options =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       OneofOptions::default()
     } else {
       OneofOptions::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1873,19 +2623,19 @@ pub async fn[R: @protobuf.AsyncReader] OneofDescriptorProto::read_with_limit(rea
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] OneofDescriptorProto::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] OneofDescriptorProto::write(self:Self, writer : W) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -1917,6 +2667,57 @@ pub impl @json.FromJson for OneofDescriptorProto with from_json(json: Json, path
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] OneofDescriptorProto::async_read(reader : R) -> OneofDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  OneofDescriptorProto::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] OneofDescriptorProto::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> OneofDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = OneofDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      (2, _) => msg.options =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      OneofOptions::default()
+    } else {
+      OneofOptions::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] OneofDescriptorProto::async_write(self:Self, writer : W) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct EnumDescriptorProto_EnumReservedRange {
   mut start : Int?
   mut end : Int?
@@ -1939,11 +2740,11 @@ pub impl Default for EnumDescriptorProto_EnumReservedRange with default() -> Enu
     end : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::read(reader : R) -> EnumDescriptorProto_EnumReservedRange raise {
+pub  fn[R: @protobuf.Reader] EnumDescriptorProto_EnumReservedRange::read(reader : R) -> EnumDescriptorProto_EnumReservedRange raise {
   let reader = @protobuf.LimitedReader::new(reader)
   EnumDescriptorProto_EnumReservedRange::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumDescriptorProto_EnumReservedRange raise {
+pub  fn[R: @protobuf.Reader] EnumDescriptorProto_EnumReservedRange::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumDescriptorProto_EnumReservedRange raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -1952,10 +2753,10 @@ pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::re
   let msg = EnumDescriptorProto_EnumReservedRange::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
-      (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.start = reader |> @protobuf.read_int32() |> Some
+      (2, _) => msg.end = reader |> @protobuf.read_int32() |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -1965,19 +2766,19 @@ pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::re
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] EnumDescriptorProto_EnumReservedRange::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] EnumDescriptorProto_EnumReservedRange::write(self:Self, writer : W) -> Unit raise {
   match self.start {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(8UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.end {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
@@ -2008,6 +2809,50 @@ pub impl @json.FromJson for EnumDescriptorProto_EnumReservedRange with from_json
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::async_read(reader : R) -> EnumDescriptorProto_EnumReservedRange raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EnumDescriptorProto_EnumReservedRange::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto_EnumReservedRange::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumDescriptorProto_EnumReservedRange raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = EnumDescriptorProto_EnumReservedRange::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.start = reader |> @protobuf.async_read_int32() |> Some
+      (2, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] EnumDescriptorProto_EnumReservedRange::async_write(self:Self, writer : W) -> Unit raise {
+  match self.start {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.end {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
 }
 pub(all) struct EnumDescriptorProto {
   mut name : String?
@@ -2046,11 +2891,11 @@ pub impl Default for EnumDescriptorProto with default() -> EnumDescriptorProto {
     visibility : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto::read(reader : R) -> EnumDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] EnumDescriptorProto::read(reader : R) -> EnumDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
   EnumDescriptorProto::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] EnumDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumDescriptorProto raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -2059,10 +2904,10 @@ pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(read
   let msg = EnumDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
       (2, _) => msg.value.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       EnumValueDescriptorProto::default()
     } else {
@@ -2070,7 +2915,7 @@ pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(read
     }
   })
       (3, _) => msg.options =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       EnumOptions::default()
     } else {
@@ -2078,16 +2923,16 @@ pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(read
     }
   } |> Some
       (4, _) => msg.reserved_range.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       EnumDescriptorProto_EnumReservedRange::default()
     } else {
       EnumDescriptorProto_EnumReservedRange::read_with_limit(reader, limit=len)
     }
   })
-      (5, _) => msg.reserved_name.push(reader |> @protobuf.async_read_string())
-      (6, _) => msg.visibility = reader |> @protobuf.async_read_enum() |> SymbolVisibility::from_enum |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      (5, _) => msg.reserved_name.push(reader |> @protobuf.read_string())
+      (6, _) => msg.visibility = reader |> @protobuf.read_enum() |> SymbolVisibility::from_enum |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -2097,42 +2942,42 @@ pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto::read_with_limit(read
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] EnumDescriptorProto::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] EnumDescriptorProto::write(self:Self, writer : W) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   for item in self.value {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(18UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.reserved_range {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(34UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   for item in self.reserved_name {
-    writer |> @protobuf.async_write_varint(42UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(42UL)
+    writer |> @protobuf.write_string(item)
 
   }
   match self.visibility {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(48UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(48UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
@@ -2184,6 +3029,98 @@ pub impl @json.FromJson for EnumDescriptorProto with from_json(json: Json, path:
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto::async_read(reader : R) -> EnumDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EnumDescriptorProto::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] EnumDescriptorProto::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = EnumDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      (2, _) => msg.value.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      EnumValueDescriptorProto::default()
+    } else {
+      EnumValueDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (3, _) => msg.options =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      EnumOptions::default()
+    } else {
+      EnumOptions::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (4, _) => msg.reserved_range.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      EnumDescriptorProto_EnumReservedRange::default()
+    } else {
+      EnumDescriptorProto_EnumReservedRange::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (5, _) => msg.reserved_name.push(reader |> @protobuf.async_read_string())
+      (6, _) => msg.visibility = reader |> @protobuf.async_read_enum() |> SymbolVisibility::from_enum |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] EnumDescriptorProto::async_write(self:Self, writer : W) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  for item in self.value {
+    writer |> @protobuf.async_write_varint(18UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.reserved_range {
+    writer |> @protobuf.async_write_varint(34UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  for item in self.reserved_name {
+    writer |> @protobuf.async_write_varint(42UL)
+    writer |> @protobuf.async_write_string(item)
+
+  }
+  match self.visibility {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(48UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+}
 pub(all) struct EnumValueDescriptorProto {
   mut name : String?
   mut number : Int?
@@ -2212,11 +3149,11 @@ pub impl Default for EnumValueDescriptorProto with default() -> EnumValueDescrip
     options : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] EnumValueDescriptorProto::read(reader : R) -> EnumValueDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] EnumValueDescriptorProto::read(reader : R) -> EnumValueDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
   EnumValueDescriptorProto::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] EnumValueDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumValueDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] EnumValueDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumValueDescriptorProto raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -2225,18 +3162,18 @@ pub async fn[R: @protobuf.AsyncReader] EnumValueDescriptorProto::read_with_limit
   let msg = EnumValueDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
-      (2, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
+      (2, _) => msg.number = reader |> @protobuf.read_int32() |> Some
       (3, _) => msg.options =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       EnumValueOptions::default()
     } else {
       EnumValueOptions::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -2246,27 +3183,27 @@ pub async fn[R: @protobuf.AsyncReader] EnumValueDescriptorProto::read_with_limit
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] EnumValueDescriptorProto::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] EnumValueDescriptorProto::write(self:Self, writer : W) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.number {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -2303,6 +3240,66 @@ pub impl @json.FromJson for EnumValueDescriptorProto with from_json(json: Json, 
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] EnumValueDescriptorProto::async_read(reader : R) -> EnumValueDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EnumValueDescriptorProto::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] EnumValueDescriptorProto::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumValueDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = EnumValueDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      (2, _) => msg.number = reader |> @protobuf.async_read_int32() |> Some
+      (3, _) => msg.options =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      EnumValueOptions::default()
+    } else {
+      EnumValueOptions::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] EnumValueDescriptorProto::async_write(self:Self, writer : W) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.number {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct ServiceDescriptorProto {
   mut name : String?
   mut method_ : Array[MethodDescriptorProto]
@@ -2328,11 +3325,11 @@ pub impl Default for ServiceDescriptorProto with default() -> ServiceDescriptorP
     options : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] ServiceDescriptorProto::read(reader : R) -> ServiceDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] ServiceDescriptorProto::read(reader : R) -> ServiceDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
   ServiceDescriptorProto::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] ServiceDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ServiceDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] ServiceDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ServiceDescriptorProto raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -2341,10 +3338,10 @@ pub async fn[R: @protobuf.AsyncReader] ServiceDescriptorProto::read_with_limit(r
   let msg = ServiceDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
       (2, _) => msg.method_.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       MethodDescriptorProto::default()
     } else {
@@ -2352,14 +3349,14 @@ pub async fn[R: @protobuf.AsyncReader] ServiceDescriptorProto::read_with_limit(r
     }
   })
       (3, _) => msg.options =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       ServiceOptions::default()
     } else {
       ServiceOptions::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -2369,24 +3366,24 @@ pub async fn[R: @protobuf.AsyncReader] ServiceDescriptorProto::read_with_limit(r
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] ServiceDescriptorProto::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] ServiceDescriptorProto::write(self:Self, writer : W) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   for item in self.method_ {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(18UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -2422,6 +3419,70 @@ pub impl @json.FromJson for ServiceDescriptorProto with from_json(json: Json, pa
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] ServiceDescriptorProto::async_read(reader : R) -> ServiceDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  ServiceDescriptorProto::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] ServiceDescriptorProto::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ServiceDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = ServiceDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      (2, _) => msg.method_.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      MethodDescriptorProto::default()
+    } else {
+      MethodDescriptorProto::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (3, _) => msg.options =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      ServiceOptions::default()
+    } else {
+      ServiceOptions::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] ServiceDescriptorProto::async_write(self:Self, writer : W) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  for item in self.method_ {
+    writer |> @protobuf.async_write_varint(18UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
 }
 pub(all) struct MethodDescriptorProto {
   mut name : String?
@@ -2469,11 +3530,11 @@ pub impl Default for MethodDescriptorProto with default() -> MethodDescriptorPro
     server_streaming : Some(false),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] MethodDescriptorProto::read(reader : R) -> MethodDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] MethodDescriptorProto::read(reader : R) -> MethodDescriptorProto raise {
   let reader = @protobuf.LimitedReader::new(reader)
   MethodDescriptorProto::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] MethodDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> MethodDescriptorProto raise {
+pub  fn[R: @protobuf.Reader] MethodDescriptorProto::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> MethodDescriptorProto raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -2482,21 +3543,21 @@ pub async fn[R: @protobuf.AsyncReader] MethodDescriptorProto::read_with_limit(re
   let msg = MethodDescriptorProto::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
-      (2, _) => msg.input_type = reader |> @protobuf.async_read_string() |> Some
-      (3, _) => msg.output_type = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
+      (2, _) => msg.input_type = reader |> @protobuf.read_string() |> Some
+      (3, _) => msg.output_type = reader |> @protobuf.read_string() |> Some
       (4, _) => msg.options =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       MethodOptions::default()
     } else {
       MethodOptions::read_with_limit(reader, limit=len)
     }
   } |> Some
-      (5, _) => msg.client_streaming = reader |> @protobuf.async_read_bool() |> Some
-      (6, _) => msg.server_streaming = reader |> @protobuf.async_read_bool() |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      (5, _) => msg.client_streaming = reader |> @protobuf.read_bool() |> Some
+      (6, _) => msg.server_streaming = reader |> @protobuf.read_bool() |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -2506,51 +3567,51 @@ pub async fn[R: @protobuf.AsyncReader] MethodDescriptorProto::read_with_limit(re
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] MethodDescriptorProto::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] MethodDescriptorProto::write(self:Self, writer : W) -> Unit raise {
   match self.name {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.input_type {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.output_type {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.options {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(34UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.client_streaming {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(40UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.server_streaming {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(48UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(48UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
@@ -2601,6 +3662,93 @@ pub impl @json.FromJson for MethodDescriptorProto with from_json(json: Json, pat
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] MethodDescriptorProto::async_read(reader : R) -> MethodDescriptorProto raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  MethodDescriptorProto::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] MethodDescriptorProto::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> MethodDescriptorProto raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = MethodDescriptorProto::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      (2, _) => msg.input_type = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.output_type = reader |> @protobuf.async_read_string() |> Some
+      (4, _) => msg.options =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      MethodOptions::default()
+    } else {
+      MethodOptions::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (5, _) => msg.client_streaming = reader |> @protobuf.async_read_bool() |> Some
+      (6, _) => msg.server_streaming = reader |> @protobuf.async_read_bool() |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] MethodDescriptorProto::async_write(self:Self, writer : W) -> Unit raise {
+  match self.name {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.input_type {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.output_type {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.options {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.client_streaming {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.server_streaming {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(48UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
 }
 pub(all) enum FileOptions_OptimizeMode {
   SPEED
@@ -2779,11 +3927,358 @@ pub impl Default for FileOptions with default() -> FileOptions {
     uninterpreted_option : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FileOptions::read(reader : R) -> FileOptions raise {
+pub  fn[R: @protobuf.Reader] FileOptions::read(reader : R) -> FileOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FileOptions::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FileOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FileOptions raise {
+pub  fn[R: @protobuf.Reader] FileOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FileOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FileOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.java_package = reader |> @protobuf.read_string() |> Some
+      (8, _) => msg.java_outer_classname = reader |> @protobuf.read_string() |> Some
+      (10, _) => msg.java_multiple_files = reader |> @protobuf.read_bool() |> Some
+      (20, _) => msg.java_generate_equals_and_hash = reader |> @protobuf.read_bool() |> Some
+      (27, _) => msg.java_string_check_utf8 = reader |> @protobuf.read_bool() |> Some
+      (9, _) => msg.optimize_for = reader |> @protobuf.read_enum() |> FileOptions_OptimizeMode::from_enum |> Some
+      (11, _) => msg.go_package = reader |> @protobuf.read_string() |> Some
+      (16, _) => msg.cc_generic_services = reader |> @protobuf.read_bool() |> Some
+      (17, _) => msg.java_generic_services = reader |> @protobuf.read_bool() |> Some
+      (18, _) => msg.py_generic_services = reader |> @protobuf.read_bool() |> Some
+      (23, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
+      (31, _) => msg.cc_enable_arenas = reader |> @protobuf.read_bool() |> Some
+      (36, _) => msg.objc_class_prefix = reader |> @protobuf.read_string() |> Some
+      (37, _) => msg.csharp_namespace = reader |> @protobuf.read_string() |> Some
+      (39, _) => msg.swift_prefix = reader |> @protobuf.read_string() |> Some
+      (40, _) => msg.php_class_prefix = reader |> @protobuf.read_string() |> Some
+      (41, _) => msg.php_namespace = reader |> @protobuf.read_string() |> Some
+      (44, _) => msg.php_metadata_namespace = reader |> @protobuf.read_string() |> Some
+      (45, _) => msg.ruby_package = reader |> @protobuf.read_string() |> Some
+      (50, _) => msg.features =   {
+    let len = reader |> @protobuf.read_int32()
+    if len == 0 {
+      FeatureSet::default()
+    } else {
+      FeatureSet::read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (999, _) => msg.uninterpreted_option.push(  {
+    let len = reader |> @protobuf.read_int32()
+    if len == 0 {
+      UninterpretedOption::default()
+    } else {
+      UninterpretedOption::read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub  fn[W: @protobuf.Writer] FileOptions::write(self:Self, writer : W) -> Unit raise {
+  match self.java_package {
+    Some(v) => {
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_string(v)
+
+    }
+    None => ()
+  }
+  match self.java_outer_classname {
+    Some(v) => {
+      writer |> @protobuf.write_varint(66UL);
+      writer |> @protobuf.write_string(v)
+
+    }
+    None => ()
+  }
+  match self.java_multiple_files {
+    Some(v) => {
+      writer |> @protobuf.write_varint(80UL);
+      writer |> @protobuf.write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.java_generate_equals_and_hash {
+    Some(v) => {
+      writer |> @protobuf.write_varint(160UL);
+      writer |> @protobuf.write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.java_string_check_utf8 {
+    Some(v) => {
+      writer |> @protobuf.write_varint(216UL);
+      writer |> @protobuf.write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.optimize_for {
+    Some(v) => {
+      writer |> @protobuf.write_varint(72UL);
+      writer |> @protobuf.write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.go_package {
+    Some(v) => {
+      writer |> @protobuf.write_varint(90UL);
+      writer |> @protobuf.write_string(v)
+
+    }
+    None => ()
+  }
+  match self.cc_generic_services {
+    Some(v) => {
+      writer |> @protobuf.write_varint(128UL);
+      writer |> @protobuf.write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.java_generic_services {
+    Some(v) => {
+      writer |> @protobuf.write_varint(136UL);
+      writer |> @protobuf.write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.py_generic_services {
+    Some(v) => {
+      writer |> @protobuf.write_varint(144UL);
+      writer |> @protobuf.write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.write_varint(184UL);
+      writer |> @protobuf.write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.cc_enable_arenas {
+    Some(v) => {
+      writer |> @protobuf.write_varint(248UL);
+      writer |> @protobuf.write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.objc_class_prefix {
+    Some(v) => {
+      writer |> @protobuf.write_varint(290UL);
+      writer |> @protobuf.write_string(v)
+
+    }
+    None => ()
+  }
+  match self.csharp_namespace {
+    Some(v) => {
+      writer |> @protobuf.write_varint(298UL);
+      writer |> @protobuf.write_string(v)
+
+    }
+    None => ()
+  }
+  match self.swift_prefix {
+    Some(v) => {
+      writer |> @protobuf.write_varint(314UL);
+      writer |> @protobuf.write_string(v)
+
+    }
+    None => ()
+  }
+  match self.php_class_prefix {
+    Some(v) => {
+      writer |> @protobuf.write_varint(322UL);
+      writer |> @protobuf.write_string(v)
+
+    }
+    None => ()
+  }
+  match self.php_namespace {
+    Some(v) => {
+      writer |> @protobuf.write_varint(330UL);
+      writer |> @protobuf.write_string(v)
+
+    }
+    None => ()
+  }
+  match self.php_metadata_namespace {
+    Some(v) => {
+      writer |> @protobuf.write_varint(354UL);
+      writer |> @protobuf.write_string(v)
+
+    }
+    None => ()
+  }
+  match self.ruby_package {
+    Some(v) => {
+      writer |> @protobuf.write_varint(362UL);
+      writer |> @protobuf.write_string(v)
+
+    }
+    None => ()
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.write_varint(402UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
+
+  }
+}
+pub impl ToJson for FileOptions with to_json(self) {
+  let json: Map[String, Json] = {}
+  match self.java_package {
+      Some(v) => json["javaPackage"] = v.to_json()
+      _ => ()
+    }
+  match self.java_outer_classname {
+      Some(v) => json["javaOuterClassname"] = v.to_json()
+      _ => ()
+    }
+  match self.java_multiple_files {
+      Some(v) if v != false => json["javaMultipleFiles"] = v.to_json()
+      _ => ()
+    }
+  match self.java_generate_equals_and_hash {
+      Some(v) => json["javaGenerateEqualsAndHash"] = v.to_json()
+      _ => ()
+    }
+  match self.java_string_check_utf8 {
+      Some(v) if v != false => json["javaStringCheckUtf8"] = v.to_json()
+      _ => ()
+    }
+  match self.optimize_for {
+      Some(v) if v != FileOptions_OptimizeMode::SPEED => json["optimizeFor"] = v.to_json()
+      _ => ()
+    }
+  match self.go_package {
+      Some(v) => json["goPackage"] = v.to_json()
+      _ => ()
+    }
+  match self.cc_generic_services {
+      Some(v) if v != false => json["ccGenericServices"] = v.to_json()
+      _ => ()
+    }
+  match self.java_generic_services {
+      Some(v) if v != false => json["javaGenericServices"] = v.to_json()
+      _ => ()
+    }
+  match self.py_generic_services {
+      Some(v) if v != false => json["pyGenericServices"] = v.to_json()
+      _ => ()
+    }
+  match self.deprecated {
+      Some(v) if v != false => json["deprecated"] = v.to_json()
+      _ => ()
+    }
+  match self.cc_enable_arenas {
+      Some(v) if v != true => json["ccEnableArenas"] = v.to_json()
+      _ => ()
+    }
+  match self.objc_class_prefix {
+      Some(v) => json["objcClassPrefix"] = v.to_json()
+      _ => ()
+    }
+  match self.csharp_namespace {
+      Some(v) => json["csharpNamespace"] = v.to_json()
+      _ => ()
+    }
+  match self.swift_prefix {
+      Some(v) => json["swiftPrefix"] = v.to_json()
+      _ => ()
+    }
+  match self.php_class_prefix {
+      Some(v) => json["phpClassPrefix"] = v.to_json()
+      _ => ()
+    }
+  match self.php_namespace {
+      Some(v) => json["phpNamespace"] = v.to_json()
+      _ => ()
+    }
+  match self.php_metadata_namespace {
+      Some(v) => json["phpMetadataNamespace"] = v.to_json()
+      _ => ()
+    }
+  match self.ruby_package {
+      Some(v) => json["rubyPackage"] = v.to_json()
+      _ => ()
+    }
+  match self.features {
+      Some(v) => json["features"] = v.to_json()
+      _ => ()
+    }
+  if self.uninterpreted_option != Default::default() {
+  json["uninterpretedOption"] = self.uninterpreted_option.to_json()
+  }
+  Json::object(json)
+}
+pub impl @json.FromJson for FileOptions with from_json(json: Json, path: @json.JsonPath) -> FileOptions raise {
+  guard json is Object(obj) else {
+    raise @json.JsonDecodeError((path, "Expected an object for FileOptions"))
+  }
+  let message = FileOptions::default()
+  for key, value in obj {
+    match (key, value) {
+      ("javaPackage", value) => message.java_package = Some(@json.from_json(value, path~))
+      ("javaOuterClassname", value) => message.java_outer_classname = Some(@json.from_json(value, path~))
+      ("javaMultipleFiles", value) => message.java_multiple_files = Some(@json.from_json(value, path~))
+      ("javaGenerateEqualsAndHash", value) => message.java_generate_equals_and_hash = Some(@json.from_json(value, path~))
+      ("javaStringCheckUtf8", value) => message.java_string_check_utf8 = Some(@json.from_json(value, path~))
+      ("optimizeFor", value) => message.optimize_for = Some(@json.from_json(value, path~))
+      ("goPackage", value) => message.go_package = Some(@json.from_json(value, path~))
+      ("ccGenericServices", value) => message.cc_generic_services = Some(@json.from_json(value, path~))
+      ("javaGenericServices", value) => message.java_generic_services = Some(@json.from_json(value, path~))
+      ("pyGenericServices", value) => message.py_generic_services = Some(@json.from_json(value, path~))
+      ("deprecated", value) => message.deprecated = Some(@json.from_json(value, path~))
+      ("ccEnableArenas", value) => message.cc_enable_arenas = Some(@json.from_json(value, path~))
+      ("objcClassPrefix", value) => message.objc_class_prefix = Some(@json.from_json(value, path~))
+      ("csharpNamespace", value) => message.csharp_namespace = Some(@json.from_json(value, path~))
+      ("swiftPrefix", value) => message.swift_prefix = Some(@json.from_json(value, path~))
+      ("phpClassPrefix", value) => message.php_class_prefix = Some(@json.from_json(value, path~))
+      ("phpNamespace", value) => message.php_namespace = Some(@json.from_json(value, path~))
+      ("phpMetadataNamespace", value) => message.php_metadata_namespace = Some(@json.from_json(value, path~))
+      ("rubyPackage", value) => message.ruby_package = Some(@json.from_json(value, path~))
+      ("features", value) => message.features = Some(@json.from_json(value, path~))
+      ("uninterpretedOption", Array(value)) => message.uninterpreted_option = value.map(v => 
+@json.from_json(v, path~))
+      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+    }
+  }
+  message
+}
+pub async fn[R: @protobuf.AsyncReader] FileOptions::async_read(reader : R) -> FileOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FileOptions::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FileOptions::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FileOptions raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -2817,7 +4312,7 @@ pub async fn[R: @protobuf.AsyncReader] FileOptions::read_with_limit(reader : @pr
     if len == 0 {
       FeatureSet::default()
     } else {
-      FeatureSet::read_with_limit(reader, limit=len)
+      FeatureSet::async_read_with_limit(reader, limit=len)
     }
   } |> Some
       (999, _) => msg.uninterpreted_option.push(  {
@@ -2825,7 +4320,7 @@ pub async fn[R: @protobuf.AsyncReader] FileOptions::read_with_limit(reader : @pr
     if len == 0 {
       UninterpretedOption::default()
     } else {
-      UninterpretedOption::read_with_limit(reader, limit=len)
+      UninterpretedOption::async_read_with_limit(reader, limit=len)
     }
   })
        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
@@ -2838,7 +4333,7 @@ pub async fn[R: @protobuf.AsyncReader] FileOptions::read_with_limit(reader : @pr
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FileOptions::write(self:Self, writer : W) -> Unit raise {
+pub async fn[W: @protobuf.AsyncWriter] FileOptions::async_write(self:Self, writer : W) -> Unit raise {
   match self.java_package {
     Some(v) => {
       writer |> @protobuf.async_write_varint(10UL);
@@ -2994,137 +4489,16 @@ pub async fn[W: @protobuf.AsyncWriter] FileOptions::write(self:Self, writer : W)
   match self.features {
     Some(v) => {
       writer |> @protobuf.async_write_varint(402UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
 
     }
     None => ()
   }
   for item in self.uninterpreted_option {
     writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
 
   }
-}
-pub impl ToJson for FileOptions with to_json(self) {
-  let json: Map[String, Json] = {}
-  match self.java_package {
-      Some(v) => json["javaPackage"] = v.to_json()
-      _ => ()
-    }
-  match self.java_outer_classname {
-      Some(v) => json["javaOuterClassname"] = v.to_json()
-      _ => ()
-    }
-  match self.java_multiple_files {
-      Some(v) if v != false => json["javaMultipleFiles"] = v.to_json()
-      _ => ()
-    }
-  match self.java_generate_equals_and_hash {
-      Some(v) => json["javaGenerateEqualsAndHash"] = v.to_json()
-      _ => ()
-    }
-  match self.java_string_check_utf8 {
-      Some(v) if v != false => json["javaStringCheckUtf8"] = v.to_json()
-      _ => ()
-    }
-  match self.optimize_for {
-      Some(v) if v != FileOptions_OptimizeMode::SPEED => json["optimizeFor"] = v.to_json()
-      _ => ()
-    }
-  match self.go_package {
-      Some(v) => json["goPackage"] = v.to_json()
-      _ => ()
-    }
-  match self.cc_generic_services {
-      Some(v) if v != false => json["ccGenericServices"] = v.to_json()
-      _ => ()
-    }
-  match self.java_generic_services {
-      Some(v) if v != false => json["javaGenericServices"] = v.to_json()
-      _ => ()
-    }
-  match self.py_generic_services {
-      Some(v) if v != false => json["pyGenericServices"] = v.to_json()
-      _ => ()
-    }
-  match self.deprecated {
-      Some(v) if v != false => json["deprecated"] = v.to_json()
-      _ => ()
-    }
-  match self.cc_enable_arenas {
-      Some(v) if v != true => json["ccEnableArenas"] = v.to_json()
-      _ => ()
-    }
-  match self.objc_class_prefix {
-      Some(v) => json["objcClassPrefix"] = v.to_json()
-      _ => ()
-    }
-  match self.csharp_namespace {
-      Some(v) => json["csharpNamespace"] = v.to_json()
-      _ => ()
-    }
-  match self.swift_prefix {
-      Some(v) => json["swiftPrefix"] = v.to_json()
-      _ => ()
-    }
-  match self.php_class_prefix {
-      Some(v) => json["phpClassPrefix"] = v.to_json()
-      _ => ()
-    }
-  match self.php_namespace {
-      Some(v) => json["phpNamespace"] = v.to_json()
-      _ => ()
-    }
-  match self.php_metadata_namespace {
-      Some(v) => json["phpMetadataNamespace"] = v.to_json()
-      _ => ()
-    }
-  match self.ruby_package {
-      Some(v) => json["rubyPackage"] = v.to_json()
-      _ => ()
-    }
-  match self.features {
-      Some(v) => json["features"] = v.to_json()
-      _ => ()
-    }
-  if self.uninterpreted_option != Default::default() {
-  json["uninterpretedOption"] = self.uninterpreted_option.to_json()
-  }
-  Json::object(json)
-}
-pub impl @json.FromJson for FileOptions with from_json(json: Json, path: @json.JsonPath) -> FileOptions raise {
-  guard json is Object(obj) else {
-    raise @json.JsonDecodeError((path, "Expected an object for FileOptions"))
-  }
-  let message = FileOptions::default()
-  for key, value in obj {
-    match (key, value) {
-      ("javaPackage", value) => message.java_package = Some(@json.from_json(value, path~))
-      ("javaOuterClassname", value) => message.java_outer_classname = Some(@json.from_json(value, path~))
-      ("javaMultipleFiles", value) => message.java_multiple_files = Some(@json.from_json(value, path~))
-      ("javaGenerateEqualsAndHash", value) => message.java_generate_equals_and_hash = Some(@json.from_json(value, path~))
-      ("javaStringCheckUtf8", value) => message.java_string_check_utf8 = Some(@json.from_json(value, path~))
-      ("optimizeFor", value) => message.optimize_for = Some(@json.from_json(value, path~))
-      ("goPackage", value) => message.go_package = Some(@json.from_json(value, path~))
-      ("ccGenericServices", value) => message.cc_generic_services = Some(@json.from_json(value, path~))
-      ("javaGenericServices", value) => message.java_generic_services = Some(@json.from_json(value, path~))
-      ("pyGenericServices", value) => message.py_generic_services = Some(@json.from_json(value, path~))
-      ("deprecated", value) => message.deprecated = Some(@json.from_json(value, path~))
-      ("ccEnableArenas", value) => message.cc_enable_arenas = Some(@json.from_json(value, path~))
-      ("objcClassPrefix", value) => message.objc_class_prefix = Some(@json.from_json(value, path~))
-      ("csharpNamespace", value) => message.csharp_namespace = Some(@json.from_json(value, path~))
-      ("swiftPrefix", value) => message.swift_prefix = Some(@json.from_json(value, path~))
-      ("phpClassPrefix", value) => message.php_class_prefix = Some(@json.from_json(value, path~))
-      ("phpNamespace", value) => message.php_namespace = Some(@json.from_json(value, path~))
-      ("phpMetadataNamespace", value) => message.php_metadata_namespace = Some(@json.from_json(value, path~))
-      ("rubyPackage", value) => message.ruby_package = Some(@json.from_json(value, path~))
-      ("features", value) => message.features = Some(@json.from_json(value, path~))
-      ("uninterpretedOption", Array(value)) => message.uninterpreted_option = value.map(v => 
-@json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
-    }
-  }
-  message
 }
 pub(all) struct MessageOptions {
   mut message_set_wire_format : Bool?
@@ -3175,11 +4549,11 @@ pub impl Default for MessageOptions with default() -> MessageOptions {
     uninterpreted_option : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] MessageOptions::read(reader : R) -> MessageOptions raise {
+pub  fn[R: @protobuf.Reader] MessageOptions::read(reader : R) -> MessageOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
   MessageOptions::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] MessageOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> MessageOptions raise {
+pub  fn[R: @protobuf.Reader] MessageOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> MessageOptions raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -3188,14 +4562,14 @@ pub async fn[R: @protobuf.AsyncReader] MessageOptions::read_with_limit(reader : 
   let msg = MessageOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.message_set_wire_format = reader |> @protobuf.async_read_bool() |> Some
-      (2, _) => msg.no_standard_descriptor_accessor = reader |> @protobuf.async_read_bool() |> Some
-      (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
-      (7, _) => msg.map_entry = reader |> @protobuf.async_read_bool() |> Some
-      (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @protobuf.async_read_bool() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.message_set_wire_format = reader |> @protobuf.read_bool() |> Some
+      (2, _) => msg.no_standard_descriptor_accessor = reader |> @protobuf.read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
+      (7, _) => msg.map_entry = reader |> @protobuf.read_bool() |> Some
+      (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @protobuf.read_bool() |> Some
       (12, _) => msg.features =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FeatureSet::default()
     } else {
@@ -3203,14 +4577,14 @@ pub async fn[R: @protobuf.AsyncReader] MessageOptions::read_with_limit(reader : 
     }
   } |> Some
       (999, _) => msg.uninterpreted_option.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       UninterpretedOption::default()
     } else {
       UninterpretedOption::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -3220,58 +4594,58 @@ pub async fn[R: @protobuf.AsyncReader] MessageOptions::read_with_limit(reader : 
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] MessageOptions::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] MessageOptions::write(self:Self, writer : W) -> Unit raise {
   match self.message_set_wire_format {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(8UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.no_standard_descriptor_accessor {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.map_entry {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(56UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(56UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.deprecated_legacy_json_field_conflicts {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(88UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(88UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(98UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(98UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -3325,6 +4699,106 @@ pub impl @json.FromJson for MessageOptions with from_json(json: Json, path: @jso
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] MessageOptions::async_read(reader : R) -> MessageOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  MessageOptions::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] MessageOptions::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> MessageOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = MessageOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.message_set_wire_format = reader |> @protobuf.async_read_bool() |> Some
+      (2, _) => msg.no_standard_descriptor_accessor = reader |> @protobuf.async_read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+      (7, _) => msg.map_entry = reader |> @protobuf.async_read_bool() |> Some
+      (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @protobuf.async_read_bool() |> Some
+      (12, _) => msg.features =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FeatureSet::default()
+    } else {
+      FeatureSet::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (999, _) => msg.uninterpreted_option.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      UninterpretedOption::default()
+    } else {
+      UninterpretedOption::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] MessageOptions::async_write(self:Self, writer : W) -> Unit raise {
+  match self.message_set_wire_format {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.no_standard_descriptor_accessor {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.map_entry {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(56UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.deprecated_legacy_json_field_conflicts {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(88UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(98UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
 }
 pub(all) enum FieldOptions_CType {
   STRING
@@ -3566,11 +5040,11 @@ pub impl Default for FieldOptions_EditionDefault with default() -> FieldOptions_
     value : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FieldOptions_EditionDefault::read(reader : R) -> FieldOptions_EditionDefault raise {
+pub  fn[R: @protobuf.Reader] FieldOptions_EditionDefault::read(reader : R) -> FieldOptions_EditionDefault raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FieldOptions_EditionDefault::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FieldOptions_EditionDefault::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldOptions_EditionDefault raise {
+pub  fn[R: @protobuf.Reader] FieldOptions_EditionDefault::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldOptions_EditionDefault raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -3579,10 +5053,10 @@ pub async fn[R: @protobuf.AsyncReader] FieldOptions_EditionDefault::read_with_li
   let msg = FieldOptions_EditionDefault::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (3, _) => msg.edition = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
-      (2, _) => msg.value = reader |> @protobuf.async_read_string() |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (3, _) => msg.edition = reader |> @protobuf.read_enum() |> Edition::from_enum |> Some
+      (2, _) => msg.value = reader |> @protobuf.read_string() |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -3592,19 +5066,19 @@ pub async fn[R: @protobuf.AsyncReader] FieldOptions_EditionDefault::read_with_li
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FieldOptions_EditionDefault::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] FieldOptions_EditionDefault::write(self:Self, writer : W) -> Unit raise {
   match self.edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
   }
   match self.value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
@@ -3635,6 +5109,50 @@ pub impl @json.FromJson for FieldOptions_EditionDefault with from_json(json: Jso
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] FieldOptions_EditionDefault::async_read(reader : R) -> FieldOptions_EditionDefault raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FieldOptions_EditionDefault::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FieldOptions_EditionDefault::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldOptions_EditionDefault raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FieldOptions_EditionDefault::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (3, _) => msg.edition = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
+      (2, _) => msg.value = reader |> @protobuf.async_read_string() |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] FieldOptions_EditionDefault::async_write(self:Self, writer : W) -> Unit raise {
+  match self.edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
 }
 pub(all) struct FieldOptions_FeatureSupport {
   mut edition_introduced : Edition?
@@ -3670,11 +5188,11 @@ pub impl Default for FieldOptions_FeatureSupport with default() -> FieldOptions_
     edition_removed : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FieldOptions_FeatureSupport::read(reader : R) -> FieldOptions_FeatureSupport raise {
+pub  fn[R: @protobuf.Reader] FieldOptions_FeatureSupport::read(reader : R) -> FieldOptions_FeatureSupport raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FieldOptions_FeatureSupport::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FieldOptions_FeatureSupport::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldOptions_FeatureSupport raise {
+pub  fn[R: @protobuf.Reader] FieldOptions_FeatureSupport::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldOptions_FeatureSupport raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -3683,12 +5201,12 @@ pub async fn[R: @protobuf.AsyncReader] FieldOptions_FeatureSupport::read_with_li
   let msg = FieldOptions_FeatureSupport::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.edition_introduced = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
-      (2, _) => msg.edition_deprecated = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
-      (3, _) => msg.deprecation_warning = reader |> @protobuf.async_read_string() |> Some
-      (4, _) => msg.edition_removed = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.edition_introduced = reader |> @protobuf.read_enum() |> Edition::from_enum |> Some
+      (2, _) => msg.edition_deprecated = reader |> @protobuf.read_enum() |> Edition::from_enum |> Some
+      (3, _) => msg.deprecation_warning = reader |> @protobuf.read_string() |> Some
+      (4, _) => msg.edition_removed = reader |> @protobuf.read_enum() |> Edition::from_enum |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -3698,35 +5216,35 @@ pub async fn[R: @protobuf.AsyncReader] FieldOptions_FeatureSupport::read_with_li
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FieldOptions_FeatureSupport::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] FieldOptions_FeatureSupport::write(self:Self, writer : W) -> Unit raise {
   match self.edition_introduced {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(8UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
   }
   match self.edition_deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
   }
   match self.deprecation_warning {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.edition_removed {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(32UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
@@ -3767,6 +5285,68 @@ pub impl @json.FromJson for FieldOptions_FeatureSupport with from_json(json: Jso
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] FieldOptions_FeatureSupport::async_read(reader : R) -> FieldOptions_FeatureSupport raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FieldOptions_FeatureSupport::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FieldOptions_FeatureSupport::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldOptions_FeatureSupport raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FieldOptions_FeatureSupport::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.edition_introduced = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
+      (2, _) => msg.edition_deprecated = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
+      (3, _) => msg.deprecation_warning = reader |> @protobuf.async_read_string() |> Some
+      (4, _) => msg.edition_removed = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] FieldOptions_FeatureSupport::async_write(self:Self, writer : W) -> Unit raise {
+  match self.edition_introduced {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.edition_deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.deprecation_warning {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.edition_removed {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
 }
 pub(all) struct FieldOptions {
   mut ctype : FieldOptions_CType?
@@ -3853,11 +5433,11 @@ pub impl Default for FieldOptions with default() -> FieldOptions {
     uninterpreted_option : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FieldOptions::read(reader : R) -> FieldOptions raise {
+pub  fn[R: @protobuf.Reader] FieldOptions::read(reader : R) -> FieldOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FieldOptions::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FieldOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldOptions raise {
+pub  fn[R: @protobuf.Reader] FieldOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldOptions raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -3866,19 +5446,19 @@ pub async fn[R: @protobuf.AsyncReader] FieldOptions::read_with_limit(reader : @p
   let msg = FieldOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.ctype = reader |> @protobuf.async_read_enum() |> FieldOptions_CType::from_enum |> Some
-      (2, _) => msg.packed = reader |> @protobuf.async_read_bool() |> Some
-      (6, _) => msg.jstype = reader |> @protobuf.async_read_enum() |> FieldOptions_JSType::from_enum |> Some
-      (5, _) => msg.lazy_ = reader |> @protobuf.async_read_bool() |> Some
-      (15, _) => msg.unverified_lazy = reader |> @protobuf.async_read_bool() |> Some
-      (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
-      (10, _) => msg.weak = reader |> @protobuf.async_read_bool() |> Some
-      (16, _) => msg.debug_redact = reader |> @protobuf.async_read_bool() |> Some
-      (17, _) => msg.retention = reader |> @protobuf.async_read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
-      (19, _) => msg.targets.push(reader |> @protobuf.async_read_enum() |> FieldOptions_OptionTargetType::from_enum)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.ctype = reader |> @protobuf.read_enum() |> FieldOptions_CType::from_enum |> Some
+      (2, _) => msg.packed = reader |> @protobuf.read_bool() |> Some
+      (6, _) => msg.jstype = reader |> @protobuf.read_enum() |> FieldOptions_JSType::from_enum |> Some
+      (5, _) => msg.lazy_ = reader |> @protobuf.read_bool() |> Some
+      (15, _) => msg.unverified_lazy = reader |> @protobuf.read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
+      (10, _) => msg.weak = reader |> @protobuf.read_bool() |> Some
+      (16, _) => msg.debug_redact = reader |> @protobuf.read_bool() |> Some
+      (17, _) => msg.retention = reader |> @protobuf.read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
+      (19, _) => msg.targets.push(reader |> @protobuf.read_enum() |> FieldOptions_OptionTargetType::from_enum)
       (20, _) => msg.edition_defaults.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FieldOptions_EditionDefault::default()
     } else {
@@ -3886,7 +5466,7 @@ pub async fn[R: @protobuf.AsyncReader] FieldOptions::read_with_limit(reader : @p
     }
   })
       (21, _) => msg.features =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FeatureSet::default()
     } else {
@@ -3894,7 +5474,7 @@ pub async fn[R: @protobuf.AsyncReader] FieldOptions::read_with_limit(reader : @p
     }
   } |> Some
       (22, _) => msg.feature_support =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FieldOptions_FeatureSupport::default()
     } else {
@@ -3902,14 +5482,14 @@ pub async fn[R: @protobuf.AsyncReader] FieldOptions::read_with_limit(reader : @p
     }
   } |> Some
       (999, _) => msg.uninterpreted_option.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       UninterpretedOption::default()
     } else {
       UninterpretedOption::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -3919,108 +5499,108 @@ pub async fn[R: @protobuf.AsyncReader] FieldOptions::read_with_limit(reader : @p
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FieldOptions::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] FieldOptions::write(self:Self, writer : W) -> Unit raise {
   match self.ctype {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(8UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
   }
   match self.packed {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.jstype {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(48UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(48UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
   }
   match self.lazy_ {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(40UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.unverified_lazy {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(120UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(120UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.weak {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(80UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(80UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.debug_redact {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(128UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(128UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.retention {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(136UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(136UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
   }
   for item in self.targets {
-    writer |> @protobuf.async_write_varint(152UL)
-    writer |> @protobuf.async_write_enum(item.to_enum())
+    writer |> @protobuf.write_varint(152UL)
+    writer |> @protobuf.write_enum(item.to_enum())
 
   }
   for item in self.edition_defaults {
-    writer |> @protobuf.async_write_varint(162UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(162UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(170UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(170UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.feature_support {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(178UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(178UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -4110,6 +5690,177 @@ pub impl @json.FromJson for FieldOptions with from_json(json: Json, path: @json.
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] FieldOptions::async_read(reader : R) -> FieldOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FieldOptions::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FieldOptions::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FieldOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FieldOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.ctype = reader |> @protobuf.async_read_enum() |> FieldOptions_CType::from_enum |> Some
+      (2, _) => msg.packed = reader |> @protobuf.async_read_bool() |> Some
+      (6, _) => msg.jstype = reader |> @protobuf.async_read_enum() |> FieldOptions_JSType::from_enum |> Some
+      (5, _) => msg.lazy_ = reader |> @protobuf.async_read_bool() |> Some
+      (15, _) => msg.unverified_lazy = reader |> @protobuf.async_read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+      (10, _) => msg.weak = reader |> @protobuf.async_read_bool() |> Some
+      (16, _) => msg.debug_redact = reader |> @protobuf.async_read_bool() |> Some
+      (17, _) => msg.retention = reader |> @protobuf.async_read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
+      (19, _) => msg.targets.push(reader |> @protobuf.async_read_enum() |> FieldOptions_OptionTargetType::from_enum)
+      (20, _) => msg.edition_defaults.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FieldOptions_EditionDefault::default()
+    } else {
+      FieldOptions_EditionDefault::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (21, _) => msg.features =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FeatureSet::default()
+    } else {
+      FeatureSet::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (22, _) => msg.feature_support =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FieldOptions_FeatureSupport::default()
+    } else {
+      FieldOptions_FeatureSupport::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (999, _) => msg.uninterpreted_option.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      UninterpretedOption::default()
+    } else {
+      UninterpretedOption::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] FieldOptions::async_write(self:Self, writer : W) -> Unit raise {
+  match self.ctype {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.packed {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.jstype {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(48UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.lazy_ {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.unverified_lazy {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(120UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.weak {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(80UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.debug_redact {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(128UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.retention {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(136UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  for item in self.targets {
+    writer |> @protobuf.async_write_varint(152UL)
+    writer |> @protobuf.async_write_enum(item.to_enum())
+
+  }
+  for item in self.edition_defaults {
+    writer |> @protobuf.async_write_varint(162UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(170UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.feature_support {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(178UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct OneofOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
@@ -4129,11 +5880,11 @@ pub impl Default for OneofOptions with default() -> OneofOptions {
     uninterpreted_option : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] OneofOptions::read(reader : R) -> OneofOptions raise {
+pub  fn[R: @protobuf.Reader] OneofOptions::read(reader : R) -> OneofOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
   OneofOptions::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] OneofOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> OneofOptions raise {
+pub  fn[R: @protobuf.Reader] OneofOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> OneofOptions raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -4142,9 +5893,9 @@ pub async fn[R: @protobuf.AsyncReader] OneofOptions::read_with_limit(reader : @p
   let msg = OneofOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (1, _) => msg.features =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FeatureSet::default()
     } else {
@@ -4152,14 +5903,14 @@ pub async fn[R: @protobuf.AsyncReader] OneofOptions::read_with_limit(reader : @p
     }
   } |> Some
       (999, _) => msg.uninterpreted_option.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       UninterpretedOption::default()
     } else {
       UninterpretedOption::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -4169,18 +5920,18 @@ pub async fn[R: @protobuf.AsyncReader] OneofOptions::read_with_limit(reader : @p
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] OneofOptions::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] OneofOptions::write(self:Self, writer : W) -> Unit raise {
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(10UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(10UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -4209,6 +5960,61 @@ pub impl @json.FromJson for OneofOptions with from_json(json: Json, path: @json.
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] OneofOptions::async_read(reader : R) -> OneofOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  OneofOptions::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] OneofOptions::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> OneofOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = OneofOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.features =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FeatureSet::default()
+    } else {
+      FeatureSet::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (999, _) => msg.uninterpreted_option.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      UninterpretedOption::default()
+    } else {
+      UninterpretedOption::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] OneofOptions::async_write(self:Self, writer : W) -> Unit raise {
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(10UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
 }
 pub(all) struct EnumOptions {
   mut allow_alias : Bool?
@@ -4247,11 +6053,11 @@ pub impl Default for EnumOptions with default() -> EnumOptions {
     uninterpreted_option : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] EnumOptions::read(reader : R) -> EnumOptions raise {
+pub  fn[R: @protobuf.Reader] EnumOptions::read(reader : R) -> EnumOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
   EnumOptions::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] EnumOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumOptions raise {
+pub  fn[R: @protobuf.Reader] EnumOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumOptions raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -4260,12 +6066,12 @@ pub async fn[R: @protobuf.AsyncReader] EnumOptions::read_with_limit(reader : @pr
   let msg = EnumOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (2, _) => msg.allow_alias = reader |> @protobuf.async_read_bool() |> Some
-      (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
-      (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @protobuf.async_read_bool() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (2, _) => msg.allow_alias = reader |> @protobuf.read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
+      (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @protobuf.read_bool() |> Some
       (7, _) => msg.features =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FeatureSet::default()
     } else {
@@ -4273,14 +6079,14 @@ pub async fn[R: @protobuf.AsyncReader] EnumOptions::read_with_limit(reader : @pr
     }
   } |> Some
       (999, _) => msg.uninterpreted_option.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       UninterpretedOption::default()
     } else {
       UninterpretedOption::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -4290,42 +6096,42 @@ pub async fn[R: @protobuf.AsyncReader] EnumOptions::read_with_limit(reader : @pr
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] EnumOptions::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] EnumOptions::write(self:Self, writer : W) -> Unit raise {
   match self.allow_alias {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(16UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.deprecated_legacy_json_field_conflicts {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(48UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(48UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(58UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(58UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -4370,6 +6176,88 @@ pub impl @json.FromJson for EnumOptions with from_json(json: Json, path: @json.J
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] EnumOptions::async_read(reader : R) -> EnumOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EnumOptions::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] EnumOptions::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = EnumOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (2, _) => msg.allow_alias = reader |> @protobuf.async_read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+      (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @protobuf.async_read_bool() |> Some
+      (7, _) => msg.features =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FeatureSet::default()
+    } else {
+      FeatureSet::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (999, _) => msg.uninterpreted_option.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      UninterpretedOption::default()
+    } else {
+      UninterpretedOption::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] EnumOptions::async_write(self:Self, writer : W) -> Unit raise {
+  match self.allow_alias {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(16UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.deprecated_legacy_json_field_conflicts {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(48UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(58UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct EnumValueOptions {
   mut deprecated : Bool?
   mut features : FeatureSet?
@@ -4407,11 +6295,11 @@ pub impl Default for EnumValueOptions with default() -> EnumValueOptions {
     uninterpreted_option : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] EnumValueOptions::read(reader : R) -> EnumValueOptions raise {
+pub  fn[R: @protobuf.Reader] EnumValueOptions::read(reader : R) -> EnumValueOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
   EnumValueOptions::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] EnumValueOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumValueOptions raise {
+pub  fn[R: @protobuf.Reader] EnumValueOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumValueOptions raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -4420,19 +6308,19 @@ pub async fn[R: @protobuf.AsyncReader] EnumValueOptions::read_with_limit(reader 
   let msg = EnumValueOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
       (2, _) => msg.features =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FeatureSet::default()
     } else {
       FeatureSet::read_with_limit(reader, limit=len)
     }
   } |> Some
-      (3, _) => msg.debug_redact = reader |> @protobuf.async_read_bool() |> Some
+      (3, _) => msg.debug_redact = reader |> @protobuf.read_bool() |> Some
       (4, _) => msg.feature_support =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FieldOptions_FeatureSupport::default()
     } else {
@@ -4440,14 +6328,14 @@ pub async fn[R: @protobuf.AsyncReader] EnumValueOptions::read_with_limit(reader 
     }
   } |> Some
       (999, _) => msg.uninterpreted_option.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       UninterpretedOption::default()
     } else {
       UninterpretedOption::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -4457,42 +6345,42 @@ pub async fn[R: @protobuf.AsyncReader] EnumValueOptions::read_with_limit(reader 
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] EnumValueOptions::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] EnumValueOptions::write(self:Self, writer : W) -> Unit raise {
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(8UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(8UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.debug_redact {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.feature_support {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(34UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -4537,6 +6425,95 @@ pub impl @json.FromJson for EnumValueOptions with from_json(json: Json, path: @j
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] EnumValueOptions::async_read(reader : R) -> EnumValueOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  EnumValueOptions::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] EnumValueOptions::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> EnumValueOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = EnumValueOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+      (2, _) => msg.features =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FeatureSet::default()
+    } else {
+      FeatureSet::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (3, _) => msg.debug_redact = reader |> @protobuf.async_read_bool() |> Some
+      (4, _) => msg.feature_support =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FieldOptions_FeatureSupport::default()
+    } else {
+      FieldOptions_FeatureSupport::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (999, _) => msg.uninterpreted_option.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      UninterpretedOption::default()
+    } else {
+      UninterpretedOption::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] EnumValueOptions::async_write(self:Self, writer : W) -> Unit raise {
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(8UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.debug_redact {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.feature_support {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct ServiceOptions {
   mut features : FeatureSet?
   mut deprecated : Bool?
@@ -4562,11 +6539,11 @@ pub impl Default for ServiceOptions with default() -> ServiceOptions {
     uninterpreted_option : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] ServiceOptions::read(reader : R) -> ServiceOptions raise {
+pub  fn[R: @protobuf.Reader] ServiceOptions::read(reader : R) -> ServiceOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
   ServiceOptions::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] ServiceOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ServiceOptions raise {
+pub  fn[R: @protobuf.Reader] ServiceOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ServiceOptions raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -4575,25 +6552,25 @@ pub async fn[R: @protobuf.AsyncReader] ServiceOptions::read_with_limit(reader : 
   let msg = ServiceOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (34, _) => msg.features =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FeatureSet::default()
     } else {
       FeatureSet::read_with_limit(reader, limit=len)
     }
   } |> Some
-      (33, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+      (33, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
       (999, _) => msg.uninterpreted_option.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       UninterpretedOption::default()
     } else {
       UninterpretedOption::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -4603,26 +6580,26 @@ pub async fn[R: @protobuf.AsyncReader] ServiceOptions::read_with_limit(reader : 
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] ServiceOptions::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] ServiceOptions::write(self:Self, writer : W) -> Unit raise {
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(274UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(274UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(264UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(264UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -4656,6 +6633,70 @@ pub impl @json.FromJson for ServiceOptions with from_json(json: Json, path: @jso
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] ServiceOptions::async_read(reader : R) -> ServiceOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  ServiceOptions::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] ServiceOptions::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> ServiceOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = ServiceOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (34, _) => msg.features =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FeatureSet::default()
+    } else {
+      FeatureSet::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (33, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+      (999, _) => msg.uninterpreted_option.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      UninterpretedOption::default()
+    } else {
+      UninterpretedOption::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] ServiceOptions::async_write(self:Self, writer : W) -> Unit raise {
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(274UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(264UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
 }
 pub(all) enum MethodOptions_IdempotencyLevel {
   IDEMPOTENCY_UNKNOWN
@@ -4732,11 +6773,11 @@ pub impl Default for MethodOptions with default() -> MethodOptions {
     uninterpreted_option : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] MethodOptions::read(reader : R) -> MethodOptions raise {
+pub  fn[R: @protobuf.Reader] MethodOptions::read(reader : R) -> MethodOptions raise {
   let reader = @protobuf.LimitedReader::new(reader)
   MethodOptions::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] MethodOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> MethodOptions raise {
+pub  fn[R: @protobuf.Reader] MethodOptions::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> MethodOptions raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -4745,11 +6786,11 @@ pub async fn[R: @protobuf.AsyncReader] MethodOptions::read_with_limit(reader : @
   let msg = MethodOptions::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (33, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
-      (34, _) => msg.idempotency_level = reader |> @protobuf.async_read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (33, _) => msg.deprecated = reader |> @protobuf.read_bool() |> Some
+      (34, _) => msg.idempotency_level = reader |> @protobuf.read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
       (35, _) => msg.features =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FeatureSet::default()
     } else {
@@ -4757,14 +6798,14 @@ pub async fn[R: @protobuf.AsyncReader] MethodOptions::read_with_limit(reader : @
     }
   } |> Some
       (999, _) => msg.uninterpreted_option.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       UninterpretedOption::default()
     } else {
       UninterpretedOption::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -4774,34 +6815,34 @@ pub async fn[R: @protobuf.AsyncReader] MethodOptions::read_with_limit(reader : @
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] MethodOptions::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] MethodOptions::write(self:Self, writer : W) -> Unit raise {
   match self.deprecated {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(264UL);
-      writer |> @protobuf.async_write_bool(v)
+      writer |> @protobuf.write_varint(264UL);
+      writer |> @protobuf.write_bool(v)
 
     }
     None => ()
   }
   match self.idempotency_level {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(272UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(272UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
   }
   match self.features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(282UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(282UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   for item in self.uninterpreted_option {
-    writer |> @protobuf.async_write_varint(7994UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(7994UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -4841,6 +6882,79 @@ pub impl @json.FromJson for MethodOptions with from_json(json: Json, path: @json
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] MethodOptions::async_read(reader : R) -> MethodOptions raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  MethodOptions::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] MethodOptions::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> MethodOptions raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = MethodOptions::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (33, _) => msg.deprecated = reader |> @protobuf.async_read_bool() |> Some
+      (34, _) => msg.idempotency_level = reader |> @protobuf.async_read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
+      (35, _) => msg.features =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FeatureSet::default()
+    } else {
+      FeatureSet::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (999, _) => msg.uninterpreted_option.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      UninterpretedOption::default()
+    } else {
+      UninterpretedOption::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] MethodOptions::async_write(self:Self, writer : W) -> Unit raise {
+  match self.deprecated {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(264UL);
+      writer |> @protobuf.async_write_bool(v)
+
+    }
+    None => ()
+  }
+  match self.idempotency_level {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(272UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(282UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  for item in self.uninterpreted_option {
+    writer |> @protobuf.async_write_varint(7994UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+}
 pub(all) struct UninterpretedOption_NamePart {
   mut name_part : String
   mut is_extension : Bool
@@ -4857,11 +6971,11 @@ pub impl Default for UninterpretedOption_NamePart with default() -> Uninterprete
     is_extension : Bool::default(),
   }
 }
-pub async fn[R: @protobuf.AsyncReader] UninterpretedOption_NamePart::read(reader : R) -> UninterpretedOption_NamePart raise {
+pub  fn[R: @protobuf.Reader] UninterpretedOption_NamePart::read(reader : R) -> UninterpretedOption_NamePart raise {
   let reader = @protobuf.LimitedReader::new(reader)
   UninterpretedOption_NamePart::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] UninterpretedOption_NamePart::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> UninterpretedOption_NamePart raise {
+pub  fn[R: @protobuf.Reader] UninterpretedOption_NamePart::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> UninterpretedOption_NamePart raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -4870,10 +6984,10 @@ pub async fn[R: @protobuf.AsyncReader] UninterpretedOption_NamePart::read_with_l
   let msg = UninterpretedOption_NamePart::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => msg.name_part = reader |> @protobuf.async_read_string()
-      (2, _) => msg.is_extension = reader |> @protobuf.async_read_bool()
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name_part = reader |> @protobuf.read_string()
+      (2, _) => msg.is_extension = reader |> @protobuf.read_bool()
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -4883,11 +6997,11 @@ pub async fn[R: @protobuf.AsyncReader] UninterpretedOption_NamePart::read_with_l
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] UninterpretedOption_NamePart::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL);
-  writer |> @protobuf.async_write_string(self.name_part)
-  writer |> @protobuf.async_write_varint(16UL);
-  writer |> @protobuf.async_write_bool(self.is_extension)
+pub  fn[W: @protobuf.Writer] UninterpretedOption_NamePart::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.name_part)
+  writer |> @protobuf.write_varint(16UL);
+  writer |> @protobuf.write_bool(self.is_extension)
 }
 pub impl ToJson for UninterpretedOption_NamePart with to_json(self) {
   let json: Map[String, Json] = {}
@@ -4912,6 +7026,38 @@ pub impl @json.FromJson for UninterpretedOption_NamePart with from_json(json: Js
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] UninterpretedOption_NamePart::async_read(reader : R) -> UninterpretedOption_NamePart raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  UninterpretedOption_NamePart::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] UninterpretedOption_NamePart::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> UninterpretedOption_NamePart raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = UninterpretedOption_NamePart::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name_part = reader |> @protobuf.async_read_string()
+      (2, _) => msg.is_extension = reader |> @protobuf.async_read_bool()
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] UninterpretedOption_NamePart::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.name_part)
+  writer |> @protobuf.async_write_varint(16UL);
+  writer |> @protobuf.async_write_bool(self.is_extension)
 }
 pub(all) struct UninterpretedOption {
   mut name : Array[UninterpretedOption_NamePart]
@@ -4962,11 +7108,11 @@ pub impl Default for UninterpretedOption with default() -> UninterpretedOption {
     aggregate_value : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] UninterpretedOption::read(reader : R) -> UninterpretedOption raise {
+pub  fn[R: @protobuf.Reader] UninterpretedOption::read(reader : R) -> UninterpretedOption raise {
   let reader = @protobuf.LimitedReader::new(reader)
   UninterpretedOption::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] UninterpretedOption::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> UninterpretedOption raise {
+pub  fn[R: @protobuf.Reader] UninterpretedOption::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> UninterpretedOption raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -4975,22 +7121,22 @@ pub async fn[R: @protobuf.AsyncReader] UninterpretedOption::read_with_limit(read
   let msg = UninterpretedOption::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (2, _) => msg.name.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       UninterpretedOption_NamePart::default()
     } else {
       UninterpretedOption_NamePart::read_with_limit(reader, limit=len)
     }
   })
-      (3, _) => msg.identifier_value = reader |> @protobuf.async_read_string() |> Some
-      (4, _) => msg.positive_int_value = reader |> @protobuf.async_read_uint64() |> Some
-      (5, _) => msg.negative_int_value = reader |> @protobuf.async_read_int64() |> Some
-      (6, _) => msg.double_value = reader |> @protobuf.async_read_double() |> Some
-      (7, _) => msg.string_value = reader |> @protobuf.async_read_bytes() |> Some
-      (8, _) => msg.aggregate_value = reader |> @protobuf.async_read_string() |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      (3, _) => msg.identifier_value = reader |> @protobuf.read_string() |> Some
+      (4, _) => msg.positive_int_value = reader |> @protobuf.read_uint64() |> Some
+      (5, _) => msg.negative_int_value = reader |> @protobuf.read_int64() |> Some
+      (6, _) => msg.double_value = reader |> @protobuf.read_double() |> Some
+      (7, _) => msg.string_value = reader |> @protobuf.read_bytes() |> Some
+      (8, _) => msg.aggregate_value = reader |> @protobuf.read_string() |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -5000,56 +7146,56 @@ pub async fn[R: @protobuf.AsyncReader] UninterpretedOption::read_with_limit(read
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] UninterpretedOption::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] UninterpretedOption::write(self:Self, writer : W) -> Unit raise {
   for item in self.name {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(18UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.identifier_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.positive_int_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL);
-      writer |> @protobuf.async_write_uint64(v)
+      writer |> @protobuf.write_varint(32UL);
+      writer |> @protobuf.write_uint64(v)
 
     }
     None => ()
   }
   match self.negative_int_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL);
-      writer |> @protobuf.async_write_int64(v)
+      writer |> @protobuf.write_varint(40UL);
+      writer |> @protobuf.write_int64(v)
 
     }
     None => ()
   }
   match self.double_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(49UL);
-      writer |> @protobuf.async_write_double(v)
+      writer |> @protobuf.write_varint(49UL);
+      writer |> @protobuf.write_double(v)
 
     }
     None => ()
   }
   match self.string_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(58UL);
-      writer |> @protobuf.async_write_bytes(v)
+      writer |> @protobuf.write_varint(58UL);
+      writer |> @protobuf.write_bytes(v)
 
     }
     None => ()
   }
   match self.aggregate_value {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(66UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(66UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
@@ -5105,6 +7251,99 @@ pub impl @json.FromJson for UninterpretedOption with from_json(json: Json, path:
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] UninterpretedOption::async_read(reader : R) -> UninterpretedOption raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  UninterpretedOption::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] UninterpretedOption::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> UninterpretedOption raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = UninterpretedOption::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (2, _) => msg.name.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      UninterpretedOption_NamePart::default()
+    } else {
+      UninterpretedOption_NamePart::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (3, _) => msg.identifier_value = reader |> @protobuf.async_read_string() |> Some
+      (4, _) => msg.positive_int_value = reader |> @protobuf.async_read_uint64() |> Some
+      (5, _) => msg.negative_int_value = reader |> @protobuf.async_read_int64() |> Some
+      (6, _) => msg.double_value = reader |> @protobuf.async_read_double() |> Some
+      (7, _) => msg.string_value = reader |> @protobuf.async_read_bytes() |> Some
+      (8, _) => msg.aggregate_value = reader |> @protobuf.async_read_string() |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] UninterpretedOption::async_write(self:Self, writer : W) -> Unit raise {
+  for item in self.name {
+    writer |> @protobuf.async_write_varint(18UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.identifier_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.positive_int_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL);
+      writer |> @protobuf.async_write_uint64(v)
+
+    }
+    None => ()
+  }
+  match self.negative_int_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL);
+      writer |> @protobuf.async_write_int64(v)
+
+    }
+    None => ()
+  }
+  match self.double_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(49UL);
+      writer |> @protobuf.async_write_double(v)
+
+    }
+    None => ()
+  }
+  match self.string_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(58UL);
+      writer |> @protobuf.async_write_bytes(v)
+
+    }
+    None => ()
+  }
+  match self.aggregate_value {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(66UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
 }
 pub(all) enum FeatureSet_FieldPresence {
   FIELD_PRESENCE_UNKNOWN
@@ -5485,20 +7724,29 @@ pub impl Default for FeatureSet_VisibilityFeature with default() -> FeatureSet_V
   FeatureSet_VisibilityFeature::{
   }
 }
-pub async fn[R] FeatureSet_VisibilityFeature::read(reader : R) -> FeatureSet_VisibilityFeature noraise {
+pub  fn[R] FeatureSet_VisibilityFeature::read(reader : R) -> FeatureSet_VisibilityFeature noraise {
   let reader = @protobuf.LimitedReader::new(reader)
   FeatureSet_VisibilityFeature::read_with_limit(reader)
 }
-pub async fn[R] FeatureSet_VisibilityFeature::read_with_limit(_ : @protobuf.LimitedReader[R], _limit ?: Int) -> FeatureSet_VisibilityFeature noraise {
+pub  fn[R] FeatureSet_VisibilityFeature::read_with_limit(_ : @protobuf.LimitedReader[R], _limit ?: Int) -> FeatureSet_VisibilityFeature noraise {
   FeatureSet_VisibilityFeature::default()
 }
-pub async fn[W] FeatureSet_VisibilityFeature::write(_: Self, _ : W) -> Unit noraise {
+pub  fn[W: @protobuf.Writer] FeatureSet_VisibilityFeature::write(_: Self, _ : W) -> Unit noraise {
 }
 pub impl ToJson for FeatureSet_VisibilityFeature with to_json(_) {
   {}
 }
 pub impl @json.FromJson for FeatureSet_VisibilityFeature with from_json(json: Json, path: @json.JsonPath) -> FeatureSet_VisibilityFeature noraise {
   FeatureSet_VisibilityFeature::default()
+}
+pub async fn[R] FeatureSet_VisibilityFeature::async_read(reader : R) -> FeatureSet_VisibilityFeature noraise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FeatureSet_VisibilityFeature::async_read_with_limit(reader)
+}
+pub async fn[R] FeatureSet_VisibilityFeature::async_read_with_limit(_ : @protobuf.LimitedReader[R], _limit ?: Int) -> FeatureSet_VisibilityFeature noraise {
+  FeatureSet_VisibilityFeature::default()
+}
+pub async fn[W: @protobuf.AsyncWriter] FeatureSet_VisibilityFeature::async_write(_: Self, _ : W) -> Unit noraise {
 }
 pub(all) struct FeatureSet {
   mut field_presence : FeatureSet_FieldPresence?
@@ -5558,11 +7806,165 @@ pub impl Default for FeatureSet with default() -> FeatureSet {
     default_symbol_visibility : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FeatureSet::read(reader : R) -> FeatureSet raise {
+pub  fn[R: @protobuf.Reader] FeatureSet::read(reader : R) -> FeatureSet raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FeatureSet::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FeatureSet::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FeatureSet raise {
+pub  fn[R: @protobuf.Reader] FeatureSet::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FeatureSet raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FeatureSet::default()
+  try {
+    for {
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.field_presence = reader |> @protobuf.read_enum() |> FeatureSet_FieldPresence::from_enum |> Some
+      (2, _) => msg.enum_type = reader |> @protobuf.read_enum() |> FeatureSet_EnumType::from_enum |> Some
+      (3, _) => msg.repeated_field_encoding = reader |> @protobuf.read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some
+      (4, _) => msg.utf8_validation = reader |> @protobuf.read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some
+      (5, _) => msg.message_encoding = reader |> @protobuf.read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some
+      (6, _) => msg.json_format = reader |> @protobuf.read_enum() |> FeatureSet_JsonFormat::from_enum |> Some
+      (7, _) => msg.enforce_naming_style = reader |> @protobuf.read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some
+      (8, _) => msg.default_symbol_visibility = reader |> @protobuf.read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub  fn[W: @protobuf.Writer] FeatureSet::write(self:Self, writer : W) -> Unit raise {
+  match self.field_presence {
+    Some(v) => {
+      writer |> @protobuf.write_varint(8UL);
+      writer |> @protobuf.write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.enum_type {
+    Some(v) => {
+      writer |> @protobuf.write_varint(16UL);
+      writer |> @protobuf.write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.repeated_field_encoding {
+    Some(v) => {
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.utf8_validation {
+    Some(v) => {
+      writer |> @protobuf.write_varint(32UL);
+      writer |> @protobuf.write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.message_encoding {
+    Some(v) => {
+      writer |> @protobuf.write_varint(40UL);
+      writer |> @protobuf.write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.json_format {
+    Some(v) => {
+      writer |> @protobuf.write_varint(48UL);
+      writer |> @protobuf.write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.enforce_naming_style {
+    Some(v) => {
+      writer |> @protobuf.write_varint(56UL);
+      writer |> @protobuf.write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.default_symbol_visibility {
+    Some(v) => {
+      writer |> @protobuf.write_varint(64UL);
+      writer |> @protobuf.write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+}
+pub impl ToJson for FeatureSet with to_json(self) {
+  let json: Map[String, Json] = {}
+  match self.field_presence {
+      Some(v) => json["fieldPresence"] = v.to_json()
+      _ => ()
+    }
+  match self.enum_type {
+      Some(v) => json["enumType"] = v.to_json()
+      _ => ()
+    }
+  match self.repeated_field_encoding {
+      Some(v) => json["repeatedFieldEncoding"] = v.to_json()
+      _ => ()
+    }
+  match self.utf8_validation {
+      Some(v) => json["utf8Validation"] = v.to_json()
+      _ => ()
+    }
+  match self.message_encoding {
+      Some(v) => json["messageEncoding"] = v.to_json()
+      _ => ()
+    }
+  match self.json_format {
+      Some(v) => json["jsonFormat"] = v.to_json()
+      _ => ()
+    }
+  match self.enforce_naming_style {
+      Some(v) => json["enforceNamingStyle"] = v.to_json()
+      _ => ()
+    }
+  match self.default_symbol_visibility {
+      Some(v) => json["defaultSymbolVisibility"] = v.to_json()
+      _ => ()
+    }
+  Json::object(json)
+}
+pub impl @json.FromJson for FeatureSet with from_json(json: Json, path: @json.JsonPath) -> FeatureSet raise {
+  guard json is Object(obj) else {
+    raise @json.JsonDecodeError((path, "Expected an object for FeatureSet"))
+  }
+  let message = FeatureSet::default()
+  for key, value in obj {
+    match (key, value) {
+      ("fieldPresence", value) => message.field_presence = Some(@json.from_json(value, path~))
+      ("enumType", value) => message.enum_type = Some(@json.from_json(value, path~))
+      ("repeatedFieldEncoding", value) => message.repeated_field_encoding = Some(@json.from_json(value, path~))
+      ("utf8Validation", value) => message.utf8_validation = Some(@json.from_json(value, path~))
+      ("messageEncoding", value) => message.message_encoding = Some(@json.from_json(value, path~))
+      ("jsonFormat", value) => message.json_format = Some(@json.from_json(value, path~))
+      ("enforceNamingStyle", value) => message.enforce_naming_style = Some(@json.from_json(value, path~))
+      ("defaultSymbolVisibility", value) => message.default_symbol_visibility = Some(@json.from_json(value, path~))
+      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+    }
+  }
+  message
+}
+pub async fn[R: @protobuf.AsyncReader] FeatureSet::async_read(reader : R) -> FeatureSet raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FeatureSet::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FeatureSet::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FeatureSet raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -5590,7 +7992,7 @@ pub async fn[R: @protobuf.AsyncReader] FeatureSet::read_with_limit(reader : @pro
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FeatureSet::write(self:Self, writer : W) -> Unit raise {
+pub async fn[W: @protobuf.AsyncWriter] FeatureSet::async_write(self:Self, writer : W) -> Unit raise {
   match self.field_presence {
     Some(v) => {
       writer |> @protobuf.async_write_varint(8UL);
@@ -5656,62 +8058,6 @@ pub async fn[W: @protobuf.AsyncWriter] FeatureSet::write(self:Self, writer : W) 
     None => ()
   }
 }
-pub impl ToJson for FeatureSet with to_json(self) {
-  let json: Map[String, Json] = {}
-  match self.field_presence {
-      Some(v) => json["fieldPresence"] = v.to_json()
-      _ => ()
-    }
-  match self.enum_type {
-      Some(v) => json["enumType"] = v.to_json()
-      _ => ()
-    }
-  match self.repeated_field_encoding {
-      Some(v) => json["repeatedFieldEncoding"] = v.to_json()
-      _ => ()
-    }
-  match self.utf8_validation {
-      Some(v) => json["utf8Validation"] = v.to_json()
-      _ => ()
-    }
-  match self.message_encoding {
-      Some(v) => json["messageEncoding"] = v.to_json()
-      _ => ()
-    }
-  match self.json_format {
-      Some(v) => json["jsonFormat"] = v.to_json()
-      _ => ()
-    }
-  match self.enforce_naming_style {
-      Some(v) => json["enforceNamingStyle"] = v.to_json()
-      _ => ()
-    }
-  match self.default_symbol_visibility {
-      Some(v) => json["defaultSymbolVisibility"] = v.to_json()
-      _ => ()
-    }
-  Json::object(json)
-}
-pub impl @json.FromJson for FeatureSet with from_json(json: Json, path: @json.JsonPath) -> FeatureSet raise {
-  guard json is Object(obj) else {
-    raise @json.JsonDecodeError((path, "Expected an object for FeatureSet"))
-  }
-  let message = FeatureSet::default()
-  for key, value in obj {
-    match (key, value) {
-      ("fieldPresence", value) => message.field_presence = Some(@json.from_json(value, path~))
-      ("enumType", value) => message.enum_type = Some(@json.from_json(value, path~))
-      ("repeatedFieldEncoding", value) => message.repeated_field_encoding = Some(@json.from_json(value, path~))
-      ("utf8Validation", value) => message.utf8_validation = Some(@json.from_json(value, path~))
-      ("messageEncoding", value) => message.message_encoding = Some(@json.from_json(value, path~))
-      ("jsonFormat", value) => message.json_format = Some(@json.from_json(value, path~))
-      ("enforceNamingStyle", value) => message.enforce_naming_style = Some(@json.from_json(value, path~))
-      ("defaultSymbolVisibility", value) => message.default_symbol_visibility = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
-    }
-  }
-  message
-}
 pub(all) struct FeatureSetDefaults_FeatureSetEditionDefault {
   mut edition : Edition?
   mut overridable_features : FeatureSet?
@@ -5740,11 +8086,11 @@ pub impl Default for FeatureSetDefaults_FeatureSetEditionDefault with default() 
     fixed_features : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::read(reader : R) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
+pub  fn[R: @protobuf.Reader] FeatureSetDefaults_FeatureSetEditionDefault::read(reader : R) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FeatureSetDefaults_FeatureSetEditionDefault::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
+pub  fn[R: @protobuf.Reader] FeatureSetDefaults_FeatureSetEditionDefault::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -5753,10 +8099,10 @@ pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefau
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (3, _) => msg.edition = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
+      match (reader |> @protobuf.read_tag()) {
+      (3, _) => msg.edition = reader |> @protobuf.read_enum() |> Edition::from_enum |> Some
       (4, _) => msg.overridable_features =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FeatureSet::default()
     } else {
@@ -5764,14 +8110,14 @@ pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefau
     }
   } |> Some
       (5, _) => msg.fixed_features =   {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FeatureSet::default()
     } else {
       FeatureSet::read_with_limit(reader, limit=len)
     }
   } |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -5781,27 +8127,27 @@ pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefau
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FeatureSetDefaults_FeatureSetEditionDefault::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] FeatureSetDefaults_FeatureSetEditionDefault::write(self:Self, writer : W) -> Unit raise {
   match self.edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
   }
   match self.overridable_features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(34UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
   }
   match self.fixed_features {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(42UL);
-      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.write(writer)
+      writer |> @protobuf.write_varint(42UL);
+      writer |> @protobuf.write_uint32(@protobuf.size_of(v)); v.write(writer)
 
     }
     None => ()
@@ -5838,6 +8184,73 @@ pub impl @json.FromJson for FeatureSetDefaults_FeatureSetEditionDefault with fro
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::async_read(reader : R) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FeatureSetDefaults_FeatureSetEditionDefault::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults_FeatureSetEditionDefault::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (3, _) => msg.edition = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
+      (4, _) => msg.overridable_features =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FeatureSet::default()
+    } else {
+      FeatureSet::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+      (5, _) => msg.fixed_features =   {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FeatureSet::default()
+    } else {
+      FeatureSet::async_read_with_limit(reader, limit=len)
+    }
+  } |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] FeatureSetDefaults_FeatureSetEditionDefault::async_write(self:Self, writer : W) -> Unit raise {
+  match self.edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.overridable_features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+  match self.fixed_features {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(42UL);
+      writer |> @protobuf.async_write_uint32(@protobuf.size_of(v)); v.async_write(writer)
+
+    }
+    None => ()
+  }
+}
 pub(all) struct FeatureSetDefaults {
   mut defaults : Array[FeatureSetDefaults_FeatureSetEditionDefault]
   mut minimum_edition : Edition?
@@ -5863,11 +8276,11 @@ pub impl Default for FeatureSetDefaults with default() -> FeatureSetDefaults {
     maximum_edition : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults::read(reader : R) -> FeatureSetDefaults raise {
+pub  fn[R: @protobuf.Reader] FeatureSetDefaults::read(reader : R) -> FeatureSetDefaults raise {
   let reader = @protobuf.LimitedReader::new(reader)
   FeatureSetDefaults::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FeatureSetDefaults raise {
+pub  fn[R: @protobuf.Reader] FeatureSetDefaults::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FeatureSetDefaults raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -5876,18 +8289,18 @@ pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults::read_with_limit(reade
   let msg = FeatureSetDefaults::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (1, _) => msg.defaults.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       FeatureSetDefaults_FeatureSetEditionDefault::default()
     } else {
       FeatureSetDefaults_FeatureSetEditionDefault::read_with_limit(reader, limit=len)
     }
   })
-      (4, _) => msg.minimum_edition = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
-      (5, _) => msg.maximum_edition = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      (4, _) => msg.minimum_edition = reader |> @protobuf.read_enum() |> Edition::from_enum |> Some
+      (5, _) => msg.maximum_edition = reader |> @protobuf.read_enum() |> Edition::from_enum |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -5897,24 +8310,24 @@ pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults::read_with_limit(reade
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] FeatureSetDefaults::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] FeatureSetDefaults::write(self:Self, writer : W) -> Unit raise {
   for item in self.defaults {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
   match self.minimum_edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(32UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
   }
   match self.maximum_edition {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(40UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
@@ -5951,6 +8364,63 @@ pub impl @json.FromJson for FeatureSetDefaults with from_json(json: Json, path: 
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults::async_read(reader : R) -> FeatureSetDefaults raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  FeatureSetDefaults::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] FeatureSetDefaults::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> FeatureSetDefaults raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = FeatureSetDefaults::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.defaults.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      FeatureSetDefaults_FeatureSetEditionDefault::default()
+    } else {
+      FeatureSetDefaults_FeatureSetEditionDefault::async_read_with_limit(reader, limit=len)
+    }
+  })
+      (4, _) => msg.minimum_edition = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
+      (5, _) => msg.maximum_edition = reader |> @protobuf.async_read_enum() |> Edition::from_enum |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] FeatureSetDefaults::async_write(self:Self, writer : W) -> Unit raise {
+  for item in self.defaults {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
+  match self.minimum_edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+  match self.maximum_edition {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+}
 pub(all) struct SourceCodeInfo_Location {
   mut path : Array[Int]
   mut span : Array[Int]
@@ -5982,11 +8452,11 @@ pub impl Default for SourceCodeInfo_Location with default() -> SourceCodeInfo_Lo
     leading_detached_comments : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo_Location::read(reader : R) -> SourceCodeInfo_Location raise {
+pub  fn[R: @protobuf.Reader] SourceCodeInfo_Location::read(reader : R) -> SourceCodeInfo_Location raise {
   let reader = @protobuf.LimitedReader::new(reader)
   SourceCodeInfo_Location::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo_Location::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> SourceCodeInfo_Location raise {
+pub  fn[R: @protobuf.Reader] SourceCodeInfo_Location::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> SourceCodeInfo_Location raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -5995,13 +8465,13 @@ pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo_Location::read_with_limit(
   let msg = SourceCodeInfo_Location::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => { msg.path.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter()) }
-      (2, _) => { msg.span.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter()) }
-      (3, _) => msg.leading_comments = reader |> @protobuf.async_read_string() |> Some
-      (4, _) => msg.trailing_comments = reader |> @protobuf.async_read_string() |> Some
-      (6, _) => msg.leading_detached_comments.push(reader |> @protobuf.async_read_string())
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => { msg.path.push_iter((reader |> @protobuf.read_packed(@protobuf.read_int32, None)).iter()) }
+      (2, _) => { msg.span.push_iter((reader |> @protobuf.read_packed(@protobuf.read_int32, None)).iter()) }
+      (3, _) => msg.leading_comments = reader |> @protobuf.read_string() |> Some
+      (4, _) => msg.trailing_comments = reader |> @protobuf.read_string() |> Some
+      (6, _) => msg.leading_detached_comments.push(reader |> @protobuf.read_string())
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -6011,40 +8481,40 @@ pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo_Location::read_with_limit(
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] SourceCodeInfo_Location::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL)
+pub  fn[W: @protobuf.Writer] SourceCodeInfo_Location::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL)
   let size = self.path.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.path {
-      writer |> @protobuf.async_write_int32(item)
+      writer |> @protobuf.write_int32(item)
 
   }
-  writer |> @protobuf.async_write_varint(18UL)
+  writer |> @protobuf.write_varint(18UL)
   let size = self.span.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.span {
-      writer |> @protobuf.async_write_int32(item)
+      writer |> @protobuf.write_int32(item)
 
   }
   match self.leading_comments {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(26UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(26UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.trailing_comments {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(34UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(34UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   for item in self.leading_detached_comments {
-    writer |> @protobuf.async_write_varint(50UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @protobuf.write_varint(50UL)
+    writer |> @protobuf.write_string(item)
 
   }
 }
@@ -6089,6 +8559,72 @@ pub impl @json.FromJson for SourceCodeInfo_Location with from_json(json: Json, p
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo_Location::async_read(reader : R) -> SourceCodeInfo_Location raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  SourceCodeInfo_Location::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo_Location::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> SourceCodeInfo_Location raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = SourceCodeInfo_Location::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => { msg.path.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter()) }
+      (2, _) => { msg.span.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter()) }
+      (3, _) => msg.leading_comments = reader |> @protobuf.async_read_string() |> Some
+      (4, _) => msg.trailing_comments = reader |> @protobuf.async_read_string() |> Some
+      (6, _) => msg.leading_detached_comments.push(reader |> @protobuf.async_read_string())
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] SourceCodeInfo_Location::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL)
+  let size = self.path.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.path {
+      writer |> @protobuf.async_write_int32(item)
+
+  }
+  writer |> @protobuf.async_write_varint(18UL)
+  let size = self.span.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.span {
+      writer |> @protobuf.async_write_int32(item)
+
+  }
+  match self.leading_comments {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(26UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.trailing_comments {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(34UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  for item in self.leading_detached_comments {
+    writer |> @protobuf.async_write_varint(50UL)
+    writer |> @protobuf.async_write_string(item)
+
+  }
+}
 pub(all) struct SourceCodeInfo {
   mut location : Array[SourceCodeInfo_Location]
 } derive(Eq, Show)
@@ -6102,11 +8638,11 @@ pub impl Default for SourceCodeInfo with default() -> SourceCodeInfo {
     location : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo::read(reader : R) -> SourceCodeInfo raise {
+pub  fn[R: @protobuf.Reader] SourceCodeInfo::read(reader : R) -> SourceCodeInfo raise {
   let reader = @protobuf.LimitedReader::new(reader)
   SourceCodeInfo::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> SourceCodeInfo raise {
+pub  fn[R: @protobuf.Reader] SourceCodeInfo::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> SourceCodeInfo raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -6115,16 +8651,16 @@ pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo::read_with_limit(reader : 
   let msg = SourceCodeInfo::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (1, _) => msg.location.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       SourceCodeInfo_Location::default()
     } else {
       SourceCodeInfo_Location::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -6134,10 +8670,10 @@ pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo::read_with_limit(reader : 
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] SourceCodeInfo::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] SourceCodeInfo::write(self:Self, writer : W) -> Unit raise {
   for item in self.location {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -6161,6 +8697,45 @@ pub impl @json.FromJson for SourceCodeInfo with from_json(json: Json, path: @jso
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo::async_read(reader : R) -> SourceCodeInfo raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  SourceCodeInfo::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] SourceCodeInfo::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> SourceCodeInfo raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = SourceCodeInfo::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.location.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      SourceCodeInfo_Location::default()
+    } else {
+      SourceCodeInfo_Location::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] SourceCodeInfo::async_write(self:Self, writer : W) -> Unit raise {
+  for item in self.location {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
 }
 pub(all) enum GeneratedCodeInfo_Annotation_Semantic {
   NONE
@@ -6243,11 +8818,11 @@ pub impl Default for GeneratedCodeInfo_Annotation with default() -> GeneratedCod
     semantic : None,
   }
 }
-pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::read(reader : R) -> GeneratedCodeInfo_Annotation raise {
+pub  fn[R: @protobuf.Reader] GeneratedCodeInfo_Annotation::read(reader : R) -> GeneratedCodeInfo_Annotation raise {
   let reader = @protobuf.LimitedReader::new(reader)
   GeneratedCodeInfo_Annotation::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> GeneratedCodeInfo_Annotation raise {
+pub  fn[R: @protobuf.Reader] GeneratedCodeInfo_Annotation::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> GeneratedCodeInfo_Annotation raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -6256,13 +8831,13 @@ pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::read_with_l
   let msg = GeneratedCodeInfo_Annotation::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
-      (1, _) => { msg.path.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter()) }
-      (2, _) => msg.source_file = reader |> @protobuf.async_read_string() |> Some
-      (3, _) => msg.begin = reader |> @protobuf.async_read_int32() |> Some
-      (4, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
-      (5, _) => msg.semantic = reader |> @protobuf.async_read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => { msg.path.push_iter((reader |> @protobuf.read_packed(@protobuf.read_int32, None)).iter()) }
+      (2, _) => msg.source_file = reader |> @protobuf.read_string() |> Some
+      (3, _) => msg.begin = reader |> @protobuf.read_int32() |> Some
+      (4, _) => msg.end = reader |> @protobuf.read_int32() |> Some
+      (5, _) => msg.semantic = reader |> @protobuf.read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -6272,42 +8847,42 @@ pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::read_with_l
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] GeneratedCodeInfo_Annotation::write(self:Self, writer : W) -> Unit raise {
-  writer |> @protobuf.async_write_varint(10UL)
+pub  fn[W: @protobuf.Writer] GeneratedCodeInfo_Annotation::write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL)
   let size = self.path.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
-  writer |> @protobuf.async_write_uint32(size)
+  writer |> @protobuf.write_uint32(size)
   for item in self.path {
-      writer |> @protobuf.async_write_int32(item)
+      writer |> @protobuf.write_int32(item)
 
   }
   match self.source_file {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(18UL);
-      writer |> @protobuf.async_write_string(v)
+      writer |> @protobuf.write_varint(18UL);
+      writer |> @protobuf.write_string(v)
 
     }
     None => ()
   }
   match self.begin {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(24UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(24UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.end {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(32UL);
-      writer |> @protobuf.async_write_int32(v)
+      writer |> @protobuf.write_varint(32UL);
+      writer |> @protobuf.write_int32(v)
 
     }
     None => ()
   }
   match self.semantic {
     Some(v) => {
-      writer |> @protobuf.async_write_varint(40UL);
-      writer |> @protobuf.async_write_enum(v.to_enum())
+      writer |> @protobuf.write_varint(40UL);
+      writer |> @protobuf.write_enum(v.to_enum())
 
     }
     None => ()
@@ -6354,6 +8929,76 @@ pub impl @json.FromJson for GeneratedCodeInfo_Annotation with from_json(json: Js
   }
   message
 }
+pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::async_read(reader : R) -> GeneratedCodeInfo_Annotation raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  GeneratedCodeInfo_Annotation::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo_Annotation::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> GeneratedCodeInfo_Annotation raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = GeneratedCodeInfo_Annotation::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => { msg.path.push_iter((reader |> @protobuf.async_read_packed(@protobuf.async_read_int32, None)).iter()) }
+      (2, _) => msg.source_file = reader |> @protobuf.async_read_string() |> Some
+      (3, _) => msg.begin = reader |> @protobuf.async_read_int32() |> Some
+      (4, _) => msg.end = reader |> @protobuf.async_read_int32() |> Some
+      (5, _) => msg.semantic = reader |> @protobuf.async_read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] GeneratedCodeInfo_Annotation::async_write(self:Self, writer : W) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL)
+  let size = self.path.iter().map(@protobuf.size_of).fold(init=0U, UInt::op_add)
+  writer |> @protobuf.async_write_uint32(size)
+  for item in self.path {
+      writer |> @protobuf.async_write_int32(item)
+
+  }
+  match self.source_file {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(18UL);
+      writer |> @protobuf.async_write_string(v)
+
+    }
+    None => ()
+  }
+  match self.begin {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(24UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.end {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(32UL);
+      writer |> @protobuf.async_write_int32(v)
+
+    }
+    None => ()
+  }
+  match self.semantic {
+    Some(v) => {
+      writer |> @protobuf.async_write_varint(40UL);
+      writer |> @protobuf.async_write_enum(v.to_enum())
+
+    }
+    None => ()
+  }
+}
 pub(all) struct GeneratedCodeInfo {
   mut annotation : Array[GeneratedCodeInfo_Annotation]
 } derive(Eq, Show)
@@ -6367,11 +9012,11 @@ pub impl Default for GeneratedCodeInfo with default() -> GeneratedCodeInfo {
     annotation : [],
   }
 }
-pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo::read(reader : R) -> GeneratedCodeInfo raise {
+pub  fn[R: @protobuf.Reader] GeneratedCodeInfo::read(reader : R) -> GeneratedCodeInfo raise {
   let reader = @protobuf.LimitedReader::new(reader)
   GeneratedCodeInfo::read_with_limit(reader)
 }
-pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> GeneratedCodeInfo raise {
+pub  fn[R: @protobuf.Reader] GeneratedCodeInfo::read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> GeneratedCodeInfo raise {
   let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
     if l < limit { raise @protobuf.EndOfStream }
     Some(l - limit)
@@ -6380,16 +9025,16 @@ pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo::read_with_limit(reader
   let msg = GeneratedCodeInfo::default()
   try {
     for {
-      match (reader |> @protobuf.async_read_tag()) {
+      match (reader |> @protobuf.read_tag()) {
       (1, _) => msg.annotation.push(  {
-    let len = reader |> @protobuf.async_read_int32()
+    let len = reader |> @protobuf.read_int32()
     if len == 0 {
       GeneratedCodeInfo_Annotation::default()
     } else {
       GeneratedCodeInfo_Annotation::read_with_limit(reader, limit=len)
     }
   })
-       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
       }
     }
   } catch {
@@ -6399,10 +9044,10 @@ pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo::read_with_limit(reader
   reader.limit = new_limit
   msg
 }
-pub async fn[W: @protobuf.AsyncWriter] GeneratedCodeInfo::write(self:Self, writer : W) -> Unit raise {
+pub  fn[W: @protobuf.Writer] GeneratedCodeInfo::write(self:Self, writer : W) -> Unit raise {
   for item in self.annotation {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.write(writer)
+    writer |> @protobuf.write_varint(10UL)
+    writer |> @protobuf.write_uint32(@protobuf.size_of(item)); item.write(writer)
 
   }
 }
@@ -6426,4 +9071,43 @@ pub impl @json.FromJson for GeneratedCodeInfo with from_json(json: Json, path: @
     }
   }
   message
+}
+pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo::async_read(reader : R) -> GeneratedCodeInfo raise {
+  let reader = @protobuf.LimitedReader::new(reader)
+  GeneratedCodeInfo::async_read_with_limit(reader)
+}
+pub async fn[R: @protobuf.AsyncReader] GeneratedCodeInfo::async_read_with_limit(reader : @protobuf.LimitedReader[R], limit ?: Int) -> GeneratedCodeInfo raise {
+  let new_limit = if reader.limit is Some(l) && limit is Some(limit) {
+    if l < limit { raise @protobuf.EndOfStream }
+    Some(l - limit)
+  } else { None }
+  reader.limit = limit
+  let msg = GeneratedCodeInfo::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.annotation.push(  {
+    let len = reader |> @protobuf.async_read_int32()
+    if len == 0 {
+      GeneratedCodeInfo_Annotation::default()
+    } else {
+      GeneratedCodeInfo_Annotation::async_read_with_limit(reader, limit=len)
+    }
+  })
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  reader.limit = new_limit
+  msg
+}
+pub async fn[W: @protobuf.AsyncWriter] GeneratedCodeInfo::async_write(self:Self, writer : W) -> Unit raise {
+  for item in self.annotation {
+    writer |> @protobuf.async_write_varint(10UL)
+    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item)); item.async_write(writer)
+
+  }
 }


### PR DESCRIPTION
- Added `title` formatting function
- Improved error handling for undefined message and enum types
- Removed `read_pack` raise `ReaderError`
- Added `async` option in generator