### PR TITLE
feat: add service codegen (traits + descriptors)

### DIFF
--- a/cli/template.mbt
+++ b/cli/template.mbt
@@ -47,6 +47,9 @@ fn CodeGenerator::gen_file(self : CodeGenerator, file : Package) -> Unit raise {
     self.gen_enum(enum_, content)
   }
   self.gen_messages(file.message_type, content)
+  for service in file.services {
+    self.gen_service(service, content)
+  }
   let file = File::from_builder(filename, content~)
   self.push_file(file)
 }
@@ -1485,4 +1488,117 @@ fn CodeGenerator::gen_kind_write(
         "Unsupported field type: \{field_type} for field \{field.import_path.name()}",
       )
   }
+}
+
+///|
+fn CodeGenerator::resolve_type_name(
+  self : CodeGenerator,
+  type_name : String,
+  parent_path? : ImportPath,
+) -> String raise {
+  if self.find_message(type_name) is Some(message) {
+    let message_path = message.import_path
+    if parent_path is Some(path) &&
+      path.package_name != message_path.package_name {
+      return "@\{self.qualified_name(message_path)}.\{message_path.path() |> to_camel_case}"
+    }
+    return message_path.path() |> to_camel_case
+  }
+  if self.find_enum(type_name) is Some(enum_) {
+    let path = enum_.import_path
+    if parent_path is Some(parent) &&
+      parent.package_name != path.package_name {
+      return "@\{self.qualified_name(path)}.\{path.path() |> to_camel_case}"
+    }
+    return path.path() |> to_camel_case
+  }
+  raise UnsupportedType("Type \{type_name} not found")
+}
+
+///|
+fn CodeGenerator::gen_service(
+  self : CodeGenerator,
+  service : Service,
+  content : StringBuilder,
+) -> Unit raise {
+  self.gen_service_trait(service, content)
+  self.gen_service_descriptor(service, content)
+}
+
+///|
+fn CodeGenerator::gen_service_trait(
+  self : CodeGenerator,
+  service : Service,
+  content : StringBuilder,
+) -> Unit raise {
+  let trait_name = "\{service.name}Service"
+  let parent_path = service.file.map(fn(f) { f.import_path })
+  let unary_methods : Array[Method] = []
+  let streaming_methods : Array[Method] = []
+  for m in service.methods {
+    if m.client_streaming || m.server_streaming {
+      streaming_methods.push(m)
+    } else {
+      unary_methods.push(m)
+    }
+  }
+  content.write_string("pub(open) trait \{trait_name} {\n")
+  for m in unary_methods {
+    let method_name = m.name |> pascal_to_snake
+    let input_type = self.resolve_type_name(m.input_type, parent_path?)
+    let output_type = self.resolve_type_name(m.output_type, parent_path?)
+    content.write_string(
+      "  \{method_name}(Self, \{input_type}) -> \{output_type} raise\n",
+    )
+  }
+  for m in streaming_methods {
+    let method_name = m.name |> pascal_to_snake
+    let streaming_kind = if m.client_streaming && m.server_streaming {
+      "bidirectional streaming"
+    } else if m.client_streaming {
+      "client streaming"
+    } else {
+      "server streaming"
+    }
+    content.write_string(
+      "  // \{method_name} is a \{streaming_kind} method and is not included in the trait\n",
+    )
+  }
+  content.write_string("}\n")
+}
+
+///|
+fn CodeGenerator::gen_service_descriptor(
+  _ : CodeGenerator,
+  service : Service,
+  content : StringBuilder,
+) -> Unit {
+  let var_name = "\{service.name |> pascal_to_snake}_service_descriptor"
+  let package_name = service.file.map_or("", fn(f) { f.package_name })
+  let full_name = if package_name.is_empty() {
+    service.name
+  } else {
+    "\{package_name}.\{service.name}"
+  }
+  content.write_string(
+    "pub let \{var_name} : @protobuf.ServiceDescriptor = {\n",
+  )
+  content.write_string("  name: \"\{service.name}\",\n")
+  content.write_string("  full_name: \"\{full_name}\",\n")
+  content.write_string("  methods: [\n")
+  for m in service.methods {
+    let method_full_name = "/\{full_name}/\{m.name}"
+    content.write_string("    {\n")
+    content.write_string("      name: \"\{m.name}\",\n")
+    content.write_string("      full_name: \"\{method_full_name}\",\n")
+    content.write_string(
+      "      client_streaming: \{m.client_streaming},\n",
+    )
+    content.write_string(
+      "      server_streaming: \{m.server_streaming},\n",
+    )
+    content.write_string("    },\n")
+  }
+  content.write_string("  ],\n")
+  content.write_string("}\n")
 }

