### PR TITLE
fix: validate packed field length remainder for fixed-size elements

### DIFF
--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -255,10 +255,14 @@ pub async fn[M : Sized, R : AsyncReader] async_read_packed(
   let array = []
   let reader = LimitedReader::new(reader, limit=len.reinterpret_as_int())
   match size {
-    Some(size) =>
+    Some(size) => {
+      if len % size != 0U {
+        raise ReaderError::InvalidPackedLength
+      }
       for i = 0U; i < len / size; i = i + 1 {
         array.push(reader |> async_read_fn())
       }
+    }
     None =>
       for i = 0U; i < len; {
         let value = reader |> async_read_fn()

--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -270,10 +270,14 @@ pub async fn[M : Sized, R : AsyncReader] async_read_packed(
   let array = []
   let reader = LimitedReader::new(reader, limit=len.reinterpret_as_int())
   match size {
-    Some(size) =>
+    Some(size) => {
+      if len % size != 0U {
+        raise ReaderError::InvalidPackedLength
+      }
       for i = 0U; i < len / size; i = i + 1 {
         array.push(reader |> async_read_fn())
       }
+    }
     None =>
       for i = 0U; i < len; {
         let value = reader |> async_read_fn()

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -175,6 +175,7 @@ pub(all) suberror ReaderError {
   EndOfStream
   InvalidString
   InvalidLength
+  InvalidPackedLength
   OverlongVarint
   UnknownWireType(UInt)
 } derive(Eq, @debug.Debug)

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -269,10 +269,14 @@ pub fn[M : Sized, R : Reader] read_packed(
   let array = []
   let reader = LimitedReader::new(reader, limit=len.reinterpret_as_int())
   match size {
-    Some(size) =>
+    Some(size) => {
+      if len % size != 0U {
+        raise ReaderError::InvalidPackedLength
+      }
       for i = 0U; i < len / size; i = i + 1 {
         array.push(reader |> read_fn())
       }
+    }
     None =>
       for i = 0U; i < len; {
         let value = reader |> read_fn()

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -284,10 +284,14 @@ pub fn[M : Sized, R : Reader] read_packed(
   let array = []
   let reader = LimitedReader::new(reader, limit=len.reinterpret_as_int())
   match size {
-    Some(size) =>
+    Some(size) => {
+      if len % size != 0U {
+        raise ReaderError::InvalidPackedLength
+      }
       for i = 0U; i < len / size; i = i + 1 {
         array.push(reader |> read_fn())
       }
+    }
     None =>
       for i = 0U; i < len; {
         let value = reader |> read_fn()

--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -16,6 +16,7 @@
 pub(all) suberror ReaderError {
   EndOfStream
   InvalidString
+  InvalidPackedLength
   UnknownWireType(UInt)
 } derive(Eq, Show)
 

--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -17,6 +17,7 @@ pub(all) suberror ReaderError {
   EndOfStream
   InvalidString
   InvalidLength
+  InvalidPackedLength
   OverlongVarint
   UnknownWireType(UInt)
 } derive(Eq, Debug)
@@ -27,6 +28,7 @@ pub impl Show for ReaderError with fn output(self, logger) {
     EndOfStream => logger.write_string("EndOfStream")
     InvalidString => logger.write_string("InvalidString")
     InvalidLength => logger.write_string("InvalidLength")
+    InvalidPackedLength => logger.write_string("InvalidPackedLength")
     OverlongVarint => logger.write_string("OverlongVarint")
     UnknownWireType(wire_type) =>
       logger

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -67,3 +67,15 @@ test "error" {
   let r = @protobuf.BytesReader::from_bytes(b"") as &@protobuf.Reader
   inspect(try? (r |> @protobuf.read_varint32()), content="Err(EndOfStream)")
 }
+
+///|
+test "read_packed rejects misaligned length for fixed-size elements" {
+  // Length prefix of 5 bytes, but fixed32 elements are 4 bytes each.
+  // 5 % 4 != 0, so this should be rejected.
+  let bytes = b"\x05\x01\x02\x03\x04\x05"
+  let r = @protobuf.BytesReader::from_bytes(bytes)
+  inspect(
+    try? @protobuf.read_packed(r, @protobuf.read_fixed32, Some(4)),
+    content="Err(InvalidPackedLength)",
+  )
+}

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -174,3 +174,18 @@ test "read_string/negative_length" {
     err => raise err
   }
 }
+
+///|
+test "read_packed rejects misaligned length for fixed-size elements" {
+  // Length prefix of 5 bytes, but fixed32 elements are 4 bytes each.
+  // 5 % 4 != 0, so this should be rejected.
+  let bytes = b"\x05\x01\x02\x03\x04\x05"
+  let r = @protobuf.BytesReader::from_bytes(bytes)
+  try {
+    let _ = @protobuf.read_packed(r, @protobuf.read_fixed32, Some(4))
+    fail("expected InvalidPackedLength")
+  } catch {
+    @protobuf.InvalidPackedLength => ()
+    err => raise err
+  }
+}


### PR DESCRIPTION
## Summary
- When reading packed fields with a known element size, reject data whose byte length is not evenly divisible by the element size
- Raises `InvalidPackedLength` instead of silently ignoring leftover bytes
- Applied to both `read_packed` and `async_read_packed`

## Test plan
- [x] Added test with 5-byte packed field (not divisible by 4 for fixed32)
- [x] All existing tests pass (`moon test -C lib`)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)