### PR TITLE
fix: reject overlong varints to avoid stream desync

### DIFF
--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -59,7 +59,7 @@ pub async fn[T : AsyncReader] async_read_varint32(reader : T) -> UInt {
       return b
     }
   } nobreak {
-    b
+    raise ReaderError::OverlongVarint
   }
 }
 
@@ -73,7 +73,7 @@ async fn[T : AsyncReader] async_read_varint64(reader : T) -> UInt64 {
       return b
     }
   } nobreak {
-    b
+    raise ReaderError::OverlongVarint
   }
 }
 

--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -54,12 +54,15 @@ pub async fn[T : AsyncReader] async_read_varint32(reader : T) -> UInt {
   let mut b = 0U
   for i in 0..<5 {
     let byte = reader |> async_read_byte() |> Byte::to_uint()
+    if i == 4 && byte > 0x0FU {
+      raise ReaderError::OverlongVarint
+    }
     b = ((byte & 0x7F) << (i * 7)) | b
     if (byte & 0x80) == 0 {
       return b
     }
   } nobreak {
-    b
+    raise ReaderError::OverlongVarint
   }
 }
 
@@ -68,12 +71,15 @@ async fn[T : AsyncReader] async_read_varint64(reader : T) -> UInt64 {
   let mut b = 0UL
   for i in 0..<10 {
     let byte = reader |> async_read_byte() |> Byte::to_uint64()
+    if i == 9 && byte > 0x01UL {
+      raise ReaderError::OverlongVarint
+    }
     b = ((byte & 0x7F) << (i * 7)) | b
     if (byte & 0x80) == 0 {
       return b
     }
   } nobreak {
-    b
+    raise ReaderError::OverlongVarint
   }
 }
 

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -174,6 +174,7 @@ pub fn[T : Writer] write_varint(T, UInt64) -> Unit raise
 pub(all) suberror ReaderError {
   EndOfStream
   InvalidString
+  OverlongVarint
   UnknownWireType(UInt)
 } derive(Eq, @debug.Debug)
 pub impl Show for ReaderError

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -76,7 +76,7 @@ pub fn[T : Reader] read_varint32(reader : T) -> UInt raise {
       return b
     }
   } nobreak {
-    b
+    raise ReaderError::OverlongVarint
   }
 }
 
@@ -90,7 +90,7 @@ fn[T : Reader] read_varint64(reader : T) -> UInt64 raise {
       return b
     }
   } nobreak {
-    b
+    raise ReaderError::OverlongVarint
   }
 }
 

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -71,12 +71,15 @@ pub fn[T : Reader] read_varint32(reader : T) -> UInt raise {
   let mut b = 0U
   for i in 0..<5 {
     let byte = reader |> read_byte() |> Byte::to_uint()
+    if i == 4 && byte > 0x0FU {
+      raise ReaderError::OverlongVarint
+    }
     b = ((byte & 0x7F) << (i * 7)) | b
     if (byte & 0x80) == 0 {
       return b
     }
   } nobreak {
-    b
+    raise ReaderError::OverlongVarint
   }
 }
 
@@ -85,12 +88,15 @@ fn[T : Reader] read_varint64(reader : T) -> UInt64 raise {
   let mut b = 0UL
   for i in 0..<10 {
     let byte = reader |> read_byte() |> Byte::to_uint64()
+    if i == 9 && byte > 0x01UL {
+      raise ReaderError::OverlongVarint
+    }
     b = ((byte & 0x7F) << (i * 7)) | b
     if (byte & 0x80) == 0 {
       return b
     }
   } nobreak {
-    b
+    raise ReaderError::OverlongVarint
   }
 }
 

--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -17,6 +17,7 @@ pub(all) suberror ReaderError {
   EndOfStream
   InvalidString
   UnknownWireType(UInt)
+  OverlongVarint
 } derive(Eq, Show)
 
 ///|

--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -16,6 +16,7 @@
 pub(all) suberror ReaderError {
   EndOfStream
   InvalidString
+  OverlongVarint
   UnknownWireType(UInt)
 } derive(Eq, Debug)
 