--- a/cli/types.mbt
+++ b/cli/types.mbt
@@ -192,6 +192,7 @@ struct Package {
   desc : @protobuf.FileDescriptorProto
   message_type : Array[Message]
   enums : Array[Enum]
+  services : Array[Service]
   name : String
   package_name : String
   import_path : ImportPath
@@ -211,6 +212,7 @@ fn Package::from(
     desc,
     message_type: [],
     enums: [],
+    services: [],
     name,
     package_name,
     import_path: ImportPath::from("", package_name~),
@@ -228,6 +230,9 @@ fn Package::from(
   }
   for enum_ in desc.enum_type {
     package_.enums.push(Enum::from_file(enum_, package_))
+  }
+  for service in desc.service {
+    package_.services.push(Service::from_file(service, package_))
   }
   for dep in desc.dependency {
     if file_descriptors_map.contains(dep) {
@@ -491,4 +496,55 @@ fn Message::get_oneof_fields_by_index(
   return self.desc.field
     .filter(field => field.oneof_index is Some(idx) && idx == index)
     .map(field => Field::from(field, self))
+}
+
+///|
+struct Method {
+  desc : @protobuf.MethodDescriptorProto
+  name : String
+  input_type : String
+  output_type : String
+  client_streaming : Bool
+  server_streaming : Bool
+} derive(Eq, Show)
+
+///|
+fn Method::from_service(
+  desc : @protobuf.MethodDescriptorProto,
+) -> Method {
+  {
+    desc,
+    name: desc.name.unwrap(),
+    input_type: desc.input_type.unwrap(),
+    output_type: desc.output_type.unwrap(),
+    client_streaming: desc.client_streaming.unwrap_or(false),
+    server_streaming: desc.server_streaming.unwrap_or(false),
+  }
+}
+
+///|
+struct Service {
+  desc : @protobuf.ServiceDescriptorProto
+  file : Package?
+  import_path : ImportPath
+  name : String
+  methods : Array[Method]
+} derive(Eq, Show)
+
+///|
+fn Service::from_file(
+  desc : @protobuf.ServiceDescriptorProto,
+  file : Package,
+) -> Service {
+  let methods : Array[Method] = []
+  for m in desc.method_ {
+    methods.push(Method::from_service(m))
+  }
+  {
+    desc,
+    file: Some(file),
+    import_path: file.import_path.append(desc.name.unwrap()),
+    name: desc.name.unwrap(),
+    methods,
+  }
 }

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -191,4 +191,47 @@ struct M {
 
 ## Services
 
-[Services](https://developers.google.com/protocol-buffers/docs/proto#services) is currently **NOT** supported.
+[Services](https://developers.google.com/protocol-buffers/docs/proto#services) generate a **trait** (server-side interface) and a **service descriptor** (metadata for runtime routing).
+
+For example:
+
+```protobuf
+package greet;
+
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply);
+  rpc StreamHello (HelloRequest) returns (stream HelloReply);
+}
+```
+
+Will generate:
+
+```moonbit
+pub(open) trait GreeterService {
+  say_hello(Self, HelloRequest) -> HelloReply raise
+  // stream_hello is a server streaming method and is not included in the trait
+}
+pub let greeter_service_descriptor : @protobuf.ServiceDescriptor = {
+  name: "Greeter",
+  full_name: "greet.Greeter",
+  methods: [
+    {
+      name: "SayHello",
+      full_name: "/greet.Greeter/SayHello",
+      client_streaming: false,
+      server_streaming: false,
+    },
+    {
+      name: "StreamHello",
+      full_name: "/greet.Greeter/StreamHello",
+      client_streaming: false,
+      server_streaming: true,
+    },
+  ],
+}
+```
+
+- **Trait**: Only unary (non-streaming) methods are included. Streaming methods are omitted with a comment.
+- **Descriptor**: All methods are included with full metadata (name, full path, streaming flags).
+- **Method names** in the trait use `snake_case` (e.g., `SayHello` becomes `say_hello`).
+- **Descriptor variable** uses `snake_case` service name with `_service_descriptor` suffix.

--- a/lib/service.mbt
+++ b/lib/service.mbt
@@ -1,0 +1,14 @@
+///|
+pub(all) struct MethodDescriptor {
+  name : String
+  full_name : String
+  client_streaming : Bool
+  server_streaming : Bool
+} derive(Eq, Show)
+
+///|
+pub(all) struct ServiceDescriptor {
+  name : String
+  full_name : String
+  methods : Array[MethodDescriptor]
+} derive(Eq, Show)

--- a/test/snapshots/test_case11/__snapshot/moon.mod.json
+++ b/test/snapshots/test_case11/__snapshot/moon.mod.json
@@ -1,0 +1,15 @@
+{
+  "name": "username/__snapshot",
+  "version": "0.1.0",
+  "readme": "",
+  "repository": "",
+  "license": "",
+  "keywords": [],
+  "description": "",
+  "source": "src",
+  "deps": {
+    "moonbitlang/protobuf": {
+      "path": "../../../../lib"
+    }
+  }
+}

--- a/test/snapshots/test_case11/__snapshot/src/greet/moon.pkg.json
+++ b/test/snapshots/test_case11/__snapshot/src/greet/moon.pkg.json
@@ -1,0 +1,5 @@
+{
+  "import": [
+    "moonbitlang/protobuf"
+  ]
+}

--- a/test/snapshots/test_case11/__snapshot/src/greet/top.mbt
+++ b/test/snapshots/test_case11/__snapshot/src/greet/top.mbt
@@ -1,0 +1,182 @@
+pub(all) struct HelloRequest {
+  mut name : String
+} derive(Eq, Show)
+pub impl @protobuf.Sized for HelloRequest with size_of(self) {
+  let mut size = 0U
+  size += 1U + { let size = @protobuf.size_of(self.name); @protobuf.size_of(size) + size }
+  size
+}
+pub impl Default for HelloRequest with default() -> HelloRequest {
+  HelloRequest::{
+    name : String::default(),
+  }
+}
+pub fn HelloRequest::new(name : String) -> HelloRequest {
+  HelloRequest::{
+    name,
+  }
+}
+pub impl @protobuf.Read for HelloRequest with read_with_limit(reader : @protobuf.LimitedReader[&@protobuf.Reader]) -> HelloRequest raise {
+  let msg = HelloRequest::default()
+  try {
+    for {
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.read_string()
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  msg
+}
+pub impl @protobuf.Write for HelloRequest with write(self: HelloRequest, writer : &@protobuf.Writer) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.name)
+}
+pub impl ToJson for HelloRequest with to_json(self) {
+  let json: Map[String, Json] = {}
+  if self.name != Default::default() {
+  json["name"] = self.name.to_json()
+  }
+  Json::object(json)
+}
+pub impl @json.FromJson for HelloRequest with from_json(json: Json, path: @json.JsonPath) -> HelloRequest raise {
+  guard json is Object(obj) else {
+    raise @json.JsonDecodeError((path, "Expected an object for HelloRequest"))
+  }
+  let message = HelloRequest::default()
+  for key, value in obj {
+    match (key, value) {
+      ("name", value) => message.name = @json.from_json(value, path~)
+      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+    }
+  }
+  message
+}
+pub impl @protobuf.AsyncRead for HelloRequest with read_with_limit(reader : @protobuf.LimitedReader[&@protobuf.AsyncReader]) -> HelloRequest raise {
+  let msg = HelloRequest::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.name = reader |> @protobuf.async_read_string()
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  msg
+}
+pub impl @protobuf.AsyncWrite for HelloRequest with write(self: HelloRequest, writer : &@protobuf.AsyncWriter) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.name)
+}
+pub(all) struct HelloReply {
+  mut message : String
+} derive(Eq, Show)
+pub impl @protobuf.Sized for HelloReply with size_of(self) {
+  let mut size = 0U
+  size += 1U + { let size = @protobuf.size_of(self.message); @protobuf.size_of(size) + size }
+  size
+}
+pub impl Default for HelloReply with default() -> HelloReply {
+  HelloReply::{
+    message : String::default(),
+  }
+}
+pub fn HelloReply::new(message : String) -> HelloReply {
+  HelloReply::{
+    message,
+  }
+}
+pub impl @protobuf.Read for HelloReply with read_with_limit(reader : @protobuf.LimitedReader[&@protobuf.Reader]) -> HelloReply raise {
+  let msg = HelloReply::default()
+  try {
+    for {
+      match (reader |> @protobuf.read_tag()) {
+      (1, _) => msg.message = reader |> @protobuf.read_string()
+       (_, wire) => reader |> @protobuf.read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  msg
+}
+pub impl @protobuf.Write for HelloReply with write(self: HelloReply, writer : &@protobuf.Writer) -> Unit raise {
+  writer |> @protobuf.write_varint(10UL);
+  writer |> @protobuf.write_string(self.message)
+}
+pub impl ToJson for HelloReply with to_json(self) {
+  let json: Map[String, Json] = {}
+  if self.message != Default::default() {
+  json["message"] = self.message.to_json()
+  }
+  Json::object(json)
+}
+pub impl @json.FromJson for HelloReply with from_json(json: Json, path: @json.JsonPath) -> HelloReply raise {
+  guard json is Object(obj) else {
+    raise @json.JsonDecodeError((path, "Expected an object for HelloReply"))
+  }
+  let message = HelloReply::default()
+  for key, value in obj {
+    match (key, value) {
+      ("message", value) => message.message = @json.from_json(value, path~)
+      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+    }
+  }
+  message
+}
+pub impl @protobuf.AsyncRead for HelloReply with read_with_limit(reader : @protobuf.LimitedReader[&@protobuf.AsyncReader]) -> HelloReply raise {
+  let msg = HelloReply::default()
+  try {
+    for {
+      match (reader |> @protobuf.async_read_tag()) {
+      (1, _) => msg.message = reader |> @protobuf.async_read_string()
+       (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      }
+    }
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
+  msg
+}
+pub impl @protobuf.AsyncWrite for HelloReply with write(self: HelloReply, writer : &@protobuf.AsyncWriter) -> Unit raise {
+  writer |> @protobuf.async_write_varint(10UL);
+  writer |> @protobuf.async_write_string(self.message)
+}
+pub(open) trait GreeterService {
+  say_hello(Self, HelloRequest) -> HelloReply raise
+  // stream_hello is a server streaming method and is not included in the trait
+}
+pub let greeter_service_descriptor : @protobuf.ServiceDescriptor = {
+  name: "Greeter",
+  full_name: "greet.Greeter",
+  methods: [
+    {
+      name: "SayHello",
+      full_name: "/greet.Greeter/SayHello",
+      client_streaming: false,
+      server_streaming: false,
+    },
+    {
+      name: "StreamHello",
+      full_name: "/greet.Greeter/StreamHello",
+      client_streaming: false,
+      server_streaming: true,
+    },
+  ],
+}
+pub(open) trait EmptyService {
+}
+pub let empty_service_descriptor : @protobuf.ServiceDescriptor = {
+  name: "Empty",
+  full_name: "greet.Empty",
+  methods: [
+  ],
+}

--- a/test/snapshots/test_case11/input.proto
+++ b/test/snapshots/test_case11/input.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package greet;
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}
+
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply);
+  rpc StreamHello (HelloRequest) returns (stream HelloReply);
+}
+
+service Empty {
+}


### PR DESCRIPTION
## Summary

- Generate MoonBit **traits** (server-side interface) and **service descriptors** (routing metadata) from protobuf `service`/`rpc` definitions
- Add `ServiceDescriptor` and `MethodDescriptor` runtime types to `lib/`
- Add `Service` and `Method` to the CLI type model, with extraction in `Package::from()`
- Streaming methods are included in descriptors but omitted from traits (with a comment explaining why)
- Update `doc/spec.md` to document the new service codegen format

## Test plan

- [x] `moon check` passes for both `lib/` and `cli/`
- [x] `moon test` passes (7/7 tests)
- [x] `python scripts/snapshot_test.py` passes — all snapshots match including new `test_case11`
- [x] New snapshot (`test_case11`) covers: unary RPC, server-streaming RPC, empty service edge case
- [x] Generated snapshot code compiles with `moon check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)