### PR TITLE
[codex] fix varint size boundaries

### DIFF
--- a/lib/sizeof.mbt
+++ b/lib/sizeof.mbt
@@ -24,23 +24,23 @@ pub fn[T : Sized] size_of(t : T) -> UInt {
 
 ///|
 fn size_of_varint(v : UInt64) -> UInt {
-  if v < 0x80 {
+  if v < 0x80UL {
     1
-  } else if v < 0x3FFF {
+  } else if v < 0x4000UL {
     2
-  } else if v < 0x1FFFFF {
+  } else if v < 0x200000UL {
     3
-  } else if v < 0xFFFFFFF {
+  } else if v < 0x10000000UL {
     4
-  } else if v < 0x7FFFFFFFF {
+  } else if v < 0x800000000UL {
     5
-  } else if v < 0x3FFFFFFFFFF {
+  } else if v < 0x40000000000UL {
     6
-  } else if v < 0x1FFFFFFFFFFFF {
+  } else if v < 0x2000000000000UL {
     7
-  } else if v < 0xFFFFFFFFFFFFFF {
+  } else if v < 0x100000000000000UL {
     8
-  } else if v < 0x7FFFFFFFFFFFFFFF {
+  } else if v < 0x8000000000000000UL {
     9
   } else {
     10

--- a/lib/writer_test.mbt
+++ b/lib/writer_test.mbt
@@ -20,6 +20,18 @@ test "varint" {
 }
 
 ///|
+test "varint size boundaries" {
+  assert_eq(@protobuf.size_of(0x7FUL), 1U)
+  assert_eq(@protobuf.size_of(0x80UL), 2U)
+  assert_eq(@protobuf.size_of(0x3FFFUL), 2U)
+  assert_eq(@protobuf.size_of(0x4000UL), 3U)
+  assert_eq(@protobuf.size_of(0x1FFFFFUL), 3U)
+  assert_eq(@protobuf.size_of(0x200000UL), 4U)
+  assert_eq(@protobuf.size_of(0xFFFFFFFUL), 4U)
+  assert_eq(@protobuf.size_of(0x10000000UL), 5U)
+}
+
+///|
 test "integer" {
   let writer = @buffer.new()
   writer |> @protobuf.write_int64(-2)


### PR DESCRIPTION
## Summary
- correct base-128 varint size thresholds to use 7-bit boundary powers
- add boundary tests for representative varint sizes

## Root Cause
The previous thresholds used values like `0x3FFF` as exclusive cutoffs, which undercounted exact boundary values that require the next varint byte.

## Validation
- `moon -C lib test`
- `git diff --check`