@@ -24,6 +25,7 @@ pub impl Show for ReaderError with fn output(self, logger) {
   match self {
     EndOfStream => logger.write_string("EndOfStream")
     InvalidString => logger.write_string("InvalidString")
+    OverlongVarint => logger.write_string("OverlongVarint")
     UnknownWireType(wire_type) =>
       logger
       ..write_string("UnknownWireType(")

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -39,17 +39,20 @@ test "read_int32/2" {
 
 ///|
 test "read_int32/3" {
+  // negative int32 is encoded as 10-byte varint (sign-extended to 64 bits),
+  // so read_int32 (which uses read_varint64) must be used instead of read_varint32
   let bytes = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01"
   let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
-  assert_eq(r |> @protobuf.read_varint32() |> UInt::reinterpret_as_int, -1)
-  // assert_eq(r |> @protobuf.is_eof(), false)
+  assert_eq(r |> @protobuf.read_int32(), -1)
 }
 
 ///|
 test "end_of_bytes" {
+  // negative int32 is encoded as 10-byte varint (sign-extended to 64 bits),
+  // so read_int32 (which uses read_varint64) must be used instead of read_varint32
   let bytes = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01"
   let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
-  assert_eq(r |> @protobuf.read_varint32() |> UInt::reinterpret_as_int, -1)
+  assert_eq(r |> @protobuf.read_int32(), -1)
 }
 
 ///|
@@ -66,4 +69,20 @@ test "read_string" {
 test "error" {
   let r = @protobuf.BytesReader::from_bytes(b"") as &@protobuf.Reader
   inspect(try? (r |> @protobuf.read_varint32()), content="Err(EndOfStream)")
+}
+
+///|
+test "overlong_varint32" {
+  // 6 bytes all with continuation bit set: overlong for varint32 (max 5 bytes)
+  let bytes = b"\x80\x80\x80\x80\x80\x80"
+  let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  inspect(try? (r |> @protobuf.read_varint32()), content="Err(OverlongVarint)")
+}
+
+///|
+test "overlong_varint64" {
+  // 11 bytes all with continuation bit set: overlong for varint64 (max 10 bytes)
+  let bytes = b"\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80"
+  let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  inspect(try? (r |> @protobuf.read_int64()), content="Err(OverlongVarint)")
 }

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -39,23 +39,20 @@ test "read_int32/2" {
 
 ///|
 test "read_int32/3" {
+  // negative int32 is encoded as 10-byte varint (sign-extended to 64 bits),
+  // so read_int32 (which uses read_varint64) must be used instead of read_varint32
   let bytes = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01"
   let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
-  @debug.assert_eq(
-    r |> @protobuf.read_varint32() |> UInt::reinterpret_as_int,
-    -1,
-  )
-  // @debug.assert_eq(r |> @protobuf.is_eof(), false)
+  @debug.assert_eq(r |> @protobuf.read_int32(), -1)
 }
 
 ///|
 test "end_of_bytes" {
+  // negative int32 is encoded as 10-byte varint (sign-extended to 64 bits),
+  // so read_int32 (which uses read_varint64) must be used instead of read_varint32
   let bytes = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01"
   let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
-  @debug.assert_eq(
-    r |> @protobuf.read_varint32() |> UInt::reinterpret_as_int,
-    -1,
-  )
+  @debug.assert_eq(r |> @protobuf.read_int32(), -1)
 }
 
 ///|
@@ -90,4 +87,58 @@ test "BytesReader::read returns None for out-of-range offset" {
   // offset exceeds buffer length -> should also return None
   let result2 = (reader as &@protobuf.Reader).read(buf, offset=10, max_length=1)
   @debug.assert_eq(result2, None)
+}
+
+///|
+test "overlong_varint32" {
+  // 6 bytes all with continuation bit set: overlong for varint32 (max 5 bytes)
+  let bytes = b"\x80\x80\x80\x80\x80\x80"
+  let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_varint32()
+    fail("expected OverlongVarint")
+  } catch {
+    @protobuf.OverlongVarint => ()
+    err => raise err
+  }
+}
+
+///|
+test "read_varint32 rejects final-byte overflow" {
+  let bytes = b"\xFF\xFF\xFF\xFF\x10"
+  let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_varint32()
+    fail("expected OverlongVarint")
+  } catch {
+    @protobuf.OverlongVarint => ()
+    err => raise err
+  }
+}
+
+///|
+test "overlong_varint64" {
+  // 11 bytes all with continuation bit set: overlong for varint64 (max 10 bytes)
+  let bytes = b"\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80"
+  let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_int64()
+    fail("expected OverlongVarint")
+  } catch {
+    @protobuf.OverlongVarint => ()
+    err => raise err
+  }
+}
+
+///|
+test "read_varint64 rejects final-byte overflow" {
+  let bytes = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x02"
+  let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_int64()
+    fail("expected OverlongVarint")
+  } catch {
+    @protobuf.OverlongVarint => ()
+    err => raise err
+  }
 }


### PR DESCRIPTION
## Summary
- After max bytes (5 for varint32, 10 for varint64), if the continuation bit is still set, the decoder now raises `OverlongVarint` instead of silently returning a truncated value
- Applied to both sync (`read_varint32`/`read_varint64`) and async paths
- Fixed two existing tests that incorrectly used `read_varint32` on 10-byte negative int32 encodings

## Test plan
- [x] Added `overlong_varint32` test (6 bytes all with continuation bit set)
- [x] Added `overlong_varint64` test (11 bytes all with continuation bit set)
- [x] All existing tests pass (`moon test -C lib`)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)