### PR TITLE
fix: validate length-delimited sizes before allocation

### DIFF
--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -167,6 +167,9 @@ pub async fn[T : AsyncReader] async_read_enum(reader : T) -> Enum {
 ///|
 pub async fn[T : AsyncReader] async_read_bytes(reader : T) -> Bytes {
   let length = reader |> async_read_int32()
+  if length < 0 {
+    raise ReaderError::InvalidLength
+  }
   let bytes : FixedArray[Byte] = FixedArray::make(length, 0)
   reader |> async_read_exactly(bytes, offset=0, length~)
   bytes.unsafe_reinterpret_as_bytes()
@@ -175,6 +178,9 @@ pub async fn[T : AsyncReader] async_read_bytes(reader : T) -> Bytes {
 ///|
 pub async fn[T : AsyncReader] async_read_string(reader : T) -> String {
   let length = reader |> async_read_int32()
+  if length < 0 {
+    raise ReaderError::InvalidLength
+  }
   let string = StringBuilder::new()
   for i = 0; i < length; {
     let b = reader |> async_read_byte() |> Byte::to_int()
@@ -222,6 +228,9 @@ pub async fn[M : AsyncRead + Default] async_read_message(
   reader : LimitedReader[&AsyncReader],
 ) -> M {
   let len = reader |> async_read_int32()
+  if len < 0 {
+    raise ReaderError::InvalidLength
+  }
   match len {
     0 => M::default()
     _ => {

--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -173,6 +173,9 @@ pub async fn[T : AsyncReader] async_read_enum(reader : T) -> Enum {
 ///|
 pub async fn[T : AsyncReader] async_read_bytes(reader : T) -> Bytes {
   let length = reader |> async_read_int32()
+  if length < 0 {
+    raise ReaderError::InvalidLength
+  }
   let bytes : FixedArray[Byte] = FixedArray::make(length, 0)
   reader |> async_read_exactly(bytes, offset=0, length~)
   bytes.unsafe_reinterpret_as_bytes()
@@ -181,6 +184,9 @@ pub async fn[T : AsyncReader] async_read_bytes(reader : T) -> Bytes {
 ///|
 pub async fn[T : AsyncReader] async_read_string(reader : T) -> String {
   let length = reader |> async_read_int32()
+  if length < 0 {
+    raise ReaderError::InvalidLength
+  }
   let string = StringBuilder::new()
   for i = 0; i < length; {
     let b = reader |> async_read_byte() |> Byte::to_int()
@@ -228,6 +234,9 @@ pub async fn[M : AsyncRead + Default] async_read_message(
   reader : LimitedReader[&AsyncReader],
 ) -> M {
   let len = reader |> async_read_int32()
+  if len < 0 {
+    raise ReaderError::InvalidLength
+  }
   match len {
     0 => M::default()
     _ => {

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -174,6 +174,7 @@ pub fn[T : Writer] write_varint(T, UInt64) -> Unit raise
 pub(all) suberror ReaderError {
   EndOfStream
   InvalidString
+  InvalidLength
   OverlongVarint
   UnknownWireType(UInt)
 } derive(Eq, @debug.Debug)

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -182,6 +182,9 @@ pub fn[T : Reader] read_enum(reader : T) -> Enum raise {
 ///|
 pub fn[T : Reader] read_bytes(reader : T) -> Bytes raise {
   let length = reader |> read_int32()
+  if length < 0 {
+    raise ReaderError::InvalidLength
+  }
   let bytes : FixedArray[Byte] = FixedArray::make(length, 0)
   read_exactly(reader, bytes, offset=0, length~)
   bytes.unsafe_reinterpret_as_bytes()
@@ -190,6 +193,9 @@ pub fn[T : Reader] read_bytes(reader : T) -> Bytes raise {
 ///|
 pub fn[T : Reader] read_string(reader : T) -> String raise {
   let length = reader |> read_int32()
+  if length < 0 {
+    raise ReaderError::InvalidLength
+  }
   let string = StringBuilder::new()
   for i = 0; i < length; {
     let b = reader |> read_byte() |> Byte::to_int()
@@ -236,6 +242,9 @@ pub fn[M : Read + Default] read_message(
   reader : LimitedReader[&Reader],
 ) -> M raise {
   let len = reader |> read_int32()
+  if len < 0 {
+    raise ReaderError::InvalidLength
+  }
   match len {
     0 => M::default()
     _ => {

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -188,6 +188,9 @@ pub fn[T : Reader] read_enum(reader : T) -> Enum raise {
 ///|
 pub fn[T : Reader] read_bytes(reader : T) -> Bytes raise {
   let length = reader |> read_int32()
+  if length < 0 {
+    raise ReaderError::InvalidLength
+  }
   let bytes : FixedArray[Byte] = FixedArray::make(length, 0)
   read_exactly(reader, bytes, offset=0, length~)
   bytes.unsafe_reinterpret_as_bytes()
@@ -196,6 +199,9 @@ pub fn[T : Reader] read_bytes(reader : T) -> Bytes raise {
 ///|
 pub fn[T : Reader] read_string(reader : T) -> String raise {
   let length = reader |> read_int32()
+  if length < 0 {
+    raise ReaderError::InvalidLength
+  }
   let string = StringBuilder::new()
   for i = 0; i < length; {
     let b = reader |> read_byte() |> Byte::to_int()
@@ -242,6 +248,9 @@ pub fn[M : Read + Default] read_message(
   reader : LimitedReader[&Reader],
 ) -> M raise {
   let len = reader |> read_int32()
+  if len < 0 {
+    raise ReaderError::InvalidLength
+  }
   match len {
     0 => M::default()
     _ => {

--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -16,6 +16,7 @@
 pub(all) suberror ReaderError {
   EndOfStream
   InvalidString
+  InvalidLength
   UnknownWireType(UInt)
 } derive(Eq, Show)
 

--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -16,6 +16,7 @@
 pub(all) suberror ReaderError {
   EndOfStream
   InvalidString
+  InvalidLength
   OverlongVarint
   UnknownWireType(UInt)
 } derive(Eq, Debug)
@@ -25,6 +26,7 @@ pub impl Show for ReaderError with fn output(self, logger) {
   match self {
     EndOfStream => logger.write_string("EndOfStream")
     InvalidString => logger.write_string("InvalidString")
+    InvalidLength => logger.write_string("InvalidLength")
     OverlongVarint => logger.write_string("OverlongVarint")
     UnknownWireType(wire_type) =>
       logger

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -67,3 +67,23 @@ test "error" {
   let r = @protobuf.BytesReader::from_bytes(b"") as &@protobuf.Reader
   inspect(try? (r |> @protobuf.read_varint32()), content="Err(EndOfStream)")
 }
+
+///|
+test "read_bytes/negative_length" {
+  // -1 encoded as a protobuf int32 (10-byte varint)
+  let r = @protobuf.BytesReader::from_bytes(
+      b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01",
+    )
+    as &@protobuf.Reader
+  inspect(try? (r |> @protobuf.read_bytes()), content="Err(InvalidLength)")
+}
+
+///|
+test "read_string/negative_length" {
+  // -1 encoded as a protobuf int32 (10-byte varint)
+  let r = @protobuf.BytesReader::from_bytes(
+      b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01",
+    )
+    as &@protobuf.Reader
+  inspect(try? (r |> @protobuf.read_string()), content="Err(InvalidLength)")
+}

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -142,3 +142,35 @@ test "read_varint64 rejects final-byte overflow" {
     err => raise err
   }
 }
+
+///|
+test "read_bytes/negative_length" {
+  // -1 encoded as a protobuf int32 (10-byte varint)
+  let r = @protobuf.BytesReader::from_bytes(
+      b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01",
+    )
+    as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_bytes()
+    fail("expected InvalidLength")
+  } catch {
+    @protobuf.InvalidLength => ()
+    err => raise err
+  }
+}
+
+///|
+test "read_string/negative_length" {
+  // -1 encoded as a protobuf int32 (10-byte varint)
+  let r = @protobuf.BytesReader::from_bytes(
+      b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01",
+    )
+    as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_string()
+    fail("expected InvalidLength")
+  } catch {
+    @protobuf.InvalidLength => ()
+    err => raise err
+  }
+}


### PR DESCRIPTION
## Summary
- Reject negative lengths in `read_bytes`, `read_string`, and `read_message` (and async variants) by raising `InvalidLength`
- Prevents invalid allocations or stream desync from malformed protobuf input

## Test plan
- [x] Added `read_bytes/negative_length` test
- [x] Added `read_string/negative_length` test
- [x] All existing tests pass (`moon test -C lib`)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)