### PR TITLE
Migrate deprecated not(...) to !(...)

### DIFF
--- a/cli/types.mbt
+++ b/cli/types.mbt
@@ -175,7 +175,7 @@ fn Field::is_optional(self : Field) -> Bool {
 
 ///|
 fn Field::map_key_value(self : Field) -> Message? {
-  if not(self.is_map()) {
+  if !self.is_map() {
     return None
   }
   let full_name = ImportPath::from(self.type_name.unwrap_or(""))
@@ -239,7 +239,7 @@ fn Package::from(
 
 ///|
 fn Package::find_message(self : Package, path : ImportPath) -> Message? {
-  if not(path.has_prefix(self.import_path)) {
+  if !path.has_prefix(self.import_path) {
     return None
   }
   for message in self.message_type {
@@ -252,7 +252,7 @@ fn Package::find_message(self : Package, path : ImportPath) -> Message? {
 
 ///|
 fn Package::find_enum(self : Package, path : ImportPath) -> Enum? {
-  if not(path.has_prefix(self.import_path)) {
+  if !path.has_prefix(self.import_path) {
     return None
   }
   for enum_ in self.enums {

--- a/cli/utils.mbt
+++ b/cli/utils.mbt
@@ -128,7 +128,7 @@ fn pascal_to_snake(name : String) -> String {
       continue (rest, c)
     }
     ([c, .. rest], _) => {
-      if not(upper.is_empty()) {
+      if !upper.is_empty() {
         new_name.write_string(upper.to_string())
         upper.reset()
       }
@@ -136,7 +136,7 @@ fn pascal_to_snake(name : String) -> String {
       continue (rest, c)
     }
     ([], _) => {
-      if not(upper.is_empty()) {
+      if !upper.is_empty() {
         new_name.write_string(upper.to_string())
       }
       break


### PR DESCRIPTION
## Summary
- Replace all 5 occurrences of deprecated `not(...)` syntax with `!(...)` in `cli/types.mbt` and `cli/utils.mbt`

## Test plan
- [x] `moon check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)