### PR TITLE
fix: tighten UTF-8 validation in read_string

### DIFF
--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -186,7 +186,13 @@ pub async fn[T : AsyncReader] async_read_string(reader : T) -> String {
         raise ReaderError::InvalidString
       }
       let b2 = reader |> async_read_byte() |> Byte::to_int()
+      if (b2 & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x1F) << 6) | (b2 & 0x3F)
+      if ch < 0x80 {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 2
     } else if b < 0xF0 {
@@ -195,7 +201,13 @@ pub async fn[T : AsyncReader] async_read_string(reader : T) -> String {
       }
       let b2 = reader |> async_read_byte() |> Byte::to_int()
       let b3 = reader |> async_read_byte() |> Byte::to_int()
+      if (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x0F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F)
+      if ch < 0x800 || (ch >= 0xD800 && ch <= 0xDFFF) {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 3
     } else if b < 0xF8 {
@@ -204,10 +216,18 @@ pub async fn[T : AsyncReader] async_read_string(reader : T) -> String {
       }
       let varint_bytes : FixedArray[Byte] = FixedArray::make(3, 0)
       reader |> async_read_exactly(varint_bytes, offset=0, length=3)
+      if (varint_bytes[0].to_int() & 0xC0) != 0x80 ||
+        (varint_bytes[1].to_int() & 0xC0) != 0x80 ||
+        (varint_bytes[2].to_int() & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x07) << 18) |
         ((varint_bytes[0].to_int() & 0x3F) << 12) |
         ((varint_bytes[1].to_int() & 0x3F) << 6) |
         (varint_bytes[2].to_int() & 0x3F)
+      if ch < 0x10000 || ch > 0x10FFFF {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 4
     } else {

--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -198,7 +198,13 @@ pub async fn[T : AsyncReader] async_read_string(reader : T) -> String {
         raise ReaderError::InvalidString
       }
       let b2 = reader |> async_read_byte() |> Byte::to_int()
+      if (b2 & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x1F) << 6) | (b2 & 0x3F)
+      if ch < 0x80 {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 2
     } else if b < 0xF0 {
@@ -207,7 +213,13 @@ pub async fn[T : AsyncReader] async_read_string(reader : T) -> String {
       }
       let b2 = reader |> async_read_byte() |> Byte::to_int()
       let b3 = reader |> async_read_byte() |> Byte::to_int()
+      if (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x0F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F)
+      if ch < 0x800 || (ch >= 0xD800 && ch <= 0xDFFF) {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 3
     } else if b < 0xF8 {
@@ -216,10 +228,18 @@ pub async fn[T : AsyncReader] async_read_string(reader : T) -> String {
       }
       let varint_bytes : FixedArray[Byte] = FixedArray::make(3, 0)
       reader |> async_read_exactly(varint_bytes, offset=0, length=3)
+      if (varint_bytes[0].to_int() & 0xC0) != 0x80 ||
+        (varint_bytes[1].to_int() & 0xC0) != 0x80 ||
+        (varint_bytes[2].to_int() & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x07) << 18) |
         ((varint_bytes[0].to_int() & 0x3F) << 12) |
         ((varint_bytes[1].to_int() & 0x3F) << 6) |
         (varint_bytes[2].to_int() & 0x3F)
+      if ch < 0x10000 || ch > 0x10FFFF {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 4
     } else {

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -201,7 +201,13 @@ pub fn[T : Reader] read_string(reader : T) -> String raise {
         raise ReaderError::InvalidString
       }
       let b2 = reader |> read_byte() |> Byte::to_int()
+      if (b2 & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x1F) << 6) | (b2 & 0x3F)
+      if ch < 0x80 {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 2
     } else if b < 0xF0 {
@@ -210,7 +216,13 @@ pub fn[T : Reader] read_string(reader : T) -> String raise {
       }
       let b2 = reader |> read_byte() |> Byte::to_int()
       let b3 = reader |> read_byte() |> Byte::to_int()
+      if (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x0F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F)
+      if ch < 0x800 || (ch >= 0xD800 && ch <= 0xDFFF) {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 3
     } else if b < 0xF8 {
@@ -218,10 +230,18 @@ pub fn[T : Reader] read_string(reader : T) -> String raise {
         raise ReaderError::InvalidString
       }
       read_exactly(reader, varint_bytes, offset=0, length=3)
+      if (varint_bytes[0].to_int() & 0xC0) != 0x80 ||
+        (varint_bytes[1].to_int() & 0xC0) != 0x80 ||
+        (varint_bytes[2].to_int() & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x07) << 18) |
         ((varint_bytes[0].to_int() & 0x3F) << 12) |
         ((varint_bytes[1].to_int() & 0x3F) << 6) |
         (varint_bytes[2].to_int() & 0x3F)
+      if ch < 0x10000 || ch > 0x10FFFF {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 4
     } else {

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -213,7 +213,13 @@ pub fn[T : Reader] read_string(reader : T) -> String raise {
         raise ReaderError::InvalidString
       }
       let b2 = reader |> read_byte() |> Byte::to_int()
+      if (b2 & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x1F) << 6) | (b2 & 0x3F)
+      if ch < 0x80 {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 2
     } else if b < 0xF0 {
@@ -222,7 +228,13 @@ pub fn[T : Reader] read_string(reader : T) -> String raise {
       }
       let b2 = reader |> read_byte() |> Byte::to_int()
       let b3 = reader |> read_byte() |> Byte::to_int()
+      if (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x0F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F)
+      if ch < 0x800 || (ch >= 0xD800 && ch <= 0xDFFF) {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 3
     } else if b < 0xF8 {
@@ -230,10 +242,18 @@ pub fn[T : Reader] read_string(reader : T) -> String raise {
         raise ReaderError::InvalidString
       }
       read_exactly(reader, varint_bytes, offset=0, length=3)
+      if (varint_bytes[0].to_int() & 0xC0) != 0x80 ||
+        (varint_bytes[1].to_int() & 0xC0) != 0x80 ||
+        (varint_bytes[2].to_int() & 0xC0) != 0x80 {
+        raise ReaderError::InvalidString
+      }
       let ch = ((b & 0x07) << 18) |
         ((varint_bytes[0].to_int() & 0x3F) << 12) |
         ((varint_bytes[1].to_int() & 0x3F) << 6) |
         (varint_bytes[2].to_int() & 0x3F)
+      if ch < 0x10000 || ch > 0x10FFFF {
+        raise ReaderError::InvalidString
+      }
       string.write_char(ch.unsafe_to_char())
       continue i + 4
     } else {

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -63,6 +63,46 @@ test "read_string" {
 }
 
 ///|
+test "read_string/overlong_2byte" {
+  // \xC0\x80 is an overlong encoding of U+0000 (null)
+  let r = @protobuf.BytesReader::from_bytes(b"\x02\xC0\x80")
+    as &@protobuf.Reader
+  inspect(try? (r |> @protobuf.read_string()), content="Err(InvalidString)")
+}
+
+///|
+test "read_string/surrogate" {
+  // \xED\xA0\x80 is U+D800 (surrogate)
+  let r = @protobuf.BytesReader::from_bytes(b"\x03\xED\xA0\x80")
+    as &@protobuf.Reader
+  inspect(try? (r |> @protobuf.read_string()), content="Err(InvalidString)")
+}
+
+///|
+test "read_string/invalid_continuation" {
+  // \xC2\xFF — second byte is not a valid continuation byte
+  let r = @protobuf.BytesReader::from_bytes(b"\x02\xC2\xFF")
+    as &@protobuf.Reader
+  inspect(try? (r |> @protobuf.read_string()), content="Err(InvalidString)")
+}
+
+///|
+test "read_string/invalid_continuation_3byte" {
+  // \xE0\x00\x80 — second byte is not a valid continuation byte
+  let r = @protobuf.BytesReader::from_bytes(b"\x03\xE0\x00\x80")
+    as &@protobuf.Reader
+  inspect(try? (r |> @protobuf.read_string()), content="Err(InvalidString)")
+}
+
+///|
+test "read_string/overlong_3byte" {
+  // \xE0\x80\x80 is an overlong encoding of U+0000 (decoded value < 0x800)
+  let r = @protobuf.BytesReader::from_bytes(b"\x03\xE0\x80\x80")
+    as &@protobuf.Reader
+  inspect(try? (r |> @protobuf.read_string()), content="Err(InvalidString)")
+}
+
+///|
 test "error" {
   let r = @protobuf.BytesReader::from_bytes(b"") as &@protobuf.Reader
   inspect(try? (r |> @protobuf.read_varint32()), content="Err(EndOfStream)")

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -66,6 +66,90 @@ test "read_string" {
 }
 
 ///|
+test "read_string/overlong_2byte" {
+  // \xC0\x80 is an overlong encoding of U+0000 (null)
+  let r = @protobuf.BytesReader::from_bytes(b"\x02\xC0\x80")
+    as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_string()
+    fail("expected InvalidString")
+  } catch {
+    @protobuf.InvalidString => ()
+    err => raise err
+  }
+}
+
+///|
+test "read_string/surrogate" {
+  // \xED\xA0\x80 is U+D800 (surrogate)
+  let r = @protobuf.BytesReader::from_bytes(b"\x03\xED\xA0\x80")
+    as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_string()
+    fail("expected InvalidString")
+  } catch {
+    @protobuf.InvalidString => ()
+    err => raise err
+  }
+}
+
+///|
+test "read_string/invalid_continuation" {
+  // \xC2\xFF has a second byte that is not a valid continuation byte.
+  let r = @protobuf.BytesReader::from_bytes(b"\x02\xC2\xFF")
+    as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_string()
+    fail("expected InvalidString")
+  } catch {
+    @protobuf.InvalidString => ()
+    err => raise err
+  }
+}
+
+///|
+test "read_string/invalid_continuation_3byte" {
+  // \xE0\x00\x80 has a second byte that is not a valid continuation byte.
+  let r = @protobuf.BytesReader::from_bytes(b"\x03\xE0\x00\x80")
+    as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_string()
+    fail("expected InvalidString")
+  } catch {
+    @protobuf.InvalidString => ()
+    err => raise err
+  }
+}
+
+///|
+test "read_string/overlong_3byte" {
+  // \xE0\x80\x80 is an overlong encoding of U+0000 (decoded value < 0x800)
+  let r = @protobuf.BytesReader::from_bytes(b"\x03\xE0\x80\x80")
+    as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_string()
+    fail("expected InvalidString")
+  } catch {
+    @protobuf.InvalidString => ()
+    err => raise err
+  }
+}
+
+///|
+test "read_string/codepoint_too_large" {
+  // \xF4\x90\x80\x80 encodes U+110000, which is above Unicode's max code point.
+  let r = @protobuf.BytesReader::from_bytes(b"\x04\xF4\x90\x80\x80")
+    as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_string()
+    fail("expected InvalidString")
+  } catch {
+    @protobuf.InvalidString => ()
+    err => raise err
+  }
+}
+
+///|
 test "error" {
   let r = @protobuf.BytesReader::from_bytes(b"") as &@protobuf.Reader
   try {


### PR DESCRIPTION
## Summary
- Validate continuation bytes have `0b10xxxxxx` form
- Reject overlong sequences (2-byte < U+80, 3-byte < U+800, 4-byte < U+10000)
- Reject surrogate range (U+D800..U+DFFF)
- Reject code points > U+10FFFF
- Applied to both `read_string` and `async_read_string`

## Test plan
- [x] `read_string/overlong_2byte` — rejects `\xC0\x80`
- [x] `read_string/surrogate` — rejects `\xED\xA0\x80` (U+D800)
- [x] `read_string/invalid_continuation` — rejects `\xC2\xFF`
- [x] `read_string/invalid_continuation_3byte` — rejects `\xE0\x00\x80`
- [x] `read_string/overlong_3byte` — rejects `\xE0\x80\x80`
- [x] All existing tests pass (`moon test -C lib`)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)