### PR TITLE
fix: fix BytesReader.read offset handling

### DIFF
--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -38,10 +38,9 @@ pub impl Reader for BytesReader with read(
   offset~ : Int,
   max_length~ : Int,
 ) -> Int? {
-  if offset >= self.len || max_length <= 0 || self.start >= self.len {
+  if offset >= bytes.length() || max_length <= 0 || self.start >= self.len {
     return None
   }
-  let offset = offset % bytes.length()
   let read_length = @cmp.minimum(
     @cmp.minimum(bytes.length() - offset, max_length),
     self.len - self.start,

--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -63,10 +63,9 @@ pub impl Reader for BytesReader with fn read(
   offset~ : Int,
   max_length~ : Int,
 ) -> Int? {
-  if offset >= self.len || max_length <= 0 || self.start >= self.len {
+  if offset >= bytes.length() || max_length <= 0 || self.start >= self.len {
     return None
   }
-  let offset = offset % bytes.length()
   let read_length = @cmp.minimum(
     @cmp.minimum(bytes.length() - offset, max_length),
     self.len - self.start,

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -67,3 +67,15 @@ test "error" {
   let r = @protobuf.BytesReader::from_bytes(b"") as &@protobuf.Reader
   inspect(try? (r |> @protobuf.read_varint32()), content="Err(EndOfStream)")
 }
+
+///|
+test "BytesReader::read returns None for out-of-range offset" {
+  let reader = @protobuf.BytesReader::from_bytes(b"\x01\x02\x03")
+  let buf : FixedArray[Byte] = FixedArray::make(4, b'\x00')
+  // offset equals buffer length -> should return None, not wrap
+  let result = (reader as &@protobuf.Reader).read(buf, offset=4, max_length=1)
+  inspect(result, content="None")
+  // offset exceeds buffer length -> should also return None
+  let result2 = (reader as &@protobuf.Reader).read(buf, offset=10, max_length=1)
+  inspect(result2, content="None")
+}

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -79,3 +79,15 @@ test "error" {
     err => raise err
   }
 }
+
+///|
+test "BytesReader::read returns None for out-of-range offset" {
+  let reader = @protobuf.BytesReader::from_bytes(b"\x01\x02\x03")
+  let buf : FixedArray[Byte] = FixedArray::make(4, b'\x00')
+  // offset equals buffer length -> should return None, not wrap
+  let result = (reader as &@protobuf.Reader).read(buf, offset=4, max_length=1)
+  @debug.assert_eq(result, None)
+  // offset exceeds buffer length -> should also return None
+  let result2 = (reader as &@protobuf.Reader).read(buf, offset=10, max_length=1)
+  @debug.assert_eq(result2, None)
+}


### PR DESCRIPTION
## Summary
- Check offset against destination buffer length (`bytes.length()`) instead of source data length (`self.len`)
- Remove modulo wrapping (`offset % bytes.length()`) that could corrupt writes by wrapping out-of-range offsets back into the buffer
- The async `Reader` impl already had the correct behavior

## Test plan
- [x] Added test verifying out-of-range offsets return `None`
- [x] All existing tests pass (`moon test -C lib`)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)