### PR TITLE
[codex] accept unpacked repeated scalar fields

### DIFF
--- a/cli/template.mbt
+++ b/cli/template.mbt
@@ -1070,7 +1070,7 @@ fn CodeGenerator::gen_repeated_field_read(
   if field.is_enum() || field.is_message() {
     name = self.get_moonbit_type(field, parent_path~)
   }
-  if field.is_base_type() {
+  if field.is_packable_scalar() {
     let unpacked_wire = match kind {
       FieldDescriptorProto_Type::TYPE_BOOL
       | FieldDescriptorProto_Type::TYPE_ENUM

--- a/cli/template.mbt
+++ b/cli/template.mbt
@@ -1070,36 +1070,61 @@ fn CodeGenerator::gen_repeated_field_read(
   if field.is_enum() || field.is_message() {
     name = self.get_moonbit_type(field, parent_path~)
   }
-  if field.is_pack() {
-    match kind {
+  if field.is_base_type() {
+    let unpacked_wire = match kind {
       FieldDescriptorProto_Type::TYPE_BOOL
+      | FieldDescriptorProto_Type::TYPE_ENUM
       | FieldDescriptorProto_Type::TYPE_INT32
       | FieldDescriptorProto_Type::TYPE_INT64
-      | FieldDescriptorProto_Type::TYPE_UINT32
-      | FieldDescriptorProto_Type::TYPE_UINT64
       | FieldDescriptorProto_Type::TYPE_SINT32
-      | FieldDescriptorProto_Type::TYPE_SINT64 =>
-        content.write_string(
-          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @lib.\{async_keyword_to_snake}read_packed(\{kind_read_func(kind, is_async~)}, None)).iter()) }\n",
-        )
-
-      // I64
+      | FieldDescriptorProto_Type::TYPE_SINT64
+      | FieldDescriptorProto_Type::TYPE_UINT32
+      | FieldDescriptorProto_Type::TYPE_UINT64 => 0
       FieldDescriptorProto_Type::TYPE_SFIXED64
       | FieldDescriptorProto_Type::TYPE_FIXED64
-      | FieldDescriptorProto_Type::TYPE_DOUBLE =>
-        content.write_string(
-          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @lib.\{async_keyword_to_snake}read_packed(\{kind_read_func(kind, is_async~)}, Some(8))).iter()) }\n",
-        )
-
-      // I32
+      | FieldDescriptorProto_Type::TYPE_DOUBLE => 1
       FieldDescriptorProto_Type::TYPE_SFIXED32
       | FieldDescriptorProto_Type::TYPE_FIXED32
-      | FieldDescriptorProto_Type::TYPE_FLOAT =>
-        content.write_string(
-          "      (\{field_number}, _) => { msg.\{field_name}.push_iter((reader |> @lib.\{async_keyword_to_snake}read_packed(\{kind_read_func(kind, is_async~)}, Some(4))).iter()) }\n",
-        )
-      _ => raise UnexpectedType("Packed field type: \{kind}")
+      | FieldDescriptorProto_Type::TYPE_FLOAT => 5
+      _ => raise UnexpectedType("Packable field type: \{kind}")
     }
+    let packed_size = match kind {
+      FieldDescriptorProto_Type::TYPE_BOOL
+      | FieldDescriptorProto_Type::TYPE_ENUM
+      | FieldDescriptorProto_Type::TYPE_INT32
+      | FieldDescriptorProto_Type::TYPE_INT64
+      | FieldDescriptorProto_Type::TYPE_SINT32
+      | FieldDescriptorProto_Type::TYPE_SINT64
+      | FieldDescriptorProto_Type::TYPE_UINT32
+      | FieldDescriptorProto_Type::TYPE_UINT64 => "None"
+      FieldDescriptorProto_Type::TYPE_SFIXED64
+      | FieldDescriptorProto_Type::TYPE_FIXED64
+      | FieldDescriptorProto_Type::TYPE_DOUBLE => "Some(8)"
+      FieldDescriptorProto_Type::TYPE_SFIXED32
+      | FieldDescriptorProto_Type::TYPE_FIXED32
+      | FieldDescriptorProto_Type::TYPE_FLOAT => "Some(4)"
+      _ => raise UnexpectedType("Packable field type: \{kind}")
+    }
+    let packed_reader = packed_kind_read_func(kind, is_async~)
+    let packed_read = "reader |> @lib.\{async_keyword_to_snake}read_packed(\{packed_reader}, \{packed_size})"
+    match kind {
+      FieldDescriptorProto_Type::TYPE_SINT32
+      | FieldDescriptorProto_Type::TYPE_SINT64 =>
+        content.write_string(
+          "      (\{field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{field_name}.push(item.0) } }\n",
+        )
+      FieldDescriptorProto_Type::TYPE_ENUM =>
+        content.write_string(
+          "      (\{field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{field_name}.push(\{name}::from_enum(item)) } }\n",
+        )
+      _ =>
+        content.write_string(
+          "      (\{field_number}, 2) => { msg.\{field_name}.push_iter((\{packed_read}).iter()) }\n",
+        )
+    }
+    content.write_string(
+      "      (\{field_number}, \{unpacked_wire}) => msg.\{field_name}.push(\{gen_kind_read(kind, name, is_async~)})\n",
+    )
   } else if field.map_key_value() is Some(_) {
     content.write_string(
       "      (\{field_number}, _) => { let {key, value} = \{gen_kind_read(kind, name, is_async~)}; msg.\{field_name}[key] = value }\n",
@@ -1108,6 +1133,18 @@ fn CodeGenerator::gen_repeated_field_read(
     content.write_string(
       "      (\{field_number}, _) => msg.\{field_name}.push(\{gen_kind_read(kind, name, is_async~)})\n",
     )
+  }
+}
+
+///|
+fn packed_kind_read_func(
+  kind : FieldDescriptorProto_Type,
+  is_async? : Bool = false,
+) -> String raise {
+  let async_keyword = if is_async { "async_" } else { "" }
+  match kind {
+    FieldDescriptorProto_Type::TYPE_ENUM => "@lib.\{async_keyword}read_enum"
+    _ => kind_read_func(kind, is_async~)
   }
 }
 

--- a/cli/types.mbt
+++ b/cli/types.mbt
@@ -114,8 +114,10 @@ fn Field::is_pack(self : Field) -> Bool {
   }
   match file.syntax {
     Proto3 =>
-      (self.desc.options is Some(options) && options.packed is Some(true)) ||
-      (self.is_list() && self.is_packable_scalar())
+      match self.desc.options {
+        Some({ packed: Some(packed), .. }) => packed
+        _ => self.is_list() && self.is_packable_scalar()
+      }
     Proto2 => self.desc.options is Some(options) && options.packed is Some(true)
   }
 }

--- a/cli/types.mbt
+++ b/cli/types.mbt
@@ -115,7 +115,7 @@ fn Field::is_pack(self : Field) -> Bool {
   match file.syntax {
     Proto3 =>
       (self.desc.options is Some(options) && options.packed is Some(true)) ||
-      (self.is_list() && self.is_base_type())
+      (self.is_list() && self.is_packable_scalar())
     Proto2 => self.desc.options is Some(options) && options.packed is Some(true)
   }
 }
@@ -135,6 +135,28 @@ fn Field::is_base_type(self : Field) -> Bool {
   guard self.type_ is Some(type_) else { return false }
   return match type_ {
     FieldDescriptorProto_Type::TYPE_BOOL
+    | FieldDescriptorProto_Type::TYPE_INT32
+    | FieldDescriptorProto_Type::TYPE_INT64
+    | FieldDescriptorProto_Type::TYPE_UINT32
+    | FieldDescriptorProto_Type::TYPE_UINT64
+    | FieldDescriptorProto_Type::TYPE_SINT32
+    | FieldDescriptorProto_Type::TYPE_SINT64
+    | FieldDescriptorProto_Type::TYPE_SFIXED64
+    | FieldDescriptorProto_Type::TYPE_FIXED64
+    | FieldDescriptorProto_Type::TYPE_DOUBLE
+    | FieldDescriptorProto_Type::TYPE_SFIXED32
+    | FieldDescriptorProto_Type::TYPE_FIXED32
+    | FieldDescriptorProto_Type::TYPE_FLOAT => true
+    _ => false
+  }
+}
+
+///|
+fn Field::is_packable_scalar(self : Field) -> Bool {
+  guard self.type_ is Some(type_) else { return false }
+  return match type_ {
+    FieldDescriptorProto_Type::TYPE_BOOL
+    | FieldDescriptorProto_Type::TYPE_ENUM
     | FieldDescriptorProto_Type::TYPE_INT32
     | FieldDescriptorProto_Type::TYPE_INT64
     | FieldDescriptorProto_Type::TYPE_UINT32

--- a/test/reader/gen_proto2/src/top.mbt
+++ b/test/reader/gen_proto2/src/top.mbt
@@ -22,17 +22,17 @@ pub fn FooEnumP2::from_enum(i : @lib.Enum) -> FooEnumP2 {
 }
 
 ///|
-pub impl Default for FooEnumP2 with default() -> FooEnumP2 {
+pub impl Default for FooEnumP2 with fn default() -> FooEnumP2 {
   FooEnumP2::FIRST_VALUEX
 }
 
 ///|
-pub impl @lib.Sized for FooEnumP2 with size_of(self : FooEnumP2) {
+pub impl @lib.Sized for FooEnumP2 with fn size_of(self : FooEnumP2) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FooEnumP2 with from_json(
+pub impl @json.FromJson for FooEnumP2 with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FooEnumP2 raise {
@@ -49,7 +49,7 @@ pub impl @json.FromJson for FooEnumP2 with from_json(
 }
 
 ///|
-pub impl ToJson for FooEnumP2 with to_json(self : FooEnumP2) -> Json {
+pub impl ToJson for FooEnumP2 with fn to_json(self : FooEnumP2) -> Json {
   match self {
     FooEnumP2::FIRST_VALUEX => "FIRST_VALUEX"
     FooEnumP2::SECOND_VALUEX => "SECOND_VALUEX"
@@ -62,14 +62,14 @@ pub(all) struct BarMessageP2 {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for BarMessageP2 with size_of(self) {
+pub impl @lib.Sized for BarMessageP2 with fn size_of(self) {
   let mut size = 0U
   size += 1U + @lib.size_of(self.b_int32)
   size
 }
 
 ///|
-pub impl Default for BarMessageP2 with default() -> BarMessageP2 {
+pub impl Default for BarMessageP2 with fn default() -> BarMessageP2 {
   BarMessageP2::{ b_int32: Int::default() }
 }
 
@@ -79,7 +79,7 @@ pub fn BarMessageP2::new(b_int32 : Int) -> BarMessageP2 {
 }
 
 ///|
-pub impl @lib.Read for BarMessageP2 with read_with_limit(
+pub impl @lib.Read for BarMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BarMessageP2 raise {
   let msg = BarMessageP2::default()
@@ -98,7 +98,7 @@ pub impl @lib.Read for BarMessageP2 with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for BarMessageP2 with write(
+pub impl @lib.Write for BarMessageP2 with fn write(
   self : BarMessageP2,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -107,7 +107,7 @@ pub impl @lib.Write for BarMessageP2 with write(
 }
 
 ///|
-pub impl ToJson for BarMessageP2 with to_json(self) {
+pub impl ToJson for BarMessageP2 with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.b_int32 != Default::default() {
     json["bInt32"] = self.b_int32.to_json()
@@ -116,7 +116,7 @@ pub impl ToJson for BarMessageP2 with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for BarMessageP2 with from_json(
+pub impl @json.FromJson for BarMessageP2 with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> BarMessageP2 raise {
@@ -134,7 +134,7 @@ pub impl @json.FromJson for BarMessageP2 with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for BarMessageP2 with read_with_limit(
+pub impl @lib.AsyncRead for BarMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BarMessageP2 raise {
   let msg = BarMessageP2::default()
@@ -153,7 +153,7 @@ pub impl @lib.AsyncRead for BarMessageP2 with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for BarMessageP2 with write(
+pub impl @lib.AsyncWrite for BarMessageP2 with fn write(
   self : BarMessageP2,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -198,10 +198,11 @@ pub(all) struct FooMessageP2 {
   mut f_default_bool : Bool?
   mut f_default_double : Double?
   mut f_default_enum : FooEnumP2?
+  mut f_repeated_packed_enum : Array[FooEnumP2]
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FooMessageP2 with size_of(self) {
+pub impl @lib.Sized for FooMessageP2 with fn size_of(self) {
   let mut size = 0U
   size += 1U + @lib.size_of(self.f_int32)
   size += 1U + @lib.size_of(self.f_int64)
@@ -347,11 +348,19 @@ pub impl @lib.Sized for FooMessageP2 with size_of(self) {
   if self.f_default_enum is Some(v) {
     size += 2U + @lib.size_of(v)
   }
+  size += 2U +
+    ({
+      let size = self.f_repeated_packed_enum
+        .iter()
+        .map(@lib.size_of)
+        .fold(init=0U, UInt::add)
+      @lib.size_of(size) + size
+    })
   size
 }
 
 ///|
-pub impl Default for FooMessageP2 with default() -> FooMessageP2 {
+pub impl Default for FooMessageP2 with fn default() -> FooMessageP2 {
   FooMessageP2::{
     f_int32: Int::default(),
     f_int64: Int64::default(),
@@ -388,6 +397,7 @@ pub impl Default for FooMessageP2 with default() -> FooMessageP2 {
     f_default_bool: Some(true),
     f_default_double: Some(3.14),
     f_default_enum: Some(FooEnumP2::SECOND_VALUEX),
+    f_repeated_packed_enum: [],
   }
 }
 
@@ -428,6 +438,7 @@ pub fn FooMessageP2::new(
   f_default_bool? : Bool,
   f_default_double? : Double,
   f_default_enum? : FooEnumP2,
+  f_repeated_packed_enum : Array[FooEnumP2],
 ) -> FooMessageP2 {
   FooMessageP2::{
     f_int32,
@@ -465,11 +476,12 @@ pub fn FooMessageP2::new(
     f_default_bool,
     f_default_double,
     f_default_enum,
+    f_repeated_packed_enum,
   }
 }
 
 ///|
-pub impl @lib.Read for FooMessageP2 with read_with_limit(
+pub impl @lib.Read for FooMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FooMessageP2 raise {
   let msg = FooMessageP2::default()
@@ -543,6 +555,16 @@ pub impl @lib.Read for FooMessageP2 with read_with_limit(
             |> @lib.read_enum()
             |> FooEnumP2::from_enum
             |> Some
+        (39, 2) => {
+          let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+          for item in packed {
+            msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
+          }
+        }
+        (39, 0) =>
+          msg.f_repeated_packed_enum.push(
+            reader |> @lib.read_enum() |> FooEnumP2::from_enum,
+          )
         (_, wire) => reader |> @lib.read_unknown(wire)
       }
     }
@@ -554,7 +576,7 @@ pub impl @lib.Read for FooMessageP2 with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FooMessageP2 with write(
+pub impl @lib.Write for FooMessageP2 with fn write(
   self : FooMessageP2,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -706,10 +728,19 @@ pub impl @lib.Write for FooMessageP2 with write(
     writer |> @lib.write_varint(304UL)
     writer |> @lib.write_enum(v.to_enum())
   }
+  writer |> @lib.write_varint(314UL)
+  let size = self.f_repeated_packed_enum
+    .iter()
+    .map(@lib.size_of)
+    .fold(init=0U, UInt::add)
+  writer |> @lib.write_uint32(size)
+  for item in self.f_repeated_packed_enum {
+    writer |> @lib.write_enum(item.to_enum())
+  }
 }
 
 ///|
-pub impl ToJson for FooMessageP2 with to_json(self) {
+pub impl ToJson for FooMessageP2 with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.f_int32 != Default::default() {
     json["fInt32"] = self.f_int32.to_json()
@@ -845,11 +876,14 @@ pub impl ToJson for FooMessageP2 with to_json(self) {
       json["fDefaultEnum"] = v.to_json()
     _ => ()
   }
+  if self.f_repeated_packed_enum != Default::default() {
+    json["fRepeatedPackedEnum"] = self.f_repeated_packed_enum.to_json()
+  }
   Json::object(json)
 }
 
 ///|
-pub impl @json.FromJson for FooMessageP2 with from_json(
+pub impl @json.FromJson for FooMessageP2 with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FooMessageP2 raise {
@@ -928,6 +962,10 @@ pub impl @json.FromJson for FooMessageP2 with from_json(
         message.f_default_double = Some(@json.from_json(value, path~))
       ("fDefaultEnum", value) =>
         message.f_default_enum = Some(@json.from_json(value, path~))
+      ("fRepeatedPackedEnum", Array(value)) =>
+        message.f_repeated_packed_enum = value.map(v => {
+          @json.from_json(v, path~)
+        })
       key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
@@ -935,7 +973,7 @@ pub impl @json.FromJson for FooMessageP2 with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for FooMessageP2 with read_with_limit(
+pub impl @lib.AsyncRead for FooMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FooMessageP2 raise {
   let msg = FooMessageP2::default()
@@ -1020,6 +1058,17 @@ pub impl @lib.AsyncRead for FooMessageP2 with read_with_limit(
             |> @lib.async_read_enum()
             |> FooEnumP2::from_enum
             |> Some
+        (39, 2) => {
+          let packed = reader
+            |> @lib.async_read_packed(@lib.async_read_enum, None)
+          for item in packed {
+            msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
+          }
+        }
+        (39, 0) =>
+          msg.f_repeated_packed_enum.push(
+            reader |> @lib.async_read_enum() |> FooEnumP2::from_enum,
+          )
         (_, wire) => reader |> @lib.async_read_unknown(wire)
       }
     }
@@ -1031,7 +1080,7 @@ pub impl @lib.AsyncRead for FooMessageP2 with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FooMessageP2 with write(
+pub impl @lib.AsyncWrite for FooMessageP2 with fn write(
   self : FooMessageP2,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1183,6 +1232,15 @@ pub impl @lib.AsyncWrite for FooMessageP2 with write(
     writer |> @lib.async_write_varint(304UL)
     writer |> @lib.async_write_enum(v.to_enum())
   }
+  writer |> @lib.async_write_varint(314UL)
+  let size = self.f_repeated_packed_enum
+    .iter()
+    .map(@lib.size_of)
+    .fold(init=0U, UInt::add)
+  writer |> @lib.async_write_uint32(size)
+  for item in self.f_repeated_packed_enum {
+    writer |> @lib.async_write_enum(item.to_enum())
+  }
 }
 
 ///|
@@ -1192,7 +1250,7 @@ pub(all) struct MapEntryP2 {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for MapEntryP2 with size_of(self) {
+pub impl @lib.Sized for MapEntryP2 with fn size_of(self) {
   let mut size = 0U
   size += 1U +
     ({
@@ -1204,7 +1262,7 @@ pub impl @lib.Sized for MapEntryP2 with size_of(self) {
 }
 
 ///|
-pub impl Default for MapEntryP2 with default() -> MapEntryP2 {
+pub impl Default for MapEntryP2 with fn default() -> MapEntryP2 {
   MapEntryP2::{ key: String::default(), value: Int::default() }
 }
 
@@ -1214,7 +1272,7 @@ pub fn MapEntryP2::new(key : String, value : Int) -> MapEntryP2 {
 }
 
 ///|
-pub impl @lib.Read for MapEntryP2 with read_with_limit(
+pub impl @lib.Read for MapEntryP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MapEntryP2 raise {
   let msg = MapEntryP2::default()
@@ -1234,7 +1292,7 @@ pub impl @lib.Read for MapEntryP2 with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for MapEntryP2 with write(
+pub impl @lib.Write for MapEntryP2 with fn write(
   self : MapEntryP2,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1245,7 +1303,7 @@ pub impl @lib.Write for MapEntryP2 with write(
 }
 
 ///|
-pub impl ToJson for MapEntryP2 with to_json(self) {
+pub impl ToJson for MapEntryP2 with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.key != Default::default() {
     json["key"] = self.key.to_json()
@@ -1257,7 +1315,7 @@ pub impl ToJson for MapEntryP2 with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for MapEntryP2 with from_json(
+pub impl @json.FromJson for MapEntryP2 with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> MapEntryP2 raise {
@@ -1276,7 +1334,7 @@ pub impl @json.FromJson for MapEntryP2 with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for MapEntryP2 with read_with_limit(
+pub impl @lib.AsyncRead for MapEntryP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MapEntryP2 raise {
   let msg = MapEntryP2::default()
@@ -1296,7 +1354,7 @@ pub impl @lib.AsyncRead for MapEntryP2 with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for MapEntryP2 with write(
+pub impl @lib.AsyncWrite for MapEntryP2 with fn write(
   self : MapEntryP2,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1337,19 +1395,19 @@ pub fn BazMessageP2_Nested_NestedEnum::from_enum(
 }
 
 ///|
-pub impl Default for BazMessageP2_Nested_NestedEnum with default() -> BazMessageP2_Nested_NestedEnum {
+pub impl Default for BazMessageP2_Nested_NestedEnum with fn default() -> BazMessageP2_Nested_NestedEnum {
   BazMessageP2_Nested_NestedEnum::Foo
 }
 
 ///|
-pub impl @lib.Sized for BazMessageP2_Nested_NestedEnum with size_of(
+pub impl @lib.Sized for BazMessageP2_Nested_NestedEnum with fn size_of(
   self : BazMessageP2_Nested_NestedEnum,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for BazMessageP2_Nested_NestedEnum with from_json(
+pub impl @json.FromJson for BazMessageP2_Nested_NestedEnum with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> BazMessageP2_Nested_NestedEnum raise {
@@ -1368,7 +1426,7 @@ pub impl @json.FromJson for BazMessageP2_Nested_NestedEnum with from_json(
 }
 
 ///|
-pub impl ToJson for BazMessageP2_Nested_NestedEnum with to_json(
+pub impl ToJson for BazMessageP2_Nested_NestedEnum with fn to_json(
   self : BazMessageP2_Nested_NestedEnum,
 ) -> Json {
   match self {
@@ -1384,14 +1442,14 @@ pub(all) struct BazMessageP2_Nested_NestedMessage {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for BazMessageP2_Nested_NestedMessage with size_of(self) {
+pub impl @lib.Sized for BazMessageP2_Nested_NestedMessage with fn size_of(self) {
   let mut size = 0U
   size += 1U + @lib.size_of(self.f_nested)
   size
 }
 
 ///|
-pub impl Default for BazMessageP2_Nested_NestedMessage with default() -> BazMessageP2_Nested_NestedMessage {
+pub impl Default for BazMessageP2_Nested_NestedMessage with fn default() -> BazMessageP2_Nested_NestedMessage {
   BazMessageP2_Nested_NestedMessage::{ f_nested: Int::default() }
 }
 
@@ -1403,7 +1461,7 @@ pub fn BazMessageP2_Nested_NestedMessage::new(
 }
 
 ///|
-pub impl @lib.Read for BazMessageP2_Nested_NestedMessage with read_with_limit(
+pub impl @lib.Read for BazMessageP2_Nested_NestedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessageP2_Nested_NestedMessage raise {
   let msg = BazMessageP2_Nested_NestedMessage::default()
@@ -1422,7 +1480,7 @@ pub impl @lib.Read for BazMessageP2_Nested_NestedMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for BazMessageP2_Nested_NestedMessage with write(
+pub impl @lib.Write for BazMessageP2_Nested_NestedMessage with fn write(
   self : BazMessageP2_Nested_NestedMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1431,7 +1489,7 @@ pub impl @lib.Write for BazMessageP2_Nested_NestedMessage with write(
 }
 
 ///|
-pub impl ToJson for BazMessageP2_Nested_NestedMessage with to_json(self) {
+pub impl ToJson for BazMessageP2_Nested_NestedMessage with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.f_nested != Default::default() {
     json["fNested"] = self.f_nested.to_json()
@@ -1440,7 +1498,7 @@ pub impl ToJson for BazMessageP2_Nested_NestedMessage with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for BazMessageP2_Nested_NestedMessage with from_json(
+pub impl @json.FromJson for BazMessageP2_Nested_NestedMessage with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> BazMessageP2_Nested_NestedMessage raise {
@@ -1460,7 +1518,7 @@ pub impl @json.FromJson for BazMessageP2_Nested_NestedMessage with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for BazMessageP2_Nested_NestedMessage with read_with_limit(
+pub impl @lib.AsyncRead for BazMessageP2_Nested_NestedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessageP2_Nested_NestedMessage raise {
   let msg = BazMessageP2_Nested_NestedMessage::default()
@@ -1479,7 +1537,7 @@ pub impl @lib.AsyncRead for BazMessageP2_Nested_NestedMessage with read_with_lim
 }
 
 ///|
-pub impl @lib.AsyncWrite for BazMessageP2_Nested_NestedMessage with write(
+pub impl @lib.AsyncWrite for BazMessageP2_Nested_NestedMessage with fn write(
   self : BazMessageP2_Nested_NestedMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1493,7 +1551,7 @@ pub(all) struct BazMessageP2_Nested {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for BazMessageP2_Nested with size_of(self) {
+pub impl @lib.Sized for BazMessageP2_Nested with fn size_of(self) {
   let mut size = 0U
   if self.f_nested is Some(v) {
     size += 1U +
@@ -1506,7 +1564,7 @@ pub impl @lib.Sized for BazMessageP2_Nested with size_of(self) {
 }
 
 ///|
-pub impl Default for BazMessageP2_Nested with default() -> BazMessageP2_Nested {
+pub impl Default for BazMessageP2_Nested with fn default() -> BazMessageP2_Nested {
   BazMessageP2_Nested::{ f_nested: None }
 }
 
@@ -1518,7 +1576,7 @@ pub fn BazMessageP2_Nested::new(
 }
 
 ///|
-pub impl @lib.Read for BazMessageP2_Nested with read_with_limit(
+pub impl @lib.Read for BazMessageP2_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessageP2_Nested raise {
   let msg = BazMessageP2_Nested::default()
@@ -1540,7 +1598,7 @@ pub impl @lib.Read for BazMessageP2_Nested with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for BazMessageP2_Nested with write(
+pub impl @lib.Write for BazMessageP2_Nested with fn write(
   self : BazMessageP2_Nested,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1552,7 +1610,7 @@ pub impl @lib.Write for BazMessageP2_Nested with write(
 }
 
 ///|
-pub impl ToJson for BazMessageP2_Nested with to_json(self) {
+pub impl ToJson for BazMessageP2_Nested with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.f_nested {
     Some(v) => json["fNested"] = v.to_json()
@@ -1562,7 +1620,7 @@ pub impl ToJson for BazMessageP2_Nested with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for BazMessageP2_Nested with from_json(
+pub impl @json.FromJson for BazMessageP2_Nested with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> BazMessageP2_Nested raise {
@@ -1583,7 +1641,7 @@ pub impl @json.FromJson for BazMessageP2_Nested with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for BazMessageP2_Nested with read_with_limit(
+pub impl @lib.AsyncRead for BazMessageP2_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessageP2_Nested raise {
   let msg = BazMessageP2_Nested::default()
@@ -1606,7 +1664,7 @@ pub impl @lib.AsyncRead for BazMessageP2_Nested with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for BazMessageP2_Nested with write(
+pub impl @lib.AsyncWrite for BazMessageP2_Nested with fn write(
   self : BazMessageP2_Nested,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1625,7 +1683,7 @@ pub(all) struct BazMessageP2 {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for BazMessageP2 with size_of(self) {
+pub impl @lib.Sized for BazMessageP2 with fn size_of(self) {
   let mut size = 0U
   if self.nested is Some(v) {
     size += 1U +
@@ -1648,7 +1706,7 @@ pub impl @lib.Sized for BazMessageP2 with size_of(self) {
 }
 
 ///|
-pub impl Default for BazMessageP2 with default() -> BazMessageP2 {
+pub impl Default for BazMessageP2 with fn default() -> BazMessageP2 {
   BazMessageP2::{ nested: None, b_int64: None, b_string: None }
 }
 
@@ -1662,7 +1720,7 @@ pub fn BazMessageP2::new(
 }
 
 ///|
-pub impl @lib.Read for BazMessageP2 with read_with_limit(
+pub impl @lib.Read for BazMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessageP2 raise {
   let msg = BazMessageP2::default()
@@ -1685,7 +1743,7 @@ pub impl @lib.Read for BazMessageP2 with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for BazMessageP2 with write(
+pub impl @lib.Write for BazMessageP2 with fn write(
   self : BazMessageP2,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1705,7 +1763,7 @@ pub impl @lib.Write for BazMessageP2 with write(
 }
 
 ///|
-pub impl ToJson for BazMessageP2 with to_json(self) {
+pub impl ToJson for BazMessageP2 with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.nested {
     Some(v) => json["nested"] = v.to_json()
@@ -1723,7 +1781,7 @@ pub impl ToJson for BazMessageP2 with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for BazMessageP2 with from_json(
+pub impl @json.FromJson for BazMessageP2 with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> BazMessageP2 raise {
@@ -1744,7 +1802,7 @@ pub impl @json.FromJson for BazMessageP2 with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for BazMessageP2 with read_with_limit(
+pub impl @lib.AsyncRead for BazMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessageP2 raise {
   let msg = BazMessageP2::default()
@@ -1768,7 +1826,7 @@ pub impl @lib.AsyncRead for BazMessageP2 with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for BazMessageP2 with write(
+pub impl @lib.AsyncWrite for BazMessageP2 with fn write(
   self : BazMessageP2,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1793,7 +1851,7 @@ pub(all) struct RepeatedMessageP2 {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for RepeatedMessageP2 with size_of(self) {
+pub impl @lib.Sized for RepeatedMessageP2 with fn size_of(self) {
   let mut size = 0U
   for s in self.bar_message {
     let s = @lib.size_of(s)
@@ -1803,7 +1861,7 @@ pub impl @lib.Sized for RepeatedMessageP2 with size_of(self) {
 }
 
 ///|
-pub impl Default for RepeatedMessageP2 with default() -> RepeatedMessageP2 {
+pub impl Default for RepeatedMessageP2 with fn default() -> RepeatedMessageP2 {
   RepeatedMessageP2::{ bar_message: [] }
 }
 
@@ -1815,7 +1873,7 @@ pub fn RepeatedMessageP2::new(
 }
 
 ///|
-pub impl @lib.Read for RepeatedMessageP2 with read_with_limit(
+pub impl @lib.Read for RepeatedMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> RepeatedMessageP2 raise {
   let msg = RepeatedMessageP2::default()
@@ -1835,7 +1893,7 @@ pub impl @lib.Read for RepeatedMessageP2 with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for RepeatedMessageP2 with write(
+pub impl @lib.Write for RepeatedMessageP2 with fn write(
   self : RepeatedMessageP2,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1847,7 +1905,7 @@ pub impl @lib.Write for RepeatedMessageP2 with write(
 }
 
 ///|
-pub impl ToJson for RepeatedMessageP2 with to_json(self) {
+pub impl ToJson for RepeatedMessageP2 with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.bar_message != Default::default() {
     json["barMessage"] = self.bar_message.to_json()
@@ -1856,7 +1914,7 @@ pub impl ToJson for RepeatedMessageP2 with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for RepeatedMessageP2 with from_json(
+pub impl @json.FromJson for RepeatedMessageP2 with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> RepeatedMessageP2 raise {
@@ -1877,7 +1935,7 @@ pub impl @json.FromJson for RepeatedMessageP2 with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for RepeatedMessageP2 with read_with_limit(
+pub impl @lib.AsyncRead for RepeatedMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> RepeatedMessageP2 raise {
   let msg = RepeatedMessageP2::default()
@@ -1899,7 +1957,7 @@ pub impl @lib.AsyncRead for RepeatedMessageP2 with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for RepeatedMessageP2 with write(
+pub impl @lib.AsyncWrite for RepeatedMessageP2 with fn write(
   self : RepeatedMessageP2,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {

--- a/test/reader/gen_proto2/src/top.mbt
+++ b/test/reader/gen_proto2/src/top.mbt
@@ -499,15 +499,21 @@ pub impl @lib.Read for FooMessageP2 with read_with_limit(
         (18, _) =>
           msg.f_bar_message = (reader |> @lib.read_message() : BarMessageP2)
             |> Some
-        (19, _) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
-        (20, _) =>
+        (19, 2) =>
+          msg.f_repeated_int32.push_iter(
+            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+          )
+        (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
+        (20, 2) =>
           msg.f_repeated_packed_int32.push_iter(
             (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
           )
-        (21, _) =>
+        (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+        (21, 2) =>
           msg.f_repeated_packed_float.push_iter(
             (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
           )
+        (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
         (23, _) =>
           msg.f_baz = (reader |> @lib.read_message() : BazMessageP2) |> Some
         (24, _) =>
@@ -960,15 +966,23 @@ pub impl @lib.AsyncRead for FooMessageP2 with read_with_limit(
           msg.f_bar_message = (
               reader |> @lib.async_read_message() : BarMessageP2)
             |> Some
-        (19, _) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
-        (20, _) =>
+        (19, 2) =>
+          msg.f_repeated_int32.push_iter(
+            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+          )
+        (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+        (20, 2) =>
           msg.f_repeated_packed_int32.push_iter(
             (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
           )
-        (21, _) =>
+        (20, 0) =>
+          msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
+        (21, 2) =>
           msg.f_repeated_packed_float.push_iter(
             (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
           )
+        (21, 5) =>
+          msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
         (23, _) =>
           msg.f_baz = (reader |> @lib.async_read_message() : BazMessageP2)
             |> Some

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -602,18 +602,21 @@ pub impl @lib.Read for FooMessage with read_with_limit(
         (16, _) => msg.f_string = reader |> @lib.read_string()
         (18, _) =>
           msg.f_bar_message = (reader |> @lib.read_message() : BarMessage)
-        (19, _) =>
+        (19, 2) =>
           msg.f_repeated_int32.push_iter(
             (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
           )
-        (20, _) =>
+        (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
+        (20, 2) =>
           msg.f_repeated_packed_int32.push_iter(
             (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
           )
-        (21, _) =>
+        (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+        (21, 2) =>
           msg.f_repeated_packed_float.push_iter(
             (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
           )
+        (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
         (23, _) => msg.f_baz = (reader |> @lib.read_message() : BazMessage)
         (24, _) =>
           msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested)
@@ -966,18 +969,23 @@ pub impl @lib.AsyncRead for FooMessage with read_with_limit(
         (16, _) => msg.f_string = reader |> @lib.async_read_string()
         (18, _) =>
           msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage)
-        (19, _) =>
+        (19, 2) =>
           msg.f_repeated_int32.push_iter(
             (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
           )
-        (20, _) =>
+        (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+        (20, 2) =>
           msg.f_repeated_packed_int32.push_iter(
             (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
           )
-        (21, _) =>
+        (20, 0) =>
+          msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
+        (21, 2) =>
           msg.f_repeated_packed_float.push_iter(
             (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
           )
+        (21, 5) =>
+          msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
         (23, _) =>
           msg.f_baz = (reader |> @lib.async_read_message() : BazMessage)
         (24, _) =>

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -22,17 +22,17 @@ pub fn FooEnum::from_enum(i : @lib.Enum) -> FooEnum {
 }
 
 ///|
-pub impl Default for FooEnum with default() -> FooEnum {
+pub impl Default for FooEnum with fn default() -> FooEnum {
   FooEnum::FIRST_VALUE
 }
 
 ///|
-pub impl @lib.Sized for FooEnum with size_of(self : FooEnum) {
+pub impl @lib.Sized for FooEnum with fn size_of(self : FooEnum) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FooEnum with from_json(
+pub impl @json.FromJson for FooEnum with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FooEnum raise {
@@ -49,7 +49,7 @@ pub impl @json.FromJson for FooEnum with from_json(
 }
 
 ///|
-pub impl ToJson for FooEnum with to_json(self : FooEnum) -> Json {
+pub impl ToJson for FooEnum with fn to_json(self : FooEnum) -> Json {
   match self {
     FooEnum::FIRST_VALUE => "FIRST_VALUE"
     FooEnum::SECOND_VALUE => "SECOND_VALUE"
@@ -62,14 +62,14 @@ pub(all) struct BarMessage {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for BarMessage with size_of(self) {
+pub impl @lib.Sized for BarMessage with fn size_of(self) {
   let mut size = 0U
   size += 1U + @lib.size_of(self.b_int32)
   size
 }
 
 ///|
-pub impl Default for BarMessage with default() -> BarMessage {
+pub impl Default for BarMessage with fn default() -> BarMessage {
   BarMessage::{ b_int32: Int::default() }
 }
 
@@ -79,7 +79,7 @@ pub fn BarMessage::new(b_int32 : Int) -> BarMessage {
 }
 
 ///|
-pub impl @lib.Read for BarMessage with read_with_limit(
+pub impl @lib.Read for BarMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BarMessage raise {
   let msg = BarMessage::default()
@@ -98,7 +98,7 @@ pub impl @lib.Read for BarMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for BarMessage with write(
+pub impl @lib.Write for BarMessage with fn write(
   self : BarMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -107,7 +107,7 @@ pub impl @lib.Write for BarMessage with write(
 }
 
 ///|
-pub impl ToJson for BarMessage with to_json(self) {
+pub impl ToJson for BarMessage with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.b_int32 != Default::default() {
     json["bInt32"] = self.b_int32.to_json()
@@ -116,7 +116,7 @@ pub impl ToJson for BarMessage with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for BarMessage with from_json(
+pub impl @json.FromJson for BarMessage with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> BarMessage raise {
@@ -134,7 +134,7 @@ pub impl @json.FromJson for BarMessage with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for BarMessage with read_with_limit(
+pub impl @lib.AsyncRead for BarMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BarMessage raise {
   let msg = BarMessage::default()
@@ -153,7 +153,7 @@ pub impl @lib.AsyncRead for BarMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for BarMessage with write(
+pub impl @lib.AsyncWrite for BarMessage with fn write(
   self : BarMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -168,7 +168,7 @@ pub(all) struct FooMessage_FMapEntry {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FooMessage_FMapEntry with size_of(self) {
+pub impl @lib.Sized for FooMessage_FMapEntry with fn size_of(self) {
   let mut size = 0U
   size += 1U +
     ({
@@ -180,7 +180,7 @@ pub impl @lib.Sized for FooMessage_FMapEntry with size_of(self) {
 }
 
 ///|
-pub impl Default for FooMessage_FMapEntry with default() -> FooMessage_FMapEntry {
+pub impl Default for FooMessage_FMapEntry with fn default() -> FooMessage_FMapEntry {
   FooMessage_FMapEntry::{ key: String::default(), value: Int::default() }
 }
 
@@ -193,7 +193,7 @@ pub fn FooMessage_FMapEntry::new(
 }
 
 ///|
-pub impl @lib.Read for FooMessage_FMapEntry with read_with_limit(
+pub impl @lib.Read for FooMessage_FMapEntry with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
@@ -213,7 +213,7 @@ pub impl @lib.Read for FooMessage_FMapEntry with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FooMessage_FMapEntry with write(
+pub impl @lib.Write for FooMessage_FMapEntry with fn write(
   self : FooMessage_FMapEntry,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -224,7 +224,7 @@ pub impl @lib.Write for FooMessage_FMapEntry with write(
 }
 
 ///|
-pub impl ToJson for FooMessage_FMapEntry with to_json(self) {
+pub impl ToJson for FooMessage_FMapEntry with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.key != Default::default() {
     json["key"] = self.key.to_json()
@@ -236,7 +236,7 @@ pub impl ToJson for FooMessage_FMapEntry with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for FooMessage_FMapEntry with from_json(
+pub impl @json.FromJson for FooMessage_FMapEntry with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FooMessage_FMapEntry raise {
@@ -257,7 +257,7 @@ pub impl @json.FromJson for FooMessage_FMapEntry with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for FooMessage_FMapEntry with read_with_limit(
+pub impl @lib.AsyncRead for FooMessage_FMapEntry with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
@@ -277,7 +277,7 @@ pub impl @lib.AsyncRead for FooMessage_FMapEntry with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FooMessage_FMapEntry with write(
+pub impl @lib.AsyncWrite for FooMessage_FMapEntry with fn write(
   self : FooMessage_FMapEntry,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -317,6 +317,7 @@ pub(all) struct FooMessage {
   mut f_repeated_baz_message : Array[BazMessage]
   mut f_optional_string : String?
   mut with_json_name : String
+  mut f_repeated_packed_enum : Array[FooEnum]
   mut test_oneof : FooMessage_TestOneof
 } derive(Eq, Debug)
 
@@ -329,12 +330,12 @@ pub(all) enum FooMessage_TestOneof {
 } derive(Eq, Debug)
 
 ///|
-pub impl Default for FooMessage_TestOneof with default() -> FooMessage_TestOneof {
+pub impl Default for FooMessage_TestOneof with fn default() -> FooMessage_TestOneof {
   NotSet
 }
 
 ///|
-pub impl @json.FromJson for FooMessage_TestOneof with from_json(
+pub impl @json.FromJson for FooMessage_TestOneof with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FooMessage_TestOneof raise {
@@ -357,7 +358,7 @@ pub impl @json.FromJson for FooMessage_TestOneof with from_json(
 }
 
 ///|
-pub impl ToJson for FooMessage_TestOneof with to_json(
+pub impl ToJson for FooMessage_TestOneof with fn to_json(
   self : FooMessage_TestOneof,
 ) -> Json {
   match self {
@@ -369,7 +370,7 @@ pub impl ToJson for FooMessage_TestOneof with to_json(
 }
 
 ///|
-pub impl @lib.Sized for FooMessage with size_of(self) {
+pub impl @lib.Sized for FooMessage with fn size_of(self) {
   let mut size = 0U
   size += 1U + @lib.size_of(self.f_int32)
   size += 1U + @lib.size_of(self.f_int64)
@@ -461,6 +462,14 @@ pub impl @lib.Sized for FooMessage with size_of(self) {
       let size = @lib.size_of(self.with_json_name)
       @lib.size_of(size) + size
     })
+  size += 2U +
+    ({
+      let size = self.f_repeated_packed_enum
+        .iter()
+        .map(@lib.size_of)
+        .fold(init=0U, UInt::add)
+      @lib.size_of(size) + size
+    })
   match self.test_oneof {
     F1(v) => size += 2U + @lib.size_of(v)
     F2(v) => size += 2U + @lib.size_of(v)
@@ -476,7 +485,7 @@ pub impl @lib.Sized for FooMessage with size_of(self) {
 }
 
 ///|
-pub impl Default for FooMessage with default() -> FooMessage {
+pub impl Default for FooMessage with fn default() -> FooMessage {
   FooMessage::{
     f_int32: Int::default(),
     f_int64: Int64::default(),
@@ -506,6 +515,7 @@ pub impl Default for FooMessage with default() -> FooMessage {
     f_repeated_baz_message: [],
     f_optional_string: None,
     with_json_name: String::default(),
+    f_repeated_packed_enum: [],
     test_oneof: FooMessage_TestOneof::NotSet,
   }
 }
@@ -540,6 +550,7 @@ pub fn FooMessage::new(
   f_repeated_baz_message : Array[BazMessage],
   f_optional_string? : String,
   with_json_name : String,
+  f_repeated_packed_enum : Array[FooEnum],
   test_oneof? : FooMessage_TestOneof = FooMessage_TestOneof::NotSet,
 ) -> FooMessage {
   FooMessage::{
@@ -571,12 +582,13 @@ pub fn FooMessage::new(
     f_repeated_baz_message,
     f_optional_string,
     with_json_name,
+    f_repeated_packed_enum,
     test_oneof,
   }
 }
 
 ///|
-pub impl @lib.Read for FooMessage with read_with_limit(
+pub impl @lib.Read for FooMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FooMessage raise {
   let msg = FooMessage::default()
@@ -636,6 +648,16 @@ pub impl @lib.Read for FooMessage with read_with_limit(
           )
         (32, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
         (33, _) => msg.with_json_name = reader |> @lib.read_string()
+        (34, 2) => {
+          let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+          for item in packed {
+            msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
+          }
+        }
+        (34, 0) =>
+          msg.f_repeated_packed_enum.push(
+            reader |> @lib.read_enum() |> FooEnum::from_enum,
+          )
         (27, _) =>
           msg.test_oneof = reader
             |> @lib.read_int32()
@@ -659,7 +681,7 @@ pub impl @lib.Read for FooMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FooMessage with write(
+pub impl @lib.Write for FooMessage with fn write(
   self : FooMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -763,6 +785,15 @@ pub impl @lib.Write for FooMessage with write(
   }
   writer |> @lib.write_varint(266UL)
   writer |> @lib.write_string(self.with_json_name)
+  writer |> @lib.write_varint(274UL)
+  let size = self.f_repeated_packed_enum
+    .iter()
+    .map(@lib.size_of)
+    .fold(init=0U, UInt::add)
+  writer |> @lib.write_uint32(size)
+  for item in self.f_repeated_packed_enum {
+    writer |> @lib.write_enum(item.to_enum())
+  }
   match self.test_oneof {
     FooMessage_TestOneof::F1(v) => {
       writer |> @lib.write_varint(216UL)
@@ -781,7 +812,7 @@ pub impl @lib.Write for FooMessage with write(
 }
 
 ///|
-pub impl ToJson for FooMessage with to_json(self) {
+pub impl ToJson for FooMessage with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.f_int32 != Default::default() {
     json["fInt32"] = self.f_int32.to_json()
@@ -868,6 +899,9 @@ pub impl ToJson for FooMessage with to_json(self) {
   if self.with_json_name != Default::default() {
     json["wjn"] = self.with_json_name.to_json()
   }
+  if self.f_repeated_packed_enum != Default::default() {
+    json["fRepeatedPackedEnum"] = self.f_repeated_packed_enum.to_json()
+  }
   match self.test_oneof {
     NotSet => ()
     F1(v) => json["f1"] = v.to_json()
@@ -878,7 +912,7 @@ pub impl ToJson for FooMessage with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for FooMessage with from_json(
+pub impl @json.FromJson for FooMessage with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FooMessage raise {
@@ -931,6 +965,10 @@ pub impl @json.FromJson for FooMessage with from_json(
       ("fOptionalString", value) =>
         message.f_optional_string = Some(@json.from_json(value, path~))
       ("wjn", value) => message.with_json_name = @json.from_json(value, path~)
+      ("fRepeatedPackedEnum", Array(value)) =>
+        message.f_repeated_packed_enum = value.map(v => {
+          @json.from_json(v, path~)
+        })
       ("f1", value) => message.test_oneof = @json.from_json(value, path~)
       ("f2", value) => message.test_oneof = @json.from_json(value, path~)
       ("f3", value) => message.test_oneof = @json.from_json(value, path~)
@@ -941,7 +979,7 @@ pub impl @json.FromJson for FooMessage with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for FooMessage with read_with_limit(
+pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FooMessage raise {
   let msg = FooMessage::default()
@@ -1009,6 +1047,17 @@ pub impl @lib.AsyncRead for FooMessage with read_with_limit(
         (32, _) =>
           msg.f_optional_string = reader |> @lib.async_read_string() |> Some
         (33, _) => msg.with_json_name = reader |> @lib.async_read_string()
+        (34, 2) => {
+          let packed = reader
+            |> @lib.async_read_packed(@lib.async_read_enum, None)
+          for item in packed {
+            msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
+          }
+        }
+        (34, 0) =>
+          msg.f_repeated_packed_enum.push(
+            reader |> @lib.async_read_enum() |> FooEnum::from_enum,
+          )
         (27, _) =>
           msg.test_oneof = reader
             |> @lib.async_read_int32()
@@ -1032,7 +1081,7 @@ pub impl @lib.AsyncRead for FooMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FooMessage with write(
+pub impl @lib.AsyncWrite for FooMessage with fn write(
   self : FooMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1136,6 +1185,15 @@ pub impl @lib.AsyncWrite for FooMessage with write(
   }
   writer |> @lib.async_write_varint(266UL)
   writer |> @lib.async_write_string(self.with_json_name)
+  writer |> @lib.async_write_varint(274UL)
+  let size = self.f_repeated_packed_enum
+    .iter()
+    .map(@lib.size_of)
+    .fold(init=0U, UInt::add)
+  writer |> @lib.async_write_uint32(size)
+  for item in self.f_repeated_packed_enum {
+    writer |> @lib.async_write_enum(item.to_enum())
+  }
   match self.test_oneof {
     FooMessage_TestOneof::F1(v) => {
       writer |> @lib.async_write_varint(216UL)
@@ -1184,19 +1242,19 @@ pub fn BazMessage_Nested_NestedEnum::from_enum(
 }
 
 ///|
-pub impl Default for BazMessage_Nested_NestedEnum with default() -> BazMessage_Nested_NestedEnum {
+pub impl Default for BazMessage_Nested_NestedEnum with fn default() -> BazMessage_Nested_NestedEnum {
   BazMessage_Nested_NestedEnum::Foo
 }
 
 ///|
-pub impl @lib.Sized for BazMessage_Nested_NestedEnum with size_of(
+pub impl @lib.Sized for BazMessage_Nested_NestedEnum with fn size_of(
   self : BazMessage_Nested_NestedEnum,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for BazMessage_Nested_NestedEnum with from_json(
+pub impl @json.FromJson for BazMessage_Nested_NestedEnum with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> BazMessage_Nested_NestedEnum raise {
@@ -1215,7 +1273,7 @@ pub impl @json.FromJson for BazMessage_Nested_NestedEnum with from_json(
 }
 
 ///|
-pub impl ToJson for BazMessage_Nested_NestedEnum with to_json(
+pub impl ToJson for BazMessage_Nested_NestedEnum with fn to_json(
   self : BazMessage_Nested_NestedEnum,
 ) -> Json {
   match self {
@@ -1231,14 +1289,14 @@ pub(all) struct BazMessage_Nested_NestedMessage {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for BazMessage_Nested_NestedMessage with size_of(self) {
+pub impl @lib.Sized for BazMessage_Nested_NestedMessage with fn size_of(self) {
   let mut size = 0U
   size += 1U + @lib.size_of(self.f_nested)
   size
 }
 
 ///|
-pub impl Default for BazMessage_Nested_NestedMessage with default() -> BazMessage_Nested_NestedMessage {
+pub impl Default for BazMessage_Nested_NestedMessage with fn default() -> BazMessage_Nested_NestedMessage {
   BazMessage_Nested_NestedMessage::{ f_nested: Int::default() }
 }
 
@@ -1250,7 +1308,7 @@ pub fn BazMessage_Nested_NestedMessage::new(
 }
 
 ///|
-pub impl @lib.Read for BazMessage_Nested_NestedMessage with read_with_limit(
+pub impl @lib.Read for BazMessage_Nested_NestedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
@@ -1269,7 +1327,7 @@ pub impl @lib.Read for BazMessage_Nested_NestedMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for BazMessage_Nested_NestedMessage with write(
+pub impl @lib.Write for BazMessage_Nested_NestedMessage with fn write(
   self : BazMessage_Nested_NestedMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1278,7 +1336,7 @@ pub impl @lib.Write for BazMessage_Nested_NestedMessage with write(
 }
 
 ///|
-pub impl ToJson for BazMessage_Nested_NestedMessage with to_json(self) {
+pub impl ToJson for BazMessage_Nested_NestedMessage with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.f_nested != Default::default() {
     json["fNested"] = self.f_nested.to_json()
@@ -1287,7 +1345,7 @@ pub impl ToJson for BazMessage_Nested_NestedMessage with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for BazMessage_Nested_NestedMessage with from_json(
+pub impl @json.FromJson for BazMessage_Nested_NestedMessage with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> BazMessage_Nested_NestedMessage raise {
@@ -1307,7 +1365,7 @@ pub impl @json.FromJson for BazMessage_Nested_NestedMessage with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with read_with_limit(
+pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
@@ -1326,7 +1384,7 @@ pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with read_with_limit
 }
 
 ///|
-pub impl @lib.AsyncWrite for BazMessage_Nested_NestedMessage with write(
+pub impl @lib.AsyncWrite for BazMessage_Nested_NestedMessage with fn write(
   self : BazMessage_Nested_NestedMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1340,7 +1398,7 @@ pub(all) struct BazMessage_Nested {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for BazMessage_Nested with size_of(self) {
+pub impl @lib.Sized for BazMessage_Nested with fn size_of(self) {
   let mut size = 0U
   size += 1U +
     ({
@@ -1351,7 +1409,7 @@ pub impl @lib.Sized for BazMessage_Nested with size_of(self) {
 }
 
 ///|
-pub impl Default for BazMessage_Nested with default() -> BazMessage_Nested {
+pub impl Default for BazMessage_Nested with fn default() -> BazMessage_Nested {
   BazMessage_Nested::{ f_nested: BazMessage_Nested_NestedMessage::default() }
 }
 
@@ -1363,7 +1421,7 @@ pub fn BazMessage_Nested::new(
 }
 
 ///|
-pub impl @lib.Read for BazMessage_Nested with read_with_limit(
+pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
@@ -1384,7 +1442,7 @@ pub impl @lib.Read for BazMessage_Nested with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for BazMessage_Nested with write(
+pub impl @lib.Write for BazMessage_Nested with fn write(
   self : BazMessage_Nested,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1394,7 +1452,7 @@ pub impl @lib.Write for BazMessage_Nested with write(
 }
 
 ///|
-pub impl ToJson for BazMessage_Nested with to_json(self) {
+pub impl ToJson for BazMessage_Nested with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.f_nested != Default::default() {
     json["fNested"] = self.f_nested.to_json()
@@ -1403,7 +1461,7 @@ pub impl ToJson for BazMessage_Nested with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for BazMessage_Nested with from_json(
+pub impl @json.FromJson for BazMessage_Nested with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> BazMessage_Nested raise {
@@ -1423,7 +1481,7 @@ pub impl @json.FromJson for BazMessage_Nested with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for BazMessage_Nested with read_with_limit(
+pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
@@ -1445,7 +1503,7 @@ pub impl @lib.AsyncRead for BazMessage_Nested with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for BazMessage_Nested with write(
+pub impl @lib.AsyncWrite for BazMessage_Nested with fn write(
   self : BazMessage_Nested,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1462,7 +1520,7 @@ pub(all) struct BazMessage {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for BazMessage with size_of(self) {
+pub impl @lib.Sized for BazMessage with fn size_of(self) {
   let mut size = 0U
   size += 1U +
     ({
@@ -1479,7 +1537,7 @@ pub impl @lib.Sized for BazMessage with size_of(self) {
 }
 
 ///|
-pub impl Default for BazMessage with default() -> BazMessage {
+pub impl Default for BazMessage with fn default() -> BazMessage {
   BazMessage::{
     nested: BazMessage_Nested::default(),
     b_int64: Int64::default(),
@@ -1497,7 +1555,7 @@ pub fn BazMessage::new(
 }
 
 ///|
-pub impl @lib.Read for BazMessage with read_with_limit(
+pub impl @lib.Read for BazMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessage raise {
   let msg = BazMessage::default()
@@ -1519,7 +1577,7 @@ pub impl @lib.Read for BazMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for BazMessage with write(
+pub impl @lib.Write for BazMessage with fn write(
   self : BazMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1533,7 +1591,7 @@ pub impl @lib.Write for BazMessage with write(
 }
 
 ///|
-pub impl ToJson for BazMessage with to_json(self) {
+pub impl ToJson for BazMessage with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.nested != Default::default() {
     json["nested"] = self.nested.to_json()
@@ -1548,7 +1606,7 @@ pub impl ToJson for BazMessage with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for BazMessage with from_json(
+pub impl @json.FromJson for BazMessage with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> BazMessage raise {
@@ -1568,7 +1626,7 @@ pub impl @json.FromJson for BazMessage with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for BazMessage with read_with_limit(
+pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessage raise {
   let msg = BazMessage::default()
@@ -1590,7 +1648,7 @@ pub impl @lib.AsyncRead for BazMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for BazMessage with write(
+pub impl @lib.AsyncWrite for BazMessage with fn write(
   self : BazMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1609,7 +1667,7 @@ pub(all) struct RepeatedMessage {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for RepeatedMessage with size_of(self) {
+pub impl @lib.Sized for RepeatedMessage with fn size_of(self) {
   let mut size = 0U
   for s in self.bar_message {
     let s = @lib.size_of(s)
@@ -1619,7 +1677,7 @@ pub impl @lib.Sized for RepeatedMessage with size_of(self) {
 }
 
 ///|
-pub impl Default for RepeatedMessage with default() -> RepeatedMessage {
+pub impl Default for RepeatedMessage with fn default() -> RepeatedMessage {
   RepeatedMessage::{ bar_message: [] }
 }
 
@@ -1629,7 +1687,7 @@ pub fn RepeatedMessage::new(bar_message : Array[BarMessage]) -> RepeatedMessage 
 }
 
 ///|
-pub impl @lib.Read for RepeatedMessage with read_with_limit(
+pub impl @lib.Read for RepeatedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
@@ -1649,7 +1707,7 @@ pub impl @lib.Read for RepeatedMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for RepeatedMessage with write(
+pub impl @lib.Write for RepeatedMessage with fn write(
   self : RepeatedMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1661,7 +1719,7 @@ pub impl @lib.Write for RepeatedMessage with write(
 }
 
 ///|
-pub impl ToJson for RepeatedMessage with to_json(self) {
+pub impl ToJson for RepeatedMessage with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.bar_message != Default::default() {
     json["barMessage"] = self.bar_message.to_json()
@@ -1670,7 +1728,7 @@ pub impl ToJson for RepeatedMessage with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for RepeatedMessage with from_json(
+pub impl @json.FromJson for RepeatedMessage with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> RepeatedMessage raise {
@@ -1691,7 +1749,7 @@ pub impl @json.FromJson for RepeatedMessage with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for RepeatedMessage with read_with_limit(
+pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
@@ -1713,7 +1771,7 @@ pub impl @lib.AsyncRead for RepeatedMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for RepeatedMessage with write(
+pub impl @lib.AsyncWrite for RepeatedMessage with fn write(
   self : RepeatedMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1730,14 +1788,14 @@ pub(all) struct EmptyMessage {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for EmptyMessage with size_of(self) {
+pub impl @lib.Sized for EmptyMessage with fn size_of(self) {
   let mut size = 0U
   size += 1U + @lib.size_of(self.field)
   size
 }
 
 ///|
-pub impl Default for EmptyMessage with default() -> EmptyMessage {
+pub impl Default for EmptyMessage with fn default() -> EmptyMessage {
   EmptyMessage::{ field: Int::default() }
 }
 
@@ -1747,7 +1805,7 @@ pub fn EmptyMessage::new(field : Int) -> EmptyMessage {
 }
 
 ///|
-pub impl @lib.Read for EmptyMessage with read_with_limit(
+pub impl @lib.Read for EmptyMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EmptyMessage raise {
   let msg = EmptyMessage::default()
@@ -1766,7 +1824,7 @@ pub impl @lib.Read for EmptyMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for EmptyMessage with write(
+pub impl @lib.Write for EmptyMessage with fn write(
   self : EmptyMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1775,7 +1833,7 @@ pub impl @lib.Write for EmptyMessage with write(
 }
 
 ///|
-pub impl ToJson for EmptyMessage with to_json(self) {
+pub impl ToJson for EmptyMessage with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.field != Default::default() {
     json["field"] = self.field.to_json()
@@ -1784,7 +1842,7 @@ pub impl ToJson for EmptyMessage with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for EmptyMessage with from_json(
+pub impl @json.FromJson for EmptyMessage with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> EmptyMessage raise {
@@ -1802,7 +1860,7 @@ pub impl @json.FromJson for EmptyMessage with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for EmptyMessage with read_with_limit(
+pub impl @lib.AsyncRead for EmptyMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EmptyMessage raise {
   let msg = EmptyMessage::default()
@@ -1821,7 +1879,7 @@ pub impl @lib.AsyncRead for EmptyMessage with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for EmptyMessage with write(
+pub impl @lib.AsyncWrite for EmptyMessage with fn write(
   self : EmptyMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1835,7 +1893,7 @@ pub(all) struct EmptyMessageWithField {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for EmptyMessageWithField with size_of(self) {
+pub impl @lib.Sized for EmptyMessageWithField with fn size_of(self) {
   let mut size = 0U
   size += 1U +
     ({
@@ -1846,7 +1904,7 @@ pub impl @lib.Sized for EmptyMessageWithField with size_of(self) {
 }
 
 ///|
-pub impl Default for EmptyMessageWithField with default() -> EmptyMessageWithField {
+pub impl Default for EmptyMessageWithField with fn default() -> EmptyMessageWithField {
   EmptyMessageWithField::{ empty_message: EmptyMessage::default() }
 }
 
@@ -1858,7 +1916,7 @@ pub fn EmptyMessageWithField::new(
 }
 
 ///|
-pub impl @lib.Read for EmptyMessageWithField with read_with_limit(
+pub impl @lib.Read for EmptyMessageWithField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EmptyMessageWithField raise {
   let msg = EmptyMessageWithField::default()
@@ -1878,7 +1936,7 @@ pub impl @lib.Read for EmptyMessageWithField with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for EmptyMessageWithField with write(
+pub impl @lib.Write for EmptyMessageWithField with fn write(
   self : EmptyMessageWithField,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1888,7 +1946,7 @@ pub impl @lib.Write for EmptyMessageWithField with write(
 }
 
 ///|
-pub impl ToJson for EmptyMessageWithField with to_json(self) {
+pub impl ToJson for EmptyMessageWithField with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.empty_message != Default::default() {
     json["emptyMessage"] = self.empty_message.to_json()
@@ -1897,7 +1955,7 @@ pub impl ToJson for EmptyMessageWithField with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for EmptyMessageWithField with from_json(
+pub impl @json.FromJson for EmptyMessageWithField with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> EmptyMessageWithField raise {
@@ -1918,7 +1976,7 @@ pub impl @json.FromJson for EmptyMessageWithField with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for EmptyMessageWithField with read_with_limit(
+pub impl @lib.AsyncRead for EmptyMessageWithField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EmptyMessageWithField raise {
   let msg = EmptyMessageWithField::default()
@@ -1939,7 +1997,7 @@ pub impl @lib.AsyncRead for EmptyMessageWithField with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for EmptyMessageWithField with write(
+pub impl @lib.AsyncWrite for EmptyMessageWithField with fn write(
   self : EmptyMessageWithField,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1962,12 +2020,12 @@ pub(all) enum OnlyOneOfField_TestOneof {
 } derive(Eq, Debug)
 
 ///|
-pub impl Default for OnlyOneOfField_TestOneof with default() -> OnlyOneOfField_TestOneof {
+pub impl Default for OnlyOneOfField_TestOneof with fn default() -> OnlyOneOfField_TestOneof {
   NotSet
 }
 
 ///|
-pub impl @json.FromJson for OnlyOneOfField_TestOneof with from_json(
+pub impl @json.FromJson for OnlyOneOfField_TestOneof with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> OnlyOneOfField_TestOneof raise {
@@ -1990,7 +2048,7 @@ pub impl @json.FromJson for OnlyOneOfField_TestOneof with from_json(
 }
 
 ///|
-pub impl ToJson for OnlyOneOfField_TestOneof with to_json(
+pub impl ToJson for OnlyOneOfField_TestOneof with fn to_json(
   self : OnlyOneOfField_TestOneof,
 ) -> Json {
   match self {
@@ -2002,7 +2060,7 @@ pub impl ToJson for OnlyOneOfField_TestOneof with to_json(
 }
 
 ///|
-pub impl @lib.Sized for OnlyOneOfField with size_of(self) {
+pub impl @lib.Sized for OnlyOneOfField with fn size_of(self) {
   let mut size = 0U
   match self.test_oneof {
     F1(v) => size += 1U + @lib.size_of(v)
@@ -2019,7 +2077,7 @@ pub impl @lib.Sized for OnlyOneOfField with size_of(self) {
 }
 
 ///|
-pub impl Default for OnlyOneOfField with default() -> OnlyOneOfField {
+pub impl Default for OnlyOneOfField with fn default() -> OnlyOneOfField {
   OnlyOneOfField::{ test_oneof: OnlyOneOfField_TestOneof::NotSet }
 }
 
@@ -2031,7 +2089,7 @@ pub fn OnlyOneOfField::new(
 }
 
 ///|
-pub impl @lib.Read for OnlyOneOfField with read_with_limit(
+pub impl @lib.Read for OnlyOneOfField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> OnlyOneOfField raise {
   let msg = OnlyOneOfField::default()
@@ -2061,7 +2119,7 @@ pub impl @lib.Read for OnlyOneOfField with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for OnlyOneOfField with write(
+pub impl @lib.Write for OnlyOneOfField with fn write(
   self : OnlyOneOfField,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -2083,7 +2141,7 @@ pub impl @lib.Write for OnlyOneOfField with write(
 }
 
 ///|
-pub impl ToJson for OnlyOneOfField with to_json(self) {
+pub impl ToJson for OnlyOneOfField with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.test_oneof {
     NotSet => ()
@@ -2095,7 +2153,7 @@ pub impl ToJson for OnlyOneOfField with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for OnlyOneOfField with from_json(
+pub impl @json.FromJson for OnlyOneOfField with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> OnlyOneOfField raise {
@@ -2115,7 +2173,7 @@ pub impl @json.FromJson for OnlyOneOfField with from_json(
 }
 
 ///|
-pub impl @lib.AsyncRead for OnlyOneOfField with read_with_limit(
+pub impl @lib.AsyncRead for OnlyOneOfField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> OnlyOneOfField raise {
   let msg = OnlyOneOfField::default()
@@ -2145,7 +2203,7 @@ pub impl @lib.AsyncRead for OnlyOneOfField with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for OnlyOneOfField with write(
+pub impl @lib.AsyncWrite for OnlyOneOfField with fn write(
   self : OnlyOneOfField,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -318,6 +318,7 @@ pub(all) struct FooMessage {
   mut f_optional_string : String?
   mut with_json_name : String
   mut f_repeated_packed_enum : Array[FooEnum]
+  mut f_repeated_unpacked_enum : Array[FooEnum]
   mut test_oneof : FooMessage_TestOneof
 } derive(Eq, Debug)
 
@@ -470,6 +471,10 @@ pub impl @lib.Sized for FooMessage with fn size_of(self) {
         .fold(init=0U, UInt::add)
       @lib.size_of(size) + size
     })
+  for s in self.f_repeated_unpacked_enum {
+    let s = @lib.size_of(s)
+    size += 2U + @lib.size_of(s) + s
+  }
   match self.test_oneof {
     F1(v) => size += 2U + @lib.size_of(v)
     F2(v) => size += 2U + @lib.size_of(v)
@@ -516,6 +521,7 @@ pub impl Default for FooMessage with fn default() -> FooMessage {
     f_optional_string: None,
     with_json_name: String::default(),
     f_repeated_packed_enum: [],
+    f_repeated_unpacked_enum: [],
     test_oneof: FooMessage_TestOneof::NotSet,
   }
 }
@@ -551,6 +557,7 @@ pub fn FooMessage::new(
   f_optional_string? : String,
   with_json_name : String,
   f_repeated_packed_enum : Array[FooEnum],
+  f_repeated_unpacked_enum : Array[FooEnum],
   test_oneof? : FooMessage_TestOneof = FooMessage_TestOneof::NotSet,
 ) -> FooMessage {
   FooMessage::{
@@ -583,6 +590,7 @@ pub fn FooMessage::new(
     f_optional_string,
     with_json_name,
     f_repeated_packed_enum,
+    f_repeated_unpacked_enum,
     test_oneof,
   }
 }
@@ -656,6 +664,16 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(
         }
         (34, 0) =>
           msg.f_repeated_packed_enum.push(
+            reader |> @lib.read_enum() |> FooEnum::from_enum,
+          )
+        (35, 2) => {
+          let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+          for item in packed {
+            msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
+          }
+        }
+        (35, 0) =>
+          msg.f_repeated_unpacked_enum.push(
             reader |> @lib.read_enum() |> FooEnum::from_enum,
           )
         (27, _) =>
@@ -794,6 +812,10 @@ pub impl @lib.Write for FooMessage with fn write(
   for item in self.f_repeated_packed_enum {
     writer |> @lib.write_enum(item.to_enum())
   }
+  for item in self.f_repeated_unpacked_enum {
+    writer |> @lib.write_varint(280UL)
+    writer |> @lib.write_enum(item.to_enum())
+  }
   match self.test_oneof {
     FooMessage_TestOneof::F1(v) => {
       writer |> @lib.write_varint(216UL)
@@ -902,6 +924,9 @@ pub impl ToJson for FooMessage with fn to_json(self) {
   if self.f_repeated_packed_enum != Default::default() {
     json["fRepeatedPackedEnum"] = self.f_repeated_packed_enum.to_json()
   }
+  if self.f_repeated_unpacked_enum != Default::default() {
+    json["fRepeatedUnpackedEnum"] = self.f_repeated_unpacked_enum.to_json()
+  }
   match self.test_oneof {
     NotSet => ()
     F1(v) => json["f1"] = v.to_json()
@@ -967,6 +992,10 @@ pub impl @json.FromJson for FooMessage with fn from_json(
       ("wjn", value) => message.with_json_name = @json.from_json(value, path~)
       ("fRepeatedPackedEnum", Array(value)) =>
         message.f_repeated_packed_enum = value.map(v => {
+          @json.from_json(v, path~)
+        })
+      ("fRepeatedUnpackedEnum", Array(value)) =>
+        message.f_repeated_unpacked_enum = value.map(v => {
           @json.from_json(v, path~)
         })
       ("f1", value) => message.test_oneof = @json.from_json(value, path~)
@@ -1056,6 +1085,17 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(
         }
         (34, 0) =>
           msg.f_repeated_packed_enum.push(
+            reader |> @lib.async_read_enum() |> FooEnum::from_enum,
+          )
+        (35, 2) => {
+          let packed = reader
+            |> @lib.async_read_packed(@lib.async_read_enum, None)
+          for item in packed {
+            msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
+          }
+        }
+        (35, 0) =>
+          msg.f_repeated_unpacked_enum.push(
             reader |> @lib.async_read_enum() |> FooEnum::from_enum,
           )
         (27, _) =>
@@ -1192,6 +1232,10 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(
     .fold(init=0U, UInt::add)
   writer |> @lib.async_write_uint32(size)
   for item in self.f_repeated_packed_enum {
+    writer |> @lib.async_write_enum(item.to_enum())
+  }
+  for item in self.f_repeated_unpacked_enum {
+    writer |> @lib.async_write_varint(280UL)
     writer |> @lib.async_write_enum(item.to_enum())
   }
   match self.test_oneof {

--- a/test/reader/proto2.proto
+++ b/test/reader/proto2.proto
@@ -51,6 +51,7 @@ message FooMessageP2 {
     optional bool f_default_bool = 36 [default = true];
     optional double f_default_double = 37 [default = 3.14];
     optional FooEnumP2 f_default_enum = 38 [default = SECOND_VALUEX];
+    repeated FooEnumP2 f_repeated_packed_enum = 39 [packed = true];
 }
 
 // Map entry message for proto2 compatibility

--- a/test/reader/proto3.proto
+++ b/test/reader/proto3.proto
@@ -48,6 +48,7 @@ message FooMessage {
     optional string f_optional_string = 32;
     string with_json_name = 33 [ json_name = "wjn" ];
     repeated FooEnum f_repeated_packed_enum = 34 [ packed = true ];
+    repeated FooEnum f_repeated_unpacked_enum = 35 [ packed = false ];
 }
 
 message BazMessage {

--- a/test/reader/proto3.proto
+++ b/test/reader/proto3.proto
@@ -47,6 +47,7 @@ message FooMessage {
     repeated BazMessage f_repeated_baz_message = 31;
     optional string f_optional_string = 32;
     string with_json_name = 33 [ json_name = "wjn" ];
+    repeated FooEnum f_repeated_packed_enum = 34 [ packed = true ];
 }
 
 message BazMessage {

--- a/test/reader/runner/src/moon.pkg
+++ b/test/reader/runner/src/moon.pkg
@@ -6,6 +6,7 @@ import {
   "username/gen_proto3" @gen_proto3,
   "moonbitlang/protobuf",
   "moonbitlang/x/fs",
+  "moonbitlang/core/buffer",
   "moonbitlang/core/json",
   "moonbitlang/core/debug",
 } for "test"

--- a/test/reader/runner/src/moon.pkg
+++ b/test/reader/runner/src/moon.pkg
@@ -2,8 +2,8 @@ import {
 }
 
 import {
-  "username/gen_proto2" @gen_proto2,
-  "username/gen_proto3" @gen_proto3,
+  "username/gen_proto2",
+  "username/gen_proto3",
   "moonbitlang/protobuf",
   "moonbitlang/x/fs",
   "moonbitlang/core/buffer",

--- a/test/reader/runner/src/proto2_test.mbt
+++ b/test/reader/runner/src/proto2_test.mbt
@@ -1,4 +1,12 @@
 ///|
+test "proto2_explicit_packed_int32_accepts_unpacked_encoding" {
+  let bytes = unpacked_int32_bytes(20U, [6, 7, 8])
+  let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  let message : @gen_proto2.FooMessageP2 = @protobuf.Read::read(reader)
+  @debug.assert_eq(message.f_repeated_packed_int32, [6, 7, 8])
+}
+
+///|
 test "proto2_test_case_1" {
   let json = (
     from_bin_to_proto_message("../bin/proto2_test_case_1.bin") :

--- a/test/reader/runner/src/proto2_test.mbt
+++ b/test/reader/runner/src/proto2_test.mbt
@@ -7,6 +7,36 @@ test "proto2_explicit_packed_int32_accepts_unpacked_encoding" {
 }
 
 ///|
+test "proto2_explicit_packed_enum_writer_round_trips_packed_encoding" {
+  let message = @gen_proto2.FooMessageP2::default()
+  message.f_repeated_packed_enum.push(@gen_proto2.FooEnumP2::FIRST_VALUEX)
+  message.f_repeated_packed_enum.push(@gen_proto2.FooEnumP2::SECOND_VALUEX)
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  let reader = @protobuf.BytesReader::from_bytes(writer.to_bytes())
+    as &@protobuf.Reader
+  let decoded : @gen_proto2.FooMessageP2 = @protobuf.Read::read(reader)
+  @debug.assert_eq(decoded.f_repeated_packed_enum, [
+    @gen_proto2.FooEnumP2::FIRST_VALUEX,
+    @gen_proto2.FooEnumP2::SECOND_VALUEX,
+  ])
+}
+
+///|
+test "proto2_explicit_packed_enum_accepts_unpacked_encoding" {
+  let bytes = unpacked_enum_bytes(39U, [
+    @gen_proto2.FooEnumP2::FIRST_VALUEX.to_enum(),
+    @gen_proto2.FooEnumP2::SECOND_VALUEX.to_enum(),
+  ])
+  let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  let message : @gen_proto2.FooMessageP2 = @protobuf.Read::read(reader)
+  @debug.assert_eq(message.f_repeated_packed_enum, [
+    @gen_proto2.FooEnumP2::FIRST_VALUEX,
+    @gen_proto2.FooEnumP2::SECOND_VALUEX,
+  ])
+}
+
+///|
 test "proto2_test_case_1" {
   let json = (
     from_bin_to_proto_message("../bin/proto2_test_case_1.bin") :

--- a/test/reader/runner/src/proto3_test.mbt
+++ b/test/reader/runner/src/proto3_test.mbt
@@ -59,6 +59,19 @@ fn unpacked_float_bytes(
 }
 
 ///|
+fn unpacked_enum_bytes(
+  field_number : UInt,
+  values : Array[@protobuf.Enum],
+) -> Bytes raise {
+  let writer = @buffer.Buffer::Buffer()
+  for value in values {
+    writer |> @protobuf.write_tag((field_number, 0U))
+    writer |> @protobuf.write_enum(value)
+  }
+  writer.to_bytes()
+}
+
+///|
 test "proto3_repeated_packable_accepts_unpacked_encoding" {
   let bytes = unpacked_int32_bytes(19U, [10, 20, 30])
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
@@ -93,6 +106,36 @@ test "proto3_async_repeated_packable_accepts_unpacked_encoding" {
     }
   })
   @debug.assert_eq(message.f_repeated_int32, [10, 20, 30])
+}
+
+///|
+test "proto3_repeated_enum_writer_round_trips_packed_encoding" {
+  let message = @gen_proto3.FooMessage::default()
+  message.f_repeated_packed_enum.push(@gen_proto3.FooEnum::FIRST_VALUE)
+  message.f_repeated_packed_enum.push(@gen_proto3.FooEnum::SECOND_VALUE)
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  let reader = @protobuf.BytesReader::from_bytes(writer.to_bytes())
+    as &@protobuf.Reader
+  let decoded : @gen_proto3.FooMessage = @protobuf.Read::read(reader)
+  @debug.assert_eq(decoded.f_repeated_packed_enum, [
+    @gen_proto3.FooEnum::FIRST_VALUE,
+    @gen_proto3.FooEnum::SECOND_VALUE,
+  ])
+}
+
+///|
+test "proto3_repeated_enum_accepts_unpacked_encoding" {
+  let bytes = unpacked_enum_bytes(34U, [
+    @gen_proto3.FooEnum::FIRST_VALUE.to_enum(),
+    @gen_proto3.FooEnum::SECOND_VALUE.to_enum(),
+  ])
+  let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  let message : @gen_proto3.FooMessage = @protobuf.Read::read(reader)
+  @debug.assert_eq(message.f_repeated_packed_enum, [
+    @gen_proto3.FooEnum::FIRST_VALUE,
+    @gen_proto3.FooEnum::SECOND_VALUE,
+  ])
 }
 
 ///|

--- a/test/reader/runner/src/proto3_test.mbt
+++ b/test/reader/runner/src/proto3_test.mbt
@@ -33,6 +33,14 @@ fn[T : Default + @json.FromJson] from_json_to_proto_message(file : String) -> T 
 fn async_run(f : async () -> Unit noraise) -> Unit = "%async.run"
 
 ///|
+test "proto3_repeated_packable_accepts_unpacked_encoding" {
+  let bytes = b"\x98\x01\x0A\x98\x01\x14\x98\x01\x1E"
+  let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  let message : @gen_proto3.FooMessage = @protobuf.Read::read(reader)
+  inspect(message.f_repeated_int32, content="[10, 20, 30]")
+}
+
+///|
 test "proto3_test_case_1" {
   let json : @gen_proto3.FooMessage = from_bin_to_proto_message(
     "../bin/proto3_test_case_1.bin",

--- a/test/reader/runner/src/proto3_test.mbt
+++ b/test/reader/runner/src/proto3_test.mbt
@@ -33,11 +33,66 @@ fn[T : Default + @json.FromJson] from_json_to_proto_message(file : String) -> T 
 fn async_run(f : async () -> Unit noraise) -> Unit = "%async.run"
 
 ///|
+fn unpacked_int32_bytes(
+  field_number : UInt,
+  values : Array[Int],
+) -> Bytes raise {
+  let writer = @buffer.Buffer::Buffer()
+  for value in values {
+    writer |> @protobuf.write_tag((field_number, 0U))
+    writer |> @protobuf.write_int32(value)
+  }
+  writer.to_bytes()
+}
+
+///|
+fn unpacked_float_bytes(
+  field_number : UInt,
+  values : Array[Float],
+) -> Bytes raise {
+  let writer = @buffer.Buffer::Buffer()
+  for value in values {
+    writer |> @protobuf.write_tag((field_number, 5U))
+    writer |> @protobuf.write_float(value)
+  }
+  writer.to_bytes()
+}
+
+///|
 test "proto3_repeated_packable_accepts_unpacked_encoding" {
-  let bytes = b"\x98\x01\x0A\x98\x01\x14\x98\x01\x1E"
+  let bytes = unpacked_int32_bytes(19U, [10, 20, 30])
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let message : @gen_proto3.FooMessage = @protobuf.Read::read(reader)
-  inspect(message.f_repeated_int32, content="[10, 20, 30]")
+  @debug.assert_eq(message.f_repeated_int32, [10, 20, 30])
+}
+
+///|
+test "proto3_explicit_packed_int32_accepts_unpacked_encoding" {
+  let bytes = unpacked_int32_bytes(20U, [6, 7, 8])
+  let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  let message : @gen_proto3.FooMessage = @protobuf.Read::read(reader)
+  @debug.assert_eq(message.f_repeated_packed_int32, [6, 7, 8])
+}
+
+///|
+test "proto3_repeated_float_accepts_unpacked_encoding" {
+  let bytes = unpacked_float_bytes(21U, [1, 2.5])
+  let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  let message : @gen_proto3.FooMessage = @protobuf.Read::read(reader)
+  @debug.assert_eq(message.f_repeated_packed_float, [1, 2.5])
+}
+
+///|
+test "proto3_async_repeated_packable_accepts_unpacked_encoding" {
+  let bytes = unpacked_int32_bytes(19U, [10, 20, 30])
+  let reader = @protobuf.BytesReader::from_bytes(bytes)
+  let mut message = @gen_proto3.FooMessage::default()
+  async_run(async fn() -> Unit noraise {
+    message = @protobuf.AsyncRead::read(reader) catch {
+      _ => @gen_proto3.FooMessage::default()
+    }
+  })
+  @debug.assert_eq(message.f_repeated_int32, [10, 20, 30])
 }
 
 ///|

--- a/test/reader/runner/src/proto3_test.mbt
+++ b/test/reader/runner/src/proto3_test.mbt
@@ -72,6 +72,42 @@ fn unpacked_enum_bytes(
 }
 
 ///|
+fn enum_wire_entries(
+  bytes : Bytes,
+  field_number : UInt,
+) -> Array[(UInt, UInt)] raise {
+  let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
+  let entries = []
+  while true {
+    let tag_result = try reader |> @protobuf.read_tag() catch {
+      _ => None
+    } noraise {
+      v => Some(v)
+    }
+    match tag_result {
+      Some((tag, wire_type)) =>
+        if tag == field_number {
+          match wire_type {
+            0 => entries.push((wire_type, (reader |> @protobuf.read_enum()).0))
+            2 => {
+              let values = reader
+                |> @protobuf.read_packed(@protobuf.read_enum, None)
+              for value in values {
+                entries.push((wire_type, value.0))
+              }
+            }
+            _ => reader |> @protobuf.read_unknown(wire_type)
+          }
+        } else {
+          reader |> @protobuf.read_unknown(wire_type)
+        }
+      None => break
+    }
+  }
+  entries
+}
+
+///|
 test "proto3_repeated_packable_accepts_unpacked_encoding" {
   let bytes = unpacked_int32_bytes(19U, [10, 20, 30])
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
@@ -135,6 +171,19 @@ test "proto3_repeated_enum_accepts_unpacked_encoding" {
   @debug.assert_eq(message.f_repeated_packed_enum, [
     @gen_proto3.FooEnum::FIRST_VALUE,
     @gen_proto3.FooEnum::SECOND_VALUE,
+  ])
+}
+
+///|
+test "proto3_explicit_unpacked_enum_writer_emits_unpacked_encoding" {
+  let message = @gen_proto3.FooMessage::default()
+  message.f_repeated_unpacked_enum.push(@gen_proto3.FooEnum::FIRST_VALUE)
+  message.f_repeated_unpacked_enum.push(@gen_proto3.FooEnum::SECOND_VALUE)
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(enum_wire_entries(writer.to_bytes(), 35U), [
+    (0U, @gen_proto3.FooEnum::FIRST_VALUE.to_enum().0),
+    (0U, @gen_proto3.FooEnum::SECOND_VALUE.to_enum().0),
   ])
 }
 

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -402,9 +402,12 @@ pub impl @lib.Read for FooMessage with read_with_limit(reader : @lib.LimitedRead
       (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
       (16, _) => msg.f_string = reader |> @lib.read_string()
       (18, _) => msg.f_bar_message = (reader |> @lib.read_message() : BarMessage)
-      (19, _) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (20, _) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (21, _) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()) }
+      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
+      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()) }
+      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
       (23, _) => msg.f_baz = (reader |> @lib.read_message() : BazMessage)
       (24, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested)
       (25, _) => msg.f_nested_enum = reader |> @lib.read_enum() |> BazMessage_Nested_NestedEnum::from_enum
@@ -696,9 +699,12 @@ pub impl @lib.AsyncRead for FooMessage with read_with_limit(reader : @lib.Limite
       (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
       (16, _) => msg.f_string = reader |> @lib.async_read_string()
       (18, _) => msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage)
-      (19, _) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (20, _) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (21, _) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()) }
+      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
+      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()) }
+      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
       (23, _) => msg.f_baz = (reader |> @lib.async_read_message() : BazMessage)
       (24, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested)
       (25, _) => msg.f_nested_enum = reader |> @lib.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -4339,7 +4339,8 @@ pub impl @lib.Read for FieldOptions with read_with_limit(reader : @lib.LimitedRe
       (10, _) => msg.weak = reader |> @lib.read_bool() |> Some
       (16, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
       (17, _) => msg.retention = reader |> @lib.read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
-      (19, _) => msg.targets.push(reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum)
+      (19, 2) => { let packed = reader |> @lib.read_packed(@lib.read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
+      (19, 0) => msg.targets.push(reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum)
       (20, _) => msg.edition_defaults.push((reader |> @lib.read_message() : FieldOptions_EditionDefault))
       (21, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (22, _) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
@@ -4525,7 +4526,8 @@ pub impl @lib.AsyncRead for FieldOptions with read_with_limit(reader : @lib.Limi
       (10, _) => msg.weak = reader |> @lib.async_read_bool() |> Some
       (16, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
       (17, _) => msg.retention = reader |> @lib.async_read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
-      (19, _) => msg.targets.push(reader |> @lib.async_read_enum() |> FieldOptions_OptionTargetType::from_enum)
+      (19, 2) => { let packed = reader |> @lib.async_read_packed(@lib.async_read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
+      (19, 0) => msg.targets.push(reader |> @lib.async_read_enum() |> FieldOptions_OptionTargetType::from_enum)
       (20, _) => msg.edition_defaults.push((reader |> @lib.async_read_message() : FieldOptions_EditionDefault))
       (21, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
       (22, _) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -340,8 +340,10 @@ pub impl @lib.Read for FileDescriptorProto with read_with_limit(reader : @lib.Li
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
       (3, _) => msg.dependency.push(reader |> @lib.read_string())
-      (10, _) => msg.public_dependency.push(reader |> @lib.read_int32())
-      (11, _) => msg.weak_dependency.push(reader |> @lib.read_int32())
+      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
+      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
       (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
       (4, _) => msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
       (5, _) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
@@ -526,8 +528,10 @@ pub impl @lib.AsyncRead for FileDescriptorProto with read_with_limit(reader : @l
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
       (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
-      (10, _) => msg.public_dependency.push(reader |> @lib.async_read_int32())
-      (11, _) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
+      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (10, 0) => msg.public_dependency.push(reader |> @lib.async_read_int32())
+      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
       (15, _) => msg.option_dependency.push(reader |> @lib.async_read_string())
       (4, _) => msg.message_type.push((reader |> @lib.async_read_message() : DescriptorProto))
       (5, _) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
@@ -6671,8 +6675,10 @@ pub impl @lib.Read for SourceCodeInfo_Location with read_with_limit(reader : @li
   try {
     for ;; {
       match (reader |> @lib.read_tag()) {
-      (1, _) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (2, _) => { msg.span.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (1, 0) => msg.path.push(reader |> @lib.read_int32())
+      (2, 2) => { msg.span.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (2, 0) => msg.span.push(reader |> @lib.read_int32())
       (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
       (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
       (6, _) => msg.leading_detached_comments.push(reader |> @lib.read_string())
@@ -6762,8 +6768,10 @@ pub impl @lib.AsyncRead for SourceCodeInfo_Location with read_with_limit(reader 
   try {
     for ;; {
       match (reader |> @lib.async_read_tag()) {
-      (1, _) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (2, _) => { msg.span.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+      (2, 2) => { msg.span.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
       (3, _) => msg.leading_comments = reader |> @lib.async_read_string() |> Some
       (4, _) => msg.trailing_comments = reader |> @lib.async_read_string() |> Some
       (6, _) => msg.leading_detached_comments.push(reader |> @lib.async_read_string())
@@ -6984,7 +6992,8 @@ pub impl @lib.Read for GeneratedCodeInfo_Annotation with read_with_limit(reader 
   try {
     for ;; {
       match (reader |> @lib.read_tag()) {
-      (1, _) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (1, 0) => msg.path.push(reader |> @lib.read_int32())
       (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
       (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
       (4, _) => msg.end = reader |> @lib.read_int32() |> Some
@@ -7073,7 +7082,8 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with read_with_limit(re
   try {
     for ;; {
       match (reader |> @lib.async_read_tag()) {
-      (1, _) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
       (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
       (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
       (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some


### PR DESCRIPTION
## Summary
- generate reader branches for both packed and unpacked encodings of packable repeated fields
- handle varint, fixed32, fixed64, float, double, sint, bool, and enum cases
- update generated reader fixtures and snapshots
- add a proto3 regression for unpacked repeated int32 bytes

## Root Cause
The generated reader matched packable repeated fields as length-delimited packed payloads only. Protobuf parsers must also accept the unpacked scalar wire encoding for those fields.

## Validation
- `moon -C cli test`
- `moon -C plugin test`
- `moon -C test/reader/gen_proto2 check --target native`
- `moon -C test/reader/gen_proto3 check --target native`
- `moon -C test/reader/runner test --target native -F proto3_repeated_packable_accepts_unpacked_encoding`
- snapshot checks for updated cases
- `git diff --check`

Note: the full reader runner suite still needs the binary fixtures under `test/reader/bin`; without them it aborts before reaching this regression.