### PR TITLE
chore: clean up warnings and enforce lint

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,30 +38,27 @@ jobs:
 
       - name: moon check (library)
         run: |
-          moon check lib/ lib/test/ --target all
+          moon check lib/ lib/test/ --target all --deny-warn
 
       - name: moon lint (library)
-        continue-on-error: true
         run: |
           moon -C lib fmt && git diff --exit-code
           moon -C lib info && git diff --exit-code
 
       - name: moon check (plugin)
         run: |
-          moon -C plugin check --target native
+          moon -C plugin check --target native --deny-warn
 
       - name: moon lint (plugin)
-        continue-on-error: true
         run: |
           moon -C plugin fmt && git diff --exit-code
           moon -C plugin info && git diff --exit-code
 
       - name: moon check (cli)
         run: |
-          moon -C cli check --target native
+          moon -C cli check --target native --deny-warn
 
       - name: moon lint (cli)
-        continue-on-error: true
         run: |
           moon -C cli fmt && git diff --exit-code
           moon -C cli info --target native && git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,20 +54,20 @@ jobs:
 
       - name: moon library test
         run: |
-          moon check lib/ lib/test/ --target all
-          moon test lib/ lib/test/ --target all
+          moon check lib/ lib/test/ --target all --deny-warn
+          moon test lib/ lib/test/ --target all --deny-warn
 
       - name: moon plugin test
         # plugin uses moonbitlang/async for testing, which does not support windows yet
         if: ${{ runner.os != 'Windows' }}
         run: |
-          moon -C plugin check
-          moon -C plugin test --target native
+          moon -C plugin check --deny-warn
+          moon -C plugin test --target native --deny-warn
 
       - name: moon cli test
         run: |
-          moon check cli
-          moon test cli --target native
+          moon check cli --deny-warn
+          moon test cli --target native --deny-warn
       
       - name: reader test
         shell: bash

--- a/cli/enum_template.mbt
+++ b/cli/enum_template.mbt
@@ -57,7 +57,7 @@ fn CodeGenerator::gen_enum(
     let first_value_name = to_camel_case(enum_.value[0].name.unwrap())
     file.write_string(
       (
-        $|pub impl Default for \{enum_name} with default() -> \{enum_name} {
+        $|pub impl Default for \{enum_name} with fn default() -> \{enum_name} {
         $|  \{enum_name}::\{first_value_name}
         $|}
         $|
@@ -68,7 +68,7 @@ fn CodeGenerator::gen_enum(
   // Sized
   file.write_string(
     (
-      $|pub impl @lib.Sized for \{enum_name} with size_of(self : \{enum_name}) {
+      $|pub impl @lib.Sized for \{enum_name} with fn size_of(self : \{enum_name}) {
       $|  @lib.Sized::size_of(self.to_enum())
       $|}
       $|
@@ -78,7 +78,7 @@ fn CodeGenerator::gen_enum(
   // From JSON
   if self.support_json() {
     file.write_string(
-      "pub impl @json.FromJson for \{enum_name} with from_json(json: Json, path: @json.JsonPath) -> \{enum_name} raise {\n",
+      "pub impl @json.FromJson for \{enum_name} with fn from_json(json: Json, path: @json.JsonPath) -> \{enum_name} raise {\n",
     )
     file.write_string("  match json {\n")
     for value in enum_.value {
@@ -100,7 +100,7 @@ fn CodeGenerator::gen_enum(
         $|    _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
         $|  }
         $|}
-        $|pub impl ToJson for \{enum_name} with to_json(self : \{enum_name}) -> Json {
+        $|pub impl ToJson for \{enum_name} with fn to_json(self : \{enum_name}) -> Json {
         $|  match self {
         $|
       ),
@@ -122,4 +122,3 @@ fn CodeGenerator::gen_enum(
 
   // End
 }
-

--- a/cli/generator.mbt
+++ b/cli/generator.mbt
@@ -46,6 +46,11 @@ fn CodeGenerator::support_async(self : CodeGenerator) -> Bool {
 }
 
 ///|
+fn CodeGenerator::emit_package_files(self : CodeGenerator) -> Bool {
+  self.parameter.get_or_default("emit_package_files", "true") == "true"
+}
+
+///|
 let support_derive_list : ArrayView[String] = [
   "Debug", "Eq", "Hash", "Compare", "Arbitrary",
 ]
@@ -56,7 +61,7 @@ fn CodeGenerator::derive_list(self : CodeGenerator) -> Array[String] {
     .get_or_default("derive", "Eq,Debug")
     .split(",")
     .filter_map(arg => {
-      let arg = arg.trim(char_set=" ").to_string()
+      let arg = arg.trim(char_set=" ").to_owned()
       if support_derive_list.contains(arg) {
         return Some(arg)
       } else {
@@ -75,7 +80,7 @@ fn CodeGenerator::find_enum(self : CodeGenerator, type_name : String) -> Enum? {
     let type_name = type_name.trim(char_set=".")
     if type_name.has_prefix(name) {
       let path = pkg.import_path.append(
-        type_name.view(start_offset=name.length()).to_string(),
+        type_name.view(start_offset=name.length()).to_owned(),
       )
       if pkg.find_enum(path) is Some(enum_) {
         return enum_ |> Some
@@ -97,7 +102,7 @@ fn CodeGenerator::find_message(
         type_name
         .trim(char_set=".")
         .view(start_offset=pkg_name.length())
-        .to_string(),
+        .to_owned(),
       )
       if pkg.find_message(path) is Some(message) {
         return message |> Some
@@ -141,7 +146,7 @@ fn CodeGenerator::qualified_name(
   let import_name = package_name
     .rev_find(".")
     .map_or(package_name, pos => {
-      package_name.view(start_offset=pos + 1).to_string()
+      package_name.view(start_offset=pos + 1).to_owned()
     })
   if self.package_import.contains(package_name) {
     return self.package_import.get(package_name).unwrap()
@@ -157,12 +162,19 @@ pub fn CodeGenerator::generate(
   self : CodeGenerator,
 ) -> @compiler.CodeGeneratorResponse {
   try {
-    self.gen_module()
+    let emit_package_files = self.emit_package_files()
+    if emit_package_files {
+      self.gen_module()
+    }
     for file in self.request.proto_file {
       let filename = file.name.unwrap()
       if self.request.file_to_generate.contains(filename) {
         let package_ = self.filename_dictionary.get(filename).unwrap()
-        self.gen_package(package_)
+        if emit_package_files {
+          self.gen_package(package_)
+        } else {
+          self.gen_file(package_)
+        }
       }
     }
     for file in self.generated_files {

--- a/cli/json_template.mbt
+++ b/cli/json_template.mbt
@@ -8,10 +8,10 @@ fn CodeGenerator::gen_message_json(
   if message.fields.is_empty() && message.oneofs.is_empty() {
     content.write_string(
       (
-        $|pub impl ToJson for \{message_name} with to_json(_) {
+        $|pub impl ToJson for \{message_name} with fn to_json(_) {
         $|  {}
         $|}
-        $|pub impl @json.FromJson for \{message_name} with from_json(_, _) -> \{message_name} noraise {
+        $|pub impl @json.FromJson for \{message_name} with fn from_json(_, _) -> \{message_name} noraise {
         $|  \{message_name}::default()
         $|}
         $|
@@ -23,7 +23,7 @@ fn CodeGenerator::gen_message_json(
   // To JSON
   content.write_string(
     (
-      $|pub impl ToJson for \{message_name} with to_json(self) {
+      $|pub impl ToJson for \{message_name} with fn to_json(self) {
       $|  let json: Map[String, Json] = {}
       $|
     ),
@@ -108,7 +108,7 @@ fn CodeGenerator::gen_message_json(
     (
       $|  Json::object(json)
       $|}
-      $|pub impl @json.FromJson for \{message_name} with from_json(json: Json, path: @json.JsonPath) -> \{message_name} raise {
+      $|pub impl @json.FromJson for \{message_name} with fn from_json(json: Json, path: @json.JsonPath) -> \{message_name} raise {
       $|  guard json is Object(obj) else {
       $|    raise @json.JsonDecodeError((path, "Expected an object for \{message_name}"))
       $|  }
@@ -177,7 +177,7 @@ fn CodeGenerator::gen_message_json(
   }
   content.write_string(
     (
-      #|      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      #|      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
       #|    }
       #|  }
       #|  message
@@ -186,4 +186,3 @@ fn CodeGenerator::gen_message_json(
     ),
   )
 }
-

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -12,7 +12,7 @@ struct Stdin(@stdio.Input)
 struct Stdout(@stdio.Output)
 
 ///|
-impl @lib.AsyncReader for Stdin with read(
+impl @lib.AsyncReader for Stdin with fn read(
   self,
   bytes : FixedArray[Byte],
   offset~ : Int,
@@ -27,7 +27,7 @@ impl @lib.AsyncReader for Stdin with read(
 }
 
 ///|
-impl @lib.AsyncWriter for Stdout with write(self, bytes : BytesView) -> Unit raise {
+impl @lib.AsyncWriter for Stdout with fn write(self, bytes : BytesView) -> Unit raise {
   self.0.write(bytes)
 }
 

--- a/cli/message_template.mbt
+++ b/cli/message_template.mbt
@@ -132,7 +132,7 @@ fn CodeGenerator::gen_message_default(
   let message_name = message.import_path.path() |> to_camel_case
   content.write_string(
     (
-      $|pub impl Default for \{message_name} with default() -> \{message_name} {
+      $|pub impl Default for \{message_name} with fn default() -> \{message_name} {
       $|  \{message_name}::{
       $|
     ),
@@ -241,4 +241,3 @@ fn CodeGenerator::gen_message_new(
     ),
   )
 }
-

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -14,7 +14,7 @@ repository = ""
 
 license = "Apache-2.0"
 
-keywords = []
+keywords = [ ]
 
 description = ""
 

--- a/cli/oneof_template.mbt
+++ b/cli/oneof_template.mbt
@@ -30,7 +30,7 @@ fn CodeGenerator::gen_oneof_enum(
     (
       $|  NotSet
       $|} derive(\{derive_list})
-      $|pub impl Default for \{enum_name} with default() -> \{enum_name} {
+      $|pub impl Default for \{enum_name} with fn default() -> \{enum_name} {
       $|  NotSet
       $|}
       $|
@@ -39,7 +39,7 @@ fn CodeGenerator::gen_oneof_enum(
   if self.support_json() {
     // From Json
     content.write_string(
-      "pub impl @json.FromJson for \{enum_name} with from_json(json: Json, path: @json.JsonPath) -> \{enum_name} raise {\n",
+      "pub impl @json.FromJson for \{enum_name} with fn from_json(json: Json, path: @json.JsonPath) -> \{enum_name} raise {\n",
     )
     for field in oneof.field {
       let field_name = field.import_path.name() |> to_camel_case
@@ -58,7 +58,7 @@ fn CodeGenerator::gen_oneof_enum(
       (
         $|\{enum_name}::NotSet
         $|}
-        $|pub impl ToJson for \{enum_name} with to_json(self : \{enum_name}) -> Json {
+        $|pub impl ToJson for \{enum_name} with fn to_json(self : \{enum_name}) -> Json {
         $|  match self {
         // To Json
         $|
@@ -80,4 +80,3 @@ fn CodeGenerator::gen_oneof_enum(
     )
   }
 }
-

--- a/cli/package_template.mbt
+++ b/cli/package_template.mbt
@@ -52,4 +52,3 @@ fn CodeGenerator::gen_file(self : CodeGenerator, file : Package) -> Unit raise {
   let file = File::from_builder(filename, content~)
   self.push_file(file)
 }
-

--- a/cli/reader_template.mbt
+++ b/cli/reader_template.mbt
@@ -12,7 +12,7 @@ fn CodeGenerator::gen_message_reader(
   if message.fields.is_empty() && message.oneofs.is_empty() {
     content.write_string(
       (
-        $|pub impl @lib.\{async_keyword_to_title}Read for \{message_name} with read_with_limit(_) -> \{message_name} noraise {
+        $|pub impl @lib.\{async_keyword_to_title}Read for \{message_name} with fn read_with_limit(_) -> \{message_name} noraise {
         $|  \{message_name}::default()
         $|}
         $|
@@ -22,7 +22,7 @@ fn CodeGenerator::gen_message_reader(
   }
   content.write_string(
     (
-      $|pub impl @lib.\{async_keyword_to_title}Read for \{message_name} with read_with_limit(reader : @lib.LimitedReader[&@lib.\{async_keyword_to_title}Reader]) -> \{message_name} raise {
+      $|pub impl @lib.\{async_keyword_to_title}Read for \{message_name} with fn read_with_limit(reader : @lib.LimitedReader[&@lib.\{async_keyword_to_title}Reader]) -> \{message_name} raise {
       $|  let msg = \{message_name}::default()
       $|
     ),
@@ -111,7 +111,7 @@ fn CodeGenerator::gen_repeated_field_read(
       FieldDescriptorProto_Type::TYPE_SFIXED32
       | FieldDescriptorProto_Type::TYPE_FIXED32
       | FieldDescriptorProto_Type::TYPE_FLOAT => 5
-      _ => raise UnexpectedType("Packable field type: \{kind}")
+      _ => raise UnexpectedType("unexpected packable field type")
     }
     let packed_size = match kind {
       FieldDescriptorProto_Type::TYPE_BOOL
@@ -128,7 +128,7 @@ fn CodeGenerator::gen_repeated_field_read(
       FieldDescriptorProto_Type::TYPE_SFIXED32
       | FieldDescriptorProto_Type::TYPE_FIXED32
       | FieldDescriptorProto_Type::TYPE_FLOAT => "Some(4)"
-      _ => raise UnexpectedType("Packable field type: \{kind}")
+      _ => raise UnexpectedType("unexpected packable field type")
     }
     let packed_reader = packed_kind_read_func(kind, is_async~)
     let packed_read = "reader |> @lib.\{async_keyword_to_snake}read_packed(\{packed_reader}, \{packed_size})"
@@ -221,10 +221,9 @@ fn kind_read_func(
     FieldDescriptorProto_Type::TYPE_DOUBLE => "@lib.\{async_keyword}read_double"
     FieldDescriptorProto_Type::TYPE_STRING => "@lib.\{async_keyword}read_string"
     FieldDescriptorProto_Type::TYPE_BYTES => "@lib.\{async_keyword}read_bytes"
-    FieldDescriptorProto_Type::TYPE_ENUM =>
-      raise UnsupportedType("Enum type: \{kind}")
+    FieldDescriptorProto_Type::TYPE_ENUM => raise UnsupportedType("enum type")
     FieldDescriptorProto_Type::TYPE_MESSAGE =>
-      raise UnexpectedType("Message type: \{kind}")
+      raise UnexpectedType("message type")
     FieldDescriptorProto_Type::TYPE_GROUP => raise UnsupportedType("Group")
   }
 }
@@ -261,4 +260,3 @@ fn gen_kind_read(
     FieldDescriptorProto_Type::TYPE_GROUP => raise UnsupportedType("Group")
   }
 }
-

--- a/cli/size_template.mbt
+++ b/cli/size_template.mbt
@@ -8,7 +8,7 @@ fn CodeGenerator::gen_message_size(
   if message.fields.is_empty() && message.oneofs.is_empty() {
     content.write_string(
       (
-        $|pub impl @lib.Sized for \{message_name} with size_of(_) {
+        $|pub impl @lib.Sized for \{message_name} with fn size_of(_) {
         $|  0
         $|}
         $|
@@ -18,7 +18,7 @@ fn CodeGenerator::gen_message_size(
   }
   content.write_string(
     (
-      $|pub impl @lib.Sized for \{message_name} with size_of(self) {
+      $|pub impl @lib.Sized for \{message_name} with fn size_of(self) {
       $|  let mut size = 0U
       $|
     ),
@@ -54,7 +54,7 @@ fn CodeGenerator::gen_message_size(
             let tag_size = size_tag(field_number)
             "\{tag_size}U + { let size = self.\{field_name}.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }"
           }
-          _ => raise UnsupportedType("packed field type: \{typ}")
+          _ => raise UnsupportedType("unexpected packed field type")
         }
         content.write_string("  size += \{delta_size}\n")
       }
@@ -276,4 +276,3 @@ fn CodeGenerator::gen_message_size(
     ),
   )
 }
-

--- a/cli/types.mbt
+++ b/cli/types.mbt
@@ -21,7 +21,7 @@ fn ImportPath::from(path : String, package_name? : String = "") -> ImportPath {
     if part.is_empty() {
       continue
     }
-    import_path.push(part.to_string())
+    import_path.push(part.to_owned())
   }
   { path: import_path, package_name }
 }
@@ -48,7 +48,7 @@ fn ImportPath::append(self : ImportPath, part : String) -> ImportPath {
   new_path.push_iter(
     part
     .split(".")
-    .filter_map(x => if x.is_empty() { None } else { Some(x.to_string()) }),
+    .filter_map(x => if x.is_empty() { None } else { Some(x.to_owned()) }),
   )
   { path: new_path, package_name: self.package_name }
 }
@@ -130,27 +130,6 @@ fn Field::is_map(self : Field) -> Bool {
 ///|
 fn Field::is_list(self : Field) -> Bool {
   return self.desc.label is Some(LABEL_REPEATED)
-}
-
-///|
-fn Field::is_base_type(self : Field) -> Bool {
-  guard self.type_ is Some(type_) else { return false }
-  return match type_ {
-    FieldDescriptorProto_Type::TYPE_BOOL
-    | FieldDescriptorProto_Type::TYPE_INT32
-    | FieldDescriptorProto_Type::TYPE_INT64
-    | FieldDescriptorProto_Type::TYPE_UINT32
-    | FieldDescriptorProto_Type::TYPE_UINT64
-    | FieldDescriptorProto_Type::TYPE_SINT32
-    | FieldDescriptorProto_Type::TYPE_SINT64
-    | FieldDescriptorProto_Type::TYPE_SFIXED64
-    | FieldDescriptorProto_Type::TYPE_FIXED64
-    | FieldDescriptorProto_Type::TYPE_DOUBLE
-    | FieldDescriptorProto_Type::TYPE_SFIXED32
-    | FieldDescriptorProto_Type::TYPE_FIXED32
-    | FieldDescriptorProto_Type::TYPE_FLOAT => true
-    _ => false
-  }
 }
 
 ///|

--- a/cli/utils.mbt
+++ b/cli/utils.mbt
@@ -10,7 +10,7 @@ fn convert_args(args : String) -> Map[String, String] {
       if key.is_empty() || value.is_empty() {
         continue
       }
-      params[key.to_string()] = value.to_string()
+      params[key.to_owned()] = value.to_owned()
     }
   }
   return params

--- a/cli/writer_template.mbt
+++ b/cli/writer_template.mbt
@@ -12,7 +12,7 @@ fn CodeGenerator::gen_message_writer(
   if message.fields.is_empty() && message.oneofs.is_empty() {
     content.write_string(
       (
-        $|pub impl @lib.\{async_keyword_to_title}Write for \{message_name} with write(_, _) -> Unit noraise {
+        $|pub impl @lib.\{async_keyword_to_title}Write for \{message_name} with fn write(_, _) -> Unit noraise {
         $|}
         $|
       ),
@@ -20,7 +20,7 @@ fn CodeGenerator::gen_message_writer(
     return
   }
   content.write_string(
-    "pub impl @lib.\{async_keyword_to_title}Write for \{message_name} with write(self: \{message_name}, writer : &@lib.\{async_keyword_to_title}Writer) -> Unit raise {\n",
+    "pub impl @lib.\{async_keyword_to_title}Write for \{message_name} with fn write(self: \{message_name}, writer : &@lib.\{async_keyword_to_title}Writer) -> Unit raise {\n",
   )
   for field in message.fields {
     let field_name = field.import_path.name() |> pascal_to_snake
@@ -58,7 +58,7 @@ fn CodeGenerator::gen_message_writer(
           content.write_string(
             "  let size = self.\{field_name}.iter().map(@lib.size_of).fold(init=0U, UInt::add)\n",
           )
-        _ => raise UnexpectedType("packed field type: \{field.type_}")
+        _ => raise UnexpectedType("unexpected packed field type")
       }
       let field_write_type = self.gen_kind_write(field, "item", is_async~)
       content.write_string(
@@ -283,9 +283,6 @@ fn CodeGenerator::gen_kind_write(
       "writer |> @lib.\{async_keyword}write_uint64(\{variable})\n"
     FieldDescriptorProto_Type::TYPE_ENUM =>
       "writer |> @lib.\{async_keyword}write_enum(\{variable}.to_enum())\n"
-    _ =>
-      raise UnexpectedType(
-        "Unsupported field type: \{field_type} for field \{field.import_path.name()}",
-      )
+    _ => raise UnexpectedType("unsupported field type")
   }
 }

--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -1,6 +1,6 @@
 ///|
 pub(open) trait AsyncReader {
-  async read(Self, FixedArray[Byte], offset~ : Int, max_length~ : Int) -> Int?
+  async fn read(Self, FixedArray[Byte], offset~ : Int, max_length~ : Int) -> Int?
 }
 
 ///|

--- a/lib/async_writer.mbt
+++ b/lib/async_writer.mbt
@@ -1,6 +1,6 @@
 ///|
 pub(open) trait AsyncWriter {
-  async write(Self, BytesView) -> Unit
+  async fn write(Self, BytesView) -> Unit
 }
 
 ///|
@@ -129,7 +129,7 @@ pub async fn[T : AsyncWriter] async_write_string(
   writer : T,
   v : String,
 ) -> Unit {
-  let utf8_string = @buffer.new()
+  let utf8_string = Buffer()
   for ch in v {
     let ch = ch.to_int()
     if ch < 0x80 {

--- a/lib/json_utils.mbt
+++ b/lib/json_utils.mbt
@@ -89,7 +89,7 @@ test "decode/encode" {
       #|b"Hello, World!"
     ),
   )
-  assert_eq(data, decoded)
+  @debug.assert_eq(data, decoded)
 }
 
 ///|
@@ -104,5 +104,5 @@ test "decode/encode emoji" {
       #|b"\xf0\x9f\x98\x80"
     ),
   )
-  assert_eq(data, decoded)
+  @debug.assert_eq(data, decoded)
 }

--- a/lib/moon.mod
+++ b/lib/moon.mod
@@ -8,10 +8,6 @@ repository = "https://github.com/moonbitlang/protoc-gen-mbt"
 
 license = "Apache-2.0 WITH LLVM-exception"
 
-keywords = [
-  "idl",
-  "protobuf",
-  "codegen",
-]
+keywords = [ "idl", "protobuf", "codegen" ]
 
 description = "The runtime library for protobuf"

--- a/lib/moon.pkg
+++ b/lib/moon.pkg
@@ -1,4 +1,5 @@
 import {
   "moonbitlang/core/buffer",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/debug",
 }

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/protobuf"
 
 import {
   "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -173,7 +174,7 @@ pub(all) suberror ReaderError {
   EndOfStream
   InvalidString
   UnknownWireType(UInt)
-} derive(Eq)
+} derive(Eq, @debug.Debug)
 pub impl Show for ReaderError
 
 // Types and methods
@@ -183,11 +184,11 @@ pub impl Show for BytesReader
 pub impl AsyncReader for BytesReader
 pub impl Reader for BytesReader
 
-pub(all) struct Enum(UInt) derive(Default, Eq)
+pub(all) struct Enum(UInt) derive(Default, Eq, @debug.Debug)
 pub impl Show for Enum
 pub impl Sized for Enum
 
-pub(all) struct Len(Int) derive(Default, Eq)
+pub(all) struct Len(Int) derive(Default, Eq, @debug.Debug)
 pub impl Show for Len
 
 pub(all) struct LimitedReader[T] {
@@ -198,11 +199,11 @@ pub fn[T] LimitedReader::new(T, limit? : Int) -> Self[T]
 pub impl[T : AsyncReader] AsyncReader for LimitedReader[T]
 pub impl[T : Reader] Reader for LimitedReader[T]
 
-pub(all) struct SInt(Int) derive(Default, Eq)
+pub(all) struct SInt(Int) derive(Default, Eq, @debug.Debug)
 pub impl Show for SInt
 pub impl Sized for SInt
 
-pub(all) struct SInt64(Int64) derive(Default, Eq)
+pub(all) struct SInt64(Int64) derive(Default, Eq, @debug.Debug)
 pub impl Show for SInt64
 pub impl Sized for SInt64
 
@@ -213,20 +214,20 @@ pub(open) trait AsyncProto : AsyncRead + AsyncWrite {
 }
 
 pub(open) trait AsyncRead {
-  async read(&AsyncReader) -> Self = _
-  async read_with_limit(LimitedReader[&AsyncReader]) -> Self
+  async fn read(&AsyncReader) -> Self = _
+  async fn read_with_limit(LimitedReader[&AsyncReader]) -> Self
 }
 
 pub(open) trait AsyncReader {
-  async read(Self, FixedArray[Byte], offset~ : Int, max_length~ : Int) -> Int?
+  async fn read(Self, FixedArray[Byte], offset~ : Int, max_length~ : Int) -> Int?
 }
 
 pub(open) trait AsyncWrite {
-  async write(Self, &AsyncWriter) -> Unit
+  async fn write(Self, &AsyncWriter) -> Unit
 }
 
 pub(open) trait AsyncWriter {
-  async write(Self, BytesView) -> Unit
+  async fn write(Self, BytesView) -> Unit
 }
 pub impl AsyncWriter for @buffer.Buffer
 
@@ -234,16 +235,16 @@ pub(open) trait Proto : Read + Write {
 }
 
 pub(open) trait Read {
-  read(&Reader) -> Self raise = _
-  read_with_limit(LimitedReader[&Reader]) -> Self raise
+  fn read(&Reader) -> Self raise = _
+  fn read_with_limit(LimitedReader[&Reader]) -> Self raise
 }
 
 pub(open) trait Reader {
-  read(Self, FixedArray[Byte], offset~ : Int, max_length~ : Int) -> Int? raise
+  fn read(Self, FixedArray[Byte], offset~ : Int, max_length~ : Int) -> Int? raise
 }
 
 pub(open) trait Sized {
-  size_of(Self) -> UInt
+  fn size_of(Self) -> UInt
 }
 pub impl Sized for Bool
 pub impl Sized for Int
@@ -256,11 +257,11 @@ pub impl Sized for String
 pub impl Sized for Bytes
 
 pub(open) trait Write {
-  write(Self, &Writer) -> Unit raise
+  fn write(Self, &Writer) -> Unit raise
 }
 
 pub(open) trait Writer {
-  write(Self, BytesView) -> Unit raise
+  fn write(Self, BytesView) -> Unit raise
 }
 pub impl Writer for @buffer.Buffer
 

--- a/lib/proto.mbt
+++ b/lib/proto.mbt
@@ -14,36 +14,36 @@
 
 ///|
 pub(open) trait Read {
-  read(&Reader) -> Self raise = _
-  read_with_limit(LimitedReader[&Reader]) -> Self raise
+  fn read(&Reader) -> Self raise = _
+  fn read_with_limit(LimitedReader[&Reader]) -> Self raise
 }
 
 ///|
-impl Read with read(reader : &Reader) -> Self raise {
+impl Read with fn read(reader : &Reader) -> Self raise {
   let reader = LimitedReader::new(reader)
   Read::read_with_limit(reader)
 }
 
 ///|
 pub(open) trait Write {
-  write(Self, &Writer) -> Unit raise
+  fn write(Self, &Writer) -> Unit raise
 }
 
 ///|
 pub(open) trait AsyncRead {
-  async read(&AsyncReader) -> Self = _
-  async read_with_limit(LimitedReader[&AsyncReader]) -> Self
+  async fn read(&AsyncReader) -> Self = _
+  async fn read_with_limit(LimitedReader[&AsyncReader]) -> Self
 }
 
 ///|
-impl AsyncRead with read(reader : &AsyncReader) -> Self raise {
+impl AsyncRead with fn read(reader : &AsyncReader) -> Self raise {
   let reader = LimitedReader::new(reader)
   AsyncRead::read_with_limit(reader)
 }
 
 ///|
 pub(open) trait AsyncWrite {
-  async write(Self, &AsyncWriter) -> Unit
+  async fn write(Self, &AsyncWriter) -> Unit
 }
 
 ///|

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -15,7 +15,7 @@
 ///|
 /// Trait representing the reader
 pub(open) trait Reader {
-  read(Self, FixedArray[Byte], offset~ : Int, max_length~ : Int) -> Int? raise
+  fn read(Self, FixedArray[Byte], offset~ : Int, max_length~ : Int) -> Int? raise
 }
 
 ///|

--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -17,10 +17,10 @@ pub(all) suberror ReaderError {
   EndOfStream
   InvalidString
   UnknownWireType(UInt)
-} derive(Eq)
+} derive(Eq, Debug)
 
 ///|
-pub impl Show for ReaderError with output(self, logger) {
+pub impl Show for ReaderError with fn output(self, logger) {
   match self {
     EndOfStream => logger.write_string("EndOfStream")
     InvalidString => logger.write_string("InvalidString")
@@ -40,7 +40,7 @@ struct BytesReader {
 }
 
 ///|
-pub impl Show for BytesReader with output(self, logger) {
+pub impl Show for BytesReader with fn output(self, logger) {
   logger
   ..write_string("{data: ")
   ..write_object(self.data)
@@ -57,7 +57,7 @@ pub fn BytesReader::from_bytes(data : Bytes) -> BytesReader {
 }
 
 ///|
-pub impl Reader for BytesReader with read(
+pub impl Reader for BytesReader with fn read(
   self,
   bytes : FixedArray[Byte],
   offset~ : Int,
@@ -77,7 +77,7 @@ pub impl Reader for BytesReader with read(
 }
 
 ///|
-pub impl AsyncReader for BytesReader with read(
+pub impl AsyncReader for BytesReader with fn read(
   self,
   bytes : FixedArray[Byte],
   offset~ : Int,
@@ -107,7 +107,7 @@ pub fn[T] LimitedReader::new(reader : T, limit? : Int) -> LimitedReader[T] {
 }
 
 ///|
-pub impl[T : Reader] Reader for LimitedReader[T] with read(
+pub impl[T : Reader] Reader for LimitedReader[T] with fn read(
   self,
   bytes : FixedArray[Byte],
   offset~ : Int,
@@ -129,7 +129,7 @@ pub impl[T : Reader] Reader for LimitedReader[T] with read(
 }
 
 ///|
-pub impl[T : AsyncReader] AsyncReader for LimitedReader[T] with read(
+pub impl[T : AsyncReader] AsyncReader for LimitedReader[T] with fn read(
   self,
   bytes : FixedArray[Byte],
   offset~ : Int,

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -18,7 +18,7 @@
 test "varint" {
   let bytes = b"\x96\x01"
   let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
-  assert_eq(r |> @protobuf.read_varint32(), 150)
+  @debug.assert_eq(r |> @protobuf.read_varint32(), 150)
 }
 
 ///|
@@ -27,43 +27,55 @@ test "varint" {
 test "read_int32" {
   let bytes = b"\xFE\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01"
   let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
-  assert_eq(r |> @protobuf.read_int64(), -2)
+  @debug.assert_eq(r |> @protobuf.read_int64(), -2)
 }
 
 ///|
 test "read_int32/2" {
   let bytes = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01"
   let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
-  assert_eq(r |> @protobuf.read_int32(), -1)
+  @debug.assert_eq(r |> @protobuf.read_int32(), -1)
 }
 
 ///|
 test "read_int32/3" {
   let bytes = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01"
   let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
-  assert_eq(r |> @protobuf.read_varint32() |> UInt::reinterpret_as_int, -1)
-  // assert_eq(r |> @protobuf.is_eof(), false)
+  @debug.assert_eq(
+    r |> @protobuf.read_varint32() |> UInt::reinterpret_as_int,
+    -1,
+  )
+  // @debug.assert_eq(r |> @protobuf.is_eof(), false)
 }
 
 ///|
 test "end_of_bytes" {
   let bytes = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01"
   let r = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
-  assert_eq(r |> @protobuf.read_varint32() |> UInt::reinterpret_as_int, -1)
+  @debug.assert_eq(
+    r |> @protobuf.read_varint32() |> UInt::reinterpret_as_int,
+    -1,
+  )
 }
 
 ///|
 test "read_string" {
   let r = @protobuf.BytesReader::from_bytes(b"\x02\x61\x62")
     as &@protobuf.Reader
-  assert_eq(r |> @protobuf.read_string(), "ab")
+  @debug.assert_eq(r |> @protobuf.read_string(), "ab")
   let r = @protobuf.BytesReader::from_bytes(b"\x06\xE4\xB8\xAD\xE6\x96\x87")
     as &@protobuf.Reader
-  assert_eq(r |> @protobuf.read_string(), "中文")
+  @debug.assert_eq(r |> @protobuf.read_string(), "中文")
 }
 
 ///|
 test "error" {
   let r = @protobuf.BytesReader::from_bytes(b"") as &@protobuf.Reader
-  inspect(try? (r |> @protobuf.read_varint32()), content="Err(EndOfStream)")
+  try {
+    let _ = r |> @protobuf.read_varint32()
+    fail("expected EndOfStream")
+  } catch {
+    @protobuf.EndOfStream => ()
+    err => raise err
+  }
 }

--- a/lib/sizeof.mbt
+++ b/lib/sizeof.mbt
@@ -14,7 +14,7 @@
 
 ///|
 pub(open) trait Sized {
-  size_of(Self) -> UInt
+  fn size_of(Self) -> UInt
 }
 
 ///|
@@ -48,63 +48,63 @@ fn size_of_varint(v : UInt64) -> UInt {
 }
 
 ///|
-pub impl Sized for UInt with size_of(self) {
+pub impl Sized for UInt with fn size_of(self) {
   size_of_varint(self.to_uint64())
 }
 
 ///|
-pub impl Sized for UInt64 with size_of(self) {
+pub impl Sized for UInt64 with fn size_of(self) {
   size_of_varint(self)
 }
 
 ///|
-pub impl Sized for Int with size_of(self) {
+pub impl Sized for Int with fn size_of(self) {
   size_of_varint(self.to_int64().reinterpret_as_uint64())
 }
 
 ///|
-pub impl Sized for Int64 with size_of(self) {
+pub impl Sized for Int64 with fn size_of(self) {
   size_of_varint(self.reinterpret_as_uint64())
 }
 
 ///|
-pub impl Sized for SInt with size_of(self) {
+pub impl Sized for SInt with fn size_of(self) {
   let v64 = self.0.to_int64()
   size_of_varint(((v64 << 1) ^ (v64 >> 31)).reinterpret_as_uint64())
 }
 
 ///|
-pub impl Sized for SInt64 with size_of(self) {
+pub impl Sized for SInt64 with fn size_of(self) {
   size_of_varint(((self.0 << 1) ^ (self.0 >> 63)).reinterpret_as_uint64())
 }
 
 ///|
-pub impl Sized for Bool with size_of(__) {
+pub impl Sized for Bool with fn size_of(__) {
   1
 }
 
 ///|
-pub impl Sized for Enum with size_of(self) {
+pub impl Sized for Enum with fn size_of(self) {
   size_of_varint(self.0.to_int64().reinterpret_as_uint64())
 }
 
 ///|
-pub impl Sized for Float with size_of(__) {
+pub impl Sized for Float with fn size_of(__) {
   4
 }
 
 ///|
-pub impl Sized for Double with size_of(__) {
+pub impl Sized for Double with fn size_of(__) {
   8
 }
 
 ///|
-pub impl Sized for Bytes with size_of(self) {
+pub impl Sized for Bytes with fn size_of(self) {
   self.length().reinterpret_as_uint()
 }
 
 ///|
-pub impl Sized for String with size_of(self) {
+pub impl Sized for String with fn size_of(self) {
   self
   .iter()
   .map(ch => {

--- a/lib/test/codec_bad_test.mbt
+++ b/lib/test/codec_bad_test.mbt
@@ -4,8 +4,12 @@
 test "bad/unknown_wire" {
   let bytes = @protobuf.base64_decode("Dg==")
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
-  inspect(
-    try? (reader |> @protobuf.read_tag()),
+  debug_inspect(
+    try reader |> @protobuf.read_tag() catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content="Err(UnknownWireType(6))",
   )
 }
@@ -15,9 +19,16 @@ test "bad/truncated_string" {
   let bytes = @protobuf.base64_decode("CgJh")
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 2U)
-  inspect(try? (reader |> @protobuf.read_string()), content="Err(EndOfStream)")
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 2U)
+  debug_inspect(
+    try reader |> @protobuf.read_string() catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Err(EndOfStream)",
+  )
 }
 
 ///|
@@ -25,10 +36,14 @@ test "bad/invalid_string" {
   let bytes = @protobuf.base64_decode("CgHC")
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 2U)
-  inspect(
-    try? (reader |> @protobuf.read_string()),
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 2U)
+  debug_inspect(
+    try reader |> @protobuf.read_string() catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content="Err(InvalidString)",
   )
 }

--- a/lib/test/codec_chunked_reader_test.mbt
+++ b/lib/test/codec_chunked_reader_test.mbt
@@ -11,7 +11,7 @@ fn OneByteReader::from_bytes(data : Bytes) -> OneByteReader {
 }
 
 ///|
-pub impl @protobuf.Reader for OneByteReader with read(
+pub impl @protobuf.Reader for OneByteReader with fn read(
   self,
   bytes : FixedArray[Byte],
   offset~ : Int,
@@ -35,7 +35,7 @@ pub impl @protobuf.Reader for OneByteReader with read(
 
 ///|
 test "chunked-reader/one-byte" {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 5U))
   writer |> @protobuf.write_fixed32(0xAABBCCDDU)
   writer |> @protobuf.write_tag((2U, 1U))
@@ -49,19 +49,19 @@ test "chunked-reader/one-byte" {
   let bytes = writer.to_bytes()
   let reader = OneByteReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 5U)
-  assert_eq(reader |> @protobuf.read_fixed32(), 0xAABBCCDDU)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 5U)
+  @debug.assert_eq(reader |> @protobuf.read_fixed32(), 0xAABBCCDDU)
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 2U)
-  assert_eq(wire_type, 1U)
-  assert_eq(reader |> @protobuf.read_fixed64(), 0x1122334455667788UL)
+  @debug.assert_eq(tag, 2U)
+  @debug.assert_eq(wire_type, 1U)
+  @debug.assert_eq(reader |> @protobuf.read_fixed64(), 0x1122334455667788UL)
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 3U)
-  assert_eq(wire_type, 2U)
-  assert_eq(reader |> @protobuf.read_string(), emoji)
+  @debug.assert_eq(tag, 3U)
+  @debug.assert_eq(wire_type, 2U)
+  @debug.assert_eq(reader |> @protobuf.read_string(), emoji)
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 4U)
-  assert_eq(wire_type, 2U)
-  assert_eq(reader |> @protobuf.read_bytes(), payload)
+  @debug.assert_eq(tag, 4U)
+  @debug.assert_eq(wire_type, 2U)
+  @debug.assert_eq(reader |> @protobuf.read_bytes(), payload)
 }

--- a/lib/test/codec_difficult_test.mbt
+++ b/lib/test/codec_difficult_test.mbt
@@ -104,7 +104,10 @@ fn decode_difficult(b64 : String) -> DifficultDecoded raise {
           3 => ratio = reader |> @protobuf.read_double()
           4 => {
             let packed = reader
-              |> @protobuf.read_packed(@protobuf.read_double, Some(8U))
+              |> @protobuf.read_packed(
+                fn(r) raise { r |> @protobuf.read_double() },
+                Some(8U),
+              )
             for score in packed {
               scores.push(score)
             }
@@ -135,7 +138,7 @@ fn decode_difficult(b64 : String) -> DifficultDecoded raise {
 ///|
 fn encode_item(item : (String, Bytes, UInt64)) -> Bytes raise {
   let (name, raw, code) = item
-  let writer = @buffer.new()
+  let writer = Buffer()
   if name != "" {
     writer |> @protobuf.write_tag((1U, 2U))
     writer |> @protobuf.write_string(name)
@@ -154,7 +157,7 @@ fn encode_item(item : (String, Bytes, UInt64)) -> Bytes raise {
 ///|
 fn encode_count(entry : (String, Int)) -> Bytes raise {
   let (key, value) = entry
-  let writer = @buffer.new()
+  let writer = Buffer()
   if key != "" {
     writer |> @protobuf.write_tag((1U, 2U))
     writer |> @protobuf.write_string(key)
@@ -166,7 +169,7 @@ fn encode_count(entry : (String, Int)) -> Bytes raise {
 
 ///|
 fn encode_difficult(case : DifficultCase) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   if case.big != 0UL {
     writer |> @protobuf.write_tag((1U, 0U))
     writer |> @protobuf.write_uint64(case.big)
@@ -180,7 +183,7 @@ fn encode_difficult(case : DifficultCase) -> String raise {
     writer |> @protobuf.write_double(case.ratio)
   }
   if case.scores.length() > 0 {
-    let packed_writer = @buffer.new()
+    let packed_writer = Buffer()
     for score in case.scores {
       packed_writer |> @protobuf.write_double(score)
     }
@@ -1161,15 +1164,15 @@ test "difficult/messages" {
   ]
   for case in cases {
     let decoded = decode_difficult(case.b64)
-    assert_eq(decoded.big, case.big)
-    assert_eq(decoded.zigzag, case.zigzag)
-    assert_eq(decoded.ratio, case.ratio)
-    assert_eq(decoded.scores, case.scores)
-    assert_eq(decoded.items, case.items)
-    assert_eq(decoded.counts, case.counts)
-    assert_eq(decoded.choice_text, case.choice_text)
-    assert_eq(decoded.choice_number, case.choice_number)
-    assert_eq(decoded.payload, case.payload)
-    assert_eq(encode_difficult(case), case.b64)
+    @debug.assert_eq(decoded.big, case.big)
+    @debug.assert_eq(decoded.zigzag, case.zigzag)
+    @debug.assert_eq(decoded.ratio, case.ratio)
+    @debug.assert_eq(decoded.scores, case.scores)
+    @debug.assert_eq(decoded.items, case.items)
+    @debug.assert_eq(decoded.counts, case.counts)
+    @debug.assert_eq(decoded.choice_text, case.choice_text)
+    @debug.assert_eq(decoded.choice_number, case.choice_number)
+    @debug.assert_eq(decoded.payload, case.payload)
+    @debug.assert_eq(encode_difficult(case), case.b64)
   }
 }

--- a/lib/test/codec_middle_test.mbt
+++ b/lib/test/codec_middle_test.mbt
@@ -76,7 +76,10 @@ fn decode_middle(b64 : String) -> MiddleDecoded raise {
           2 => values.push(reader |> @protobuf.read_int32())
           3 => {
             let packed = reader
-              |> @protobuf.read_packed(r => r |> @protobuf.read_sint32(), None)
+              |> @protobuf.read_packed(
+                fn(r) raise { r |> @protobuf.read_sint32() },
+                None,
+              )
             for value in packed {
               packed_values.push(value.0)
             }
@@ -101,7 +104,7 @@ fn decode_middle(b64 : String) -> MiddleDecoded raise {
 ///|
 fn encode_middle_nested(value : (Int64, Bool, String)) -> Bytes raise {
   let (count, flag, note) = value
-  let writer = @buffer.new()
+  let writer = Buffer()
   if count != 0L {
     writer |> @protobuf.write_tag((1U, 0U))
     writer |> @protobuf.write_int64(count)
@@ -119,7 +122,7 @@ fn encode_middle_nested(value : (Int64, Bool, String)) -> Bytes raise {
 
 ///|
 fn encode_middle(case : MiddleCase) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   if case.id != 0 {
     writer |> @protobuf.write_tag((1U, 0U))
     writer |> @protobuf.write_int32(case.id)
@@ -129,7 +132,7 @@ fn encode_middle(case : MiddleCase) -> String raise {
     writer |> @protobuf.write_int32(value)
   }
   if case.packed_values.length() > 0 {
-    let packed_writer = @buffer.new()
+    let packed_writer = Buffer()
     for value in case.packed_values {
       packed_writer |> @protobuf.write_sint32(value)
     }
@@ -1111,14 +1114,14 @@ test "middle/messages" {
   ]
   for case in cases {
     let decoded = decode_middle(case.b64)
-    assert_eq(decoded.id, case.id)
-    assert_eq(decoded.values, case.values)
-    assert_eq(decoded.packed_values, case.packed_values)
-    assert_eq(decoded.label, case.label)
-    assert_eq(decoded.data, case.data)
-    assert_eq(decoded.nested, case.nested)
-    assert_eq(decoded.status, case.status)
-    assert_eq(decoded.tags, case.tags)
-    assert_eq(encode_middle(case), case.b64)
+    @debug.assert_eq(decoded.id, case.id)
+    @debug.assert_eq(decoded.values, case.values)
+    @debug.assert_eq(decoded.packed_values, case.packed_values)
+    @debug.assert_eq(decoded.label, case.label)
+    @debug.assert_eq(decoded.data, case.data)
+    @debug.assert_eq(decoded.nested, case.nested)
+    @debug.assert_eq(decoded.status, case.status)
+    @debug.assert_eq(decoded.tags, case.tags)
+    @debug.assert_eq(encode_middle(case), case.b64)
   }
 }

--- a/lib/test/codec_simple_test.mbt
+++ b/lib/test/codec_simple_test.mbt
@@ -5,14 +5,14 @@ fn decode_int32(b64 : String) -> Int raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 0U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 0U)
   reader |> @protobuf.read_int32()
 }
 
 ///|
 fn encode_int32(value : Int) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 0U))
   writer |> @protobuf.write_int32(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -54,8 +54,8 @@ test "simple/int32" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_int32(b64), expected)
-    assert_eq(encode_int32(expected), b64)
+    @debug.assert_eq(decode_int32(b64), expected)
+    @debug.assert_eq(encode_int32(expected), b64)
   }
 }
 
@@ -64,14 +64,14 @@ fn decode_int64(b64 : String) -> Int64 raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 0U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 0U)
   reader |> @protobuf.read_int64()
 }
 
 ///|
 fn encode_int64(value : Int64) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 0U))
   writer |> @protobuf.write_int64(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -118,8 +118,8 @@ test "simple/int64" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_int64(b64), expected)
-    assert_eq(encode_int64(expected), b64)
+    @debug.assert_eq(decode_int64(b64), expected)
+    @debug.assert_eq(encode_int64(expected), b64)
   }
 }
 
@@ -128,14 +128,14 @@ fn decode_uint32(b64 : String) -> UInt raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 0U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 0U)
   reader |> @protobuf.read_uint32()
 }
 
 ///|
 fn encode_uint32(value : UInt) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 0U))
   writer |> @protobuf.write_uint32(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -166,8 +166,8 @@ test "simple/uint32" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_uint32(b64), expected)
-    assert_eq(encode_uint32(expected), b64)
+    @debug.assert_eq(decode_uint32(b64), expected)
+    @debug.assert_eq(encode_uint32(expected), b64)
   }
 }
 
@@ -176,14 +176,14 @@ fn decode_uint64(b64 : String) -> UInt64 raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 0U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 0U)
   reader |> @protobuf.read_uint64()
 }
 
 ///|
 fn encode_uint64(value : UInt64) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 0U))
   writer |> @protobuf.write_uint64(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -219,8 +219,8 @@ test "simple/uint64" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_uint64(b64), expected)
-    assert_eq(encode_uint64(expected), b64)
+    @debug.assert_eq(decode_uint64(b64), expected)
+    @debug.assert_eq(encode_uint64(expected), b64)
   }
 }
 
@@ -229,14 +229,14 @@ fn decode_sint32(b64 : String) -> Int raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 0U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 0U)
   (reader |> @protobuf.read_sint32()).0
 }
 
 ///|
 fn encode_sint32(value : Int) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 0U))
   writer |> @protobuf.write_sint32(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -267,8 +267,8 @@ test "simple/sint32" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_sint32(b64), expected)
-    assert_eq(encode_sint32(expected), b64)
+    @debug.assert_eq(decode_sint32(b64), expected)
+    @debug.assert_eq(encode_sint32(expected), b64)
   }
 }
 
@@ -277,14 +277,14 @@ fn decode_sint64(b64 : String) -> Int64 raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 0U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 0U)
   (reader |> @protobuf.read_sint64()).0
 }
 
 ///|
 fn encode_sint64(value : Int64) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 0U))
   writer |> @protobuf.write_sint64(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -317,8 +317,8 @@ test "simple/sint64" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_sint64(b64), expected)
-    assert_eq(encode_sint64(expected), b64)
+    @debug.assert_eq(decode_sint64(b64), expected)
+    @debug.assert_eq(encode_sint64(expected), b64)
   }
 }
 
@@ -327,14 +327,14 @@ fn decode_bool(b64 : String) -> Bool raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 0U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 0U)
   reader |> @protobuf.read_bool()
 }
 
 ///|
 fn encode_bool(value : Bool) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 0U))
   writer |> @protobuf.write_bool(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -345,8 +345,8 @@ test "simple/bool" {
   let cases : Array[(String, Bool)] = [("CAA=", false), ("CAE=", true)]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_bool(b64), expected)
-    assert_eq(encode_bool(expected), b64)
+    @debug.assert_eq(decode_bool(b64), expected)
+    @debug.assert_eq(encode_bool(expected), b64)
   }
 }
 
@@ -355,14 +355,14 @@ fn decode_enum(b64 : String) -> UInt raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 0U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 0U)
   (reader |> @protobuf.read_enum()).0
 }
 
 ///|
 fn encode_enum(value : UInt) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 0U))
   writer |> @protobuf.write_enum(@protobuf.Enum(value))
   writer.to_bytes() |> @protobuf.base64_encode
@@ -378,8 +378,8 @@ test "simple/enum" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_enum(b64), expected)
-    assert_eq(encode_enum(expected), b64)
+    @debug.assert_eq(decode_enum(b64), expected)
+    @debug.assert_eq(encode_enum(expected), b64)
   }
 }
 
@@ -388,14 +388,14 @@ fn decode_fixed32(b64 : String) -> UInt raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 5U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 5U)
   reader |> @protobuf.read_fixed32()
 }
 
 ///|
 fn encode_fixed32(value : UInt) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 5U))
   writer |> @protobuf.write_fixed32(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -415,8 +415,8 @@ test "simple/fixed32" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_fixed32(b64), expected)
-    assert_eq(encode_fixed32(expected), b64)
+    @debug.assert_eq(decode_fixed32(b64), expected)
+    @debug.assert_eq(encode_fixed32(expected), b64)
   }
 }
 
@@ -425,14 +425,14 @@ fn decode_fixed64(b64 : String) -> UInt64 raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 1U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 1U)
   reader |> @protobuf.read_fixed64()
 }
 
 ///|
 fn encode_fixed64(value : UInt64) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 1U))
   writer |> @protobuf.write_fixed64(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -452,8 +452,8 @@ test "simple/fixed64" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_fixed64(b64), expected)
-    assert_eq(encode_fixed64(expected), b64)
+    @debug.assert_eq(decode_fixed64(b64), expected)
+    @debug.assert_eq(encode_fixed64(expected), b64)
   }
 }
 
@@ -462,14 +462,14 @@ fn decode_sfixed32(b64 : String) -> Int raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 5U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 5U)
   reader |> @protobuf.read_sfixed32()
 }
 
 ///|
 fn encode_sfixed32(value : Int) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 5U))
   writer |> @protobuf.write_sfixed32(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -489,8 +489,8 @@ test "simple/sfixed32" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_sfixed32(b64), expected)
-    assert_eq(encode_sfixed32(expected), b64)
+    @debug.assert_eq(decode_sfixed32(b64), expected)
+    @debug.assert_eq(encode_sfixed32(expected), b64)
   }
 }
 
@@ -499,14 +499,14 @@ fn decode_sfixed64(b64 : String) -> Int64 raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 1U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 1U)
   reader |> @protobuf.read_sfixed64()
 }
 
 ///|
 fn encode_sfixed64(value : Int64) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 1U))
   writer |> @protobuf.write_sfixed64(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -526,8 +526,8 @@ test "simple/sfixed64" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_sfixed64(b64), expected)
-    assert_eq(encode_sfixed64(expected), b64)
+    @debug.assert_eq(decode_sfixed64(b64), expected)
+    @debug.assert_eq(encode_sfixed64(expected), b64)
   }
 }
 
@@ -536,15 +536,15 @@ fn decode_float_bits(b64 : String) -> UInt raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 5U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 5U)
   let value = reader |> @protobuf.read_float()
   value.reinterpret_as_uint()
 }
 
 ///|
 fn encode_float_bits(bits : UInt) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 5U))
   let value = Float::reinterpret_from_int(bits.reinterpret_as_int())
   writer |> @protobuf.write_float(value)
@@ -567,8 +567,8 @@ test "simple/float" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_float_bits(b64), expected)
-    assert_eq(encode_float_bits(expected), b64)
+    @debug.assert_eq(decode_float_bits(b64), expected)
+    @debug.assert_eq(encode_float_bits(expected), b64)
   }
 }
 
@@ -577,15 +577,15 @@ fn decode_double_bits(b64 : String) -> UInt64 raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 1U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 1U)
   let value = reader |> @protobuf.read_double()
   value.reinterpret_as_uint64()
 }
 
 ///|
 fn encode_double_bits(bits : UInt64) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 1U))
   let value = Int64::reinterpret_as_double(bits.reinterpret_as_int64())
   writer |> @protobuf.write_double(value)
@@ -608,8 +608,8 @@ test "simple/double" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_double_bits(b64), expected)
-    assert_eq(encode_double_bits(expected), b64)
+    @debug.assert_eq(decode_double_bits(b64), expected)
+    @debug.assert_eq(encode_double_bits(expected), b64)
   }
 }
 
@@ -618,14 +618,14 @@ fn decode_bytes(b64 : String) -> Bytes raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 2U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 2U)
   reader |> @protobuf.read_bytes()
 }
 
 ///|
 fn encode_bytes(value : Bytes) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 2U))
   writer |> @protobuf.write_bytes(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -651,8 +651,8 @@ test "simple/bytes" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_bytes(b64), expected)
-    assert_eq(encode_bytes(expected), b64)
+    @debug.assert_eq(decode_bytes(b64), expected)
+    @debug.assert_eq(encode_bytes(expected), b64)
   }
 }
 
@@ -661,14 +661,14 @@ fn decode_string(b64 : String) -> String raise {
   let bytes = @protobuf.base64_decode(b64)
   let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader
   let (tag, wire_type) = reader |> @protobuf.read_tag()
-  assert_eq(tag, 1U)
-  assert_eq(wire_type, 2U)
+  @debug.assert_eq(tag, 1U)
+  @debug.assert_eq(wire_type, 2U)
   reader |> @protobuf.read_string()
 }
 
 ///|
 fn encode_string(value : String) -> String raise {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_tag((1U, 2U))
   writer |> @protobuf.write_string(value)
   writer.to_bytes() |> @protobuf.base64_encode
@@ -692,7 +692,7 @@ test "simple/string" {
   ]
   for case in cases {
     let (b64, expected) = case
-    assert_eq(decode_string(b64), expected)
-    assert_eq(encode_string(expected), b64)
+    @debug.assert_eq(decode_string(b64), expected)
+    @debug.assert_eq(encode_string(expected), b64)
   }
 }

--- a/lib/test/moon.pkg
+++ b/lib/test/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
 }
 
 import {

--- a/lib/types.mbt
+++ b/lib/types.mbt
@@ -14,36 +14,36 @@
 
 ///|
 /// `sint32`
-pub(all) struct SInt(Int) derive(Default, Eq)
+pub(all) struct SInt(Int) derive(Default, Eq, Debug)
 
 ///|
-pub impl Show for SInt with output(self, logger) {
+pub impl Show for SInt with fn output(self, logger) {
   logger..write_string("SInt(")..write_object(self.0).write_string(")")
 }
 
 ///|
 /// `sint64`
-pub(all) struct SInt64(Int64) derive(Default, Eq)
+pub(all) struct SInt64(Int64) derive(Default, Eq, Debug)
 
 ///|
-pub impl Show for SInt64 with output(self, logger) {
+pub impl Show for SInt64 with fn output(self, logger) {
   logger..write_string("SInt64(")..write_object(self.0).write_string(")")
 }
 
 ///|
 /// length
-pub(all) struct Len(Int) derive(Default, Eq)
+pub(all) struct Len(Int) derive(Default, Eq, Debug)
 
 ///|
-pub impl Show for Len with output(self, logger) {
+pub impl Show for Len with fn output(self, logger) {
   logger..write_string("Len(")..write_object(self.0).write_string(")")
 }
 
 ///|
 /// Enum
-pub(all) struct Enum(UInt) derive(Default, Eq)
+pub(all) struct Enum(UInt) derive(Default, Eq, Debug)
 
 ///|
-pub impl Show for Enum with output(self, logger) {
+pub impl Show for Enum with fn output(self, logger) {
   logger..write_string("Enum(")..write_object(self.0).write_string(")")
 }

--- a/lib/writer.mbt
+++ b/lib/writer.mbt
@@ -15,7 +15,7 @@
 ///|
 /// Trait representing the Writer
 pub(open) trait Writer {
-  write(Self, BytesView) -> Unit raise
+  fn write(Self, BytesView) -> Unit raise
 }
 
 ///|
@@ -122,7 +122,7 @@ pub fn[T : Writer] write_bytes(writer : T, v : Bytes) -> Unit raise {
 
 ///|
 pub fn[T : Writer] write_string(writer : T, v : String) -> Unit raise {
-  let utf8_string = @buffer.new()
+  let utf8_string = Buffer()
   for ch in v {
     let ch = ch.to_int()
     if ch < 0x80 {

--- a/lib/writer_impl.mbt
+++ b/lib/writer_impl.mbt
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 ///|
-pub impl Writer for @buffer.Buffer with write(self, bytes : BytesView) raise {
+pub impl Writer for @buffer.Buffer with fn write(self, bytes : BytesView) raise {
   self.write_bytesview(bytes)
 }
 
 ///|
-pub impl AsyncWriter for @buffer.Buffer with write(self, bytes : BytesView) raise {
+pub impl AsyncWriter for @buffer.Buffer with fn write(self, bytes : BytesView) raise {
   self.write_bytesview(bytes)
 }

--- a/lib/writer_test.mbt
+++ b/lib/writer_test.mbt
@@ -14,44 +14,50 @@
 
 ///|
 test "varint" {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_varint(150)
-  assert_eq(writer.to_bytes(), b"\x96\x01")
+  @debug.assert_eq(writer.to_bytes(), b"\x96\x01")
 }
 
 ///|
 test "varint size boundaries" {
-  assert_eq(@protobuf.size_of(0x7FUL), 1U)
-  assert_eq(@protobuf.size_of(0x80UL), 2U)
-  assert_eq(@protobuf.size_of(0x3FFFUL), 2U)
-  assert_eq(@protobuf.size_of(0x4000UL), 3U)
-  assert_eq(@protobuf.size_of(0x1FFFFFUL), 3U)
-  assert_eq(@protobuf.size_of(0x200000UL), 4U)
-  assert_eq(@protobuf.size_of(0xFFFFFFFUL), 4U)
-  assert_eq(@protobuf.size_of(0x10000000UL), 5U)
+  @debug.assert_eq(@protobuf.size_of(0x7FUL), 1U)
+  @debug.assert_eq(@protobuf.size_of(0x80UL), 2U)
+  @debug.assert_eq(@protobuf.size_of(0x3FFFUL), 2U)
+  @debug.assert_eq(@protobuf.size_of(0x4000UL), 3U)
+  @debug.assert_eq(@protobuf.size_of(0x1FFFFFUL), 3U)
+  @debug.assert_eq(@protobuf.size_of(0x200000UL), 4U)
+  @debug.assert_eq(@protobuf.size_of(0xFFFFFFFUL), 4U)
+  @debug.assert_eq(@protobuf.size_of(0x10000000UL), 5U)
 }
 
 ///|
 test "integer" {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_int64(-2)
-  assert_eq(writer.to_bytes(), b"\xFE\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01")
+  @debug.assert_eq(
+    writer.to_bytes(),
+    b"\xFE\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01",
+  )
 }
 
 ///|
 test "signed integer" {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_sint32(0)
   writer |> @protobuf.write_sint32(-1)
   writer |> @protobuf.write_sint32(1)
   writer |> @protobuf.write_sint32(-2)
-  assert_eq(writer.to_bytes(), b"\x00\x01\x02\x03")
+  @debug.assert_eq(writer.to_bytes(), b"\x00\x01\x02\x03")
 }
 
 ///|
 test "string" {
-  let writer = @buffer.new()
+  let writer = Buffer()
   writer |> @protobuf.write_string("ab")
   writer |> @protobuf.write_string("中文")
-  assert_eq(writer.to_bytes(), b"\x02\x61\x62\x06\xE4\xB8\xAD\xE6\x96\x87")
+  @debug.assert_eq(
+    writer.to_bytes(),
+    b"\x02\x61\x62\x06\xE4\xB8\xAD\xE6\x96\x87",
+  )
 }

--- a/plugin/moon.mod
+++ b/plugin/moon.mod
@@ -13,12 +13,12 @@ repository = ""
 
 license = ""
 
-keywords = []
+keywords = [ ]
 
 description = ""
+
+preferred_target = "native"
 
 options(
   source: "src",
 )
-
-preferred_target = "native"

--- a/plugin/src/google/protobuf/compiler/moon.pkg
+++ b/plugin/src/google/protobuf/compiler/moon.pkg
@@ -1,6 +1,6 @@
 import {
-  "moonbitlang/protobuf",
-  "moonbitlang/plugin/google/protobuf" @protobuf1,
+  "moonbitlang/protobuf" @lib,
+  "moonbitlang/plugin/google/protobuf",
   "moonbitlang/core/json",
   "moonbitlang/core/buffer",
 }

--- a/plugin/src/google/protobuf/compiler/top.mbt
+++ b/plugin/src/google/protobuf/compiler/top.mbt
@@ -7,29 +7,29 @@ pub(all) struct Version {
 } derive(Eq, Debug)
 
 ///|
-pub impl @protobuf.Sized for Version with size_of(self) {
+pub impl @lib.Sized for Version with fn size_of(self) {
   let mut size = 0U
   if self.major is Some(v) {
-    size += 1U + @protobuf.size_of(v)
+    size += 1U + @lib.size_of(v)
   }
   if self.minor is Some(v) {
-    size += 1U + @protobuf.size_of(v)
+    size += 1U + @lib.size_of(v)
   }
   if self.patch is Some(v) {
-    size += 1U + @protobuf.size_of(v)
+    size += 1U + @lib.size_of(v)
   }
   if self.suffix is Some(v) {
     size += 1U +
       ({
-        let size = @protobuf.size_of(v)
-        @protobuf.size_of(size) + size
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
       })
   }
   size
 }
 
 ///|
-pub impl Default for Version with default() -> Version {
+pub impl Default for Version with fn default() -> Version {
   Version::{ major: None, minor: None, patch: None, suffix: None }
 }
 
@@ -44,52 +44,52 @@ pub fn Version::new(
 }
 
 ///|
-pub impl @protobuf.Read for Version with read_with_limit(
-  reader : @protobuf.LimitedReader[&@protobuf.Reader],
+pub impl @lib.Read for Version with fn read_with_limit(
+  reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Version raise {
   let msg = Version::default()
   try {
     for ;; {
-      match (reader |> @protobuf.read_tag()) {
-        (1, _) => msg.major = reader |> @protobuf.read_int32() |> Some
-        (2, _) => msg.minor = reader |> @protobuf.read_int32() |> Some
-        (3, _) => msg.patch = reader |> @protobuf.read_int32() |> Some
-        (4, _) => msg.suffix = reader |> @protobuf.read_string() |> Some
-        (_, wire) => reader |> @protobuf.read_unknown(wire)
+      match (reader |> @lib.read_tag()) {
+        (1, _) => msg.major = reader |> @lib.read_int32() |> Some
+        (2, _) => msg.minor = reader |> @lib.read_int32() |> Some
+        (3, _) => msg.patch = reader |> @lib.read_int32() |> Some
+        (4, _) => msg.suffix = reader |> @lib.read_string() |> Some
+        (_, wire) => reader |> @lib.read_unknown(wire)
       }
     }
   } catch {
-    @protobuf.EndOfStream => ()
+    @lib.EndOfStream => ()
     err => raise err
   }
   msg
 }
 
 ///|
-pub impl @protobuf.Write for Version with write(
+pub impl @lib.Write for Version with fn write(
   self : Version,
-  writer : &@protobuf.Writer,
+  writer : &@lib.Writer,
 ) -> Unit raise {
   if self.major is Some(v) {
-    writer |> @protobuf.write_varint(8UL)
-    writer |> @protobuf.write_int32(v)
+    writer |> @lib.write_varint(8UL)
+    writer |> @lib.write_int32(v)
   }
   if self.minor is Some(v) {
-    writer |> @protobuf.write_varint(16UL)
-    writer |> @protobuf.write_int32(v)
+    writer |> @lib.write_varint(16UL)
+    writer |> @lib.write_int32(v)
   }
   if self.patch is Some(v) {
-    writer |> @protobuf.write_varint(24UL)
-    writer |> @protobuf.write_int32(v)
+    writer |> @lib.write_varint(24UL)
+    writer |> @lib.write_int32(v)
   }
   if self.suffix is Some(v) {
-    writer |> @protobuf.write_varint(34UL)
-    writer |> @protobuf.write_string(v)
+    writer |> @lib.write_varint(34UL)
+    writer |> @lib.write_string(v)
   }
 }
 
 ///|
-pub impl ToJson for Version with to_json(self) {
+pub impl ToJson for Version with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.major {
     Some(v) => json["major"] = v.to_json()
@@ -111,7 +111,7 @@ pub impl ToJson for Version with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for Version with from_json(
+pub impl @json.FromJson for Version with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> Version raise {
@@ -125,54 +125,54 @@ pub impl @json.FromJson for Version with from_json(
       ("minor", value) => message.minor = Some(@json.from_json(value, path~))
       ("patch", value) => message.patch = Some(@json.from_json(value, path~))
       ("suffix", value) => message.suffix = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @protobuf.AsyncRead for Version with read_with_limit(
-  reader : @protobuf.LimitedReader[&@protobuf.AsyncReader],
+pub impl @lib.AsyncRead for Version with fn read_with_limit(
+  reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Version raise {
   let msg = Version::default()
   try {
     for ;; {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.major = reader |> @protobuf.async_read_int32() |> Some
-        (2, _) => msg.minor = reader |> @protobuf.async_read_int32() |> Some
-        (3, _) => msg.patch = reader |> @protobuf.async_read_int32() |> Some
-        (4, _) => msg.suffix = reader |> @protobuf.async_read_string() |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+      match (reader |> @lib.async_read_tag()) {
+        (1, _) => msg.major = reader |> @lib.async_read_int32() |> Some
+        (2, _) => msg.minor = reader |> @lib.async_read_int32() |> Some
+        (3, _) => msg.patch = reader |> @lib.async_read_int32() |> Some
+        (4, _) => msg.suffix = reader |> @lib.async_read_string() |> Some
+        (_, wire) => reader |> @lib.async_read_unknown(wire)
       }
     }
   } catch {
-    @protobuf.EndOfStream => ()
+    @lib.EndOfStream => ()
     err => raise err
   }
   msg
 }
 
 ///|
-pub impl @protobuf.AsyncWrite for Version with write(
+pub impl @lib.AsyncWrite for Version with fn write(
   self : Version,
-  writer : &@protobuf.AsyncWriter,
+  writer : &@lib.AsyncWriter,
 ) -> Unit raise {
   if self.major is Some(v) {
-    writer |> @protobuf.async_write_varint(8UL)
-    writer |> @protobuf.async_write_int32(v)
+    writer |> @lib.async_write_varint(8UL)
+    writer |> @lib.async_write_int32(v)
   }
   if self.minor is Some(v) {
-    writer |> @protobuf.async_write_varint(16UL)
-    writer |> @protobuf.async_write_int32(v)
+    writer |> @lib.async_write_varint(16UL)
+    writer |> @lib.async_write_int32(v)
   }
   if self.patch is Some(v) {
-    writer |> @protobuf.async_write_varint(24UL)
-    writer |> @protobuf.async_write_int32(v)
+    writer |> @lib.async_write_varint(24UL)
+    writer |> @lib.async_write_int32(v)
   }
   if self.suffix is Some(v) {
-    writer |> @protobuf.async_write_varint(34UL)
-    writer |> @protobuf.async_write_string(v)
+    writer |> @lib.async_write_varint(34UL)
+    writer |> @lib.async_write_string(v)
   }
 }
 
@@ -180,45 +180,45 @@ pub impl @protobuf.AsyncWrite for Version with write(
 pub(all) struct CodeGeneratorRequest {
   mut file_to_generate : Array[String]
   mut parameter : String?
-  mut proto_file : Array[@protobuf1.FileDescriptorProto]
-  mut source_file_descriptors : Array[@protobuf1.FileDescriptorProto]
+  mut proto_file : Array[@protobuf.FileDescriptorProto]
+  mut source_file_descriptors : Array[@protobuf.FileDescriptorProto]
   mut compiler_version : Version?
 } derive(Eq, Debug)
 
 ///|
-pub impl @protobuf.Sized for CodeGeneratorRequest with size_of(self) {
+pub impl @lib.Sized for CodeGeneratorRequest with fn size_of(self) {
   let mut size = 0U
   for s in self.file_to_generate {
-    let s = @protobuf.size_of(s)
-    size += 1U + @protobuf.size_of(s) + s
+    let s = @lib.size_of(s)
+    size += 1U + @lib.size_of(s) + s
   }
   if self.parameter is Some(v) {
     size += 1U +
       ({
-        let size = @protobuf.size_of(v)
-        @protobuf.size_of(size) + size
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
       })
   }
   for s in self.proto_file {
-    let s = @protobuf.size_of(s)
-    size += 1U + @protobuf.size_of(s) + s
+    let s = @lib.size_of(s)
+    size += 1U + @lib.size_of(s) + s
   }
   for s in self.source_file_descriptors {
-    let s = @protobuf.size_of(s)
-    size += 2U + @protobuf.size_of(s) + s
+    let s = @lib.size_of(s)
+    size += 2U + @lib.size_of(s) + s
   }
   if self.compiler_version is Some(v) {
     size += 1U +
       ({
-        let size = @protobuf.size_of(v)
-        @protobuf.size_of(size) + size
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
       })
   }
   size
 }
 
 ///|
-pub impl Default for CodeGeneratorRequest with default() -> CodeGeneratorRequest {
+pub impl Default for CodeGeneratorRequest with fn default() -> CodeGeneratorRequest {
   CodeGeneratorRequest::{
     file_to_generate: [],
     parameter: None,
@@ -232,8 +232,8 @@ pub impl Default for CodeGeneratorRequest with default() -> CodeGeneratorRequest
 pub fn CodeGeneratorRequest::new(
   file_to_generate : Array[String],
   parameter? : String,
-  proto_file : Array[@protobuf1.FileDescriptorProto],
-  source_file_descriptors : Array[@protobuf1.FileDescriptorProto],
+  proto_file : Array[@protobuf.FileDescriptorProto],
+  source_file_descriptors : Array[@protobuf.FileDescriptorProto],
   compiler_version? : Version,
 ) -> CodeGeneratorRequest {
   CodeGeneratorRequest::{
@@ -246,68 +246,68 @@ pub fn CodeGeneratorRequest::new(
 }
 
 ///|
-pub impl @protobuf.Read for CodeGeneratorRequest with read_with_limit(
-  reader : @protobuf.LimitedReader[&@protobuf.Reader],
+pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(
+  reader : @lib.LimitedReader[&@lib.Reader],
 ) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
   try {
     for ;; {
-      match (reader |> @protobuf.read_tag()) {
-        (1, _) => msg.file_to_generate.push(reader |> @protobuf.read_string())
-        (2, _) => msg.parameter = reader |> @protobuf.read_string() |> Some
+      match (reader |> @lib.read_tag()) {
+        (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
+        (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
         (15, _) =>
           msg.proto_file.push(
-            (reader |> @protobuf.read_message() : @protobuf1.FileDescriptorProto),
+            (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
           )
         (17, _) =>
           msg.source_file_descriptors.push(
-            (reader |> @protobuf.read_message() : @protobuf1.FileDescriptorProto),
+            (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
           )
         (3, _) =>
-          msg.compiler_version = (reader |> @protobuf.read_message() : Version)
+          msg.compiler_version = (reader |> @lib.read_message() : Version)
             |> Some
-        (_, wire) => reader |> @protobuf.read_unknown(wire)
+        (_, wire) => reader |> @lib.read_unknown(wire)
       }
     }
   } catch {
-    @protobuf.EndOfStream => ()
+    @lib.EndOfStream => ()
     err => raise err
   }
   msg
 }
 
 ///|
-pub impl @protobuf.Write for CodeGeneratorRequest with write(
+pub impl @lib.Write for CodeGeneratorRequest with fn write(
   self : CodeGeneratorRequest,
-  writer : &@protobuf.Writer,
+  writer : &@lib.Writer,
 ) -> Unit raise {
   for item in self.file_to_generate {
-    writer |> @protobuf.write_varint(10UL)
-    writer |> @protobuf.write_string(item)
+    writer |> @lib.write_varint(10UL)
+    writer |> @lib.write_string(item)
   }
   if self.parameter is Some(v) {
-    writer |> @protobuf.write_varint(18UL)
-    writer |> @protobuf.write_string(v)
+    writer |> @lib.write_varint(18UL)
+    writer |> @lib.write_string(v)
   }
   for item in self.proto_file {
-    writer |> @protobuf.write_varint(122UL)
-    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
-    @protobuf.Write::write(item, writer)
+    writer |> @lib.write_varint(122UL)
+    writer |> @lib.write_uint32(@lib.size_of(item))
+    @lib.Write::write(item, writer)
   }
   for item in self.source_file_descriptors {
-    writer |> @protobuf.write_varint(138UL)
-    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
-    @protobuf.Write::write(item, writer)
+    writer |> @lib.write_varint(138UL)
+    writer |> @lib.write_uint32(@lib.size_of(item))
+    @lib.Write::write(item, writer)
   }
   if self.compiler_version is Some(v) {
-    writer |> @protobuf.write_varint(26UL)
-    writer |> @protobuf.write_uint32(@protobuf.size_of(v))
-    @protobuf.Write::write(v, writer)
+    writer |> @lib.write_varint(26UL)
+    writer |> @lib.write_uint32(@lib.size_of(v))
+    @lib.Write::write(v, writer)
   }
 }
 
 ///|
-pub impl ToJson for CodeGeneratorRequest with to_json(self) {
+pub impl ToJson for CodeGeneratorRequest with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.file_to_generate != Default::default() {
     json["fileToGenerate"] = self.file_to_generate.to_json()
@@ -330,7 +330,7 @@ pub impl ToJson for CodeGeneratorRequest with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for CodeGeneratorRequest with from_json(
+pub impl @json.FromJson for CodeGeneratorRequest with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> CodeGeneratorRequest raise {
@@ -354,77 +354,70 @@ pub impl @json.FromJson for CodeGeneratorRequest with from_json(
         })
       ("compilerVersion", value) =>
         message.compiler_version = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @protobuf.AsyncRead for CodeGeneratorRequest with read_with_limit(
-  reader : @protobuf.LimitedReader[&@protobuf.AsyncReader],
+pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(
+  reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
   try {
     for ;; {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) =>
-          msg.file_to_generate.push(reader |> @protobuf.async_read_string())
-        (2, _) =>
-          msg.parameter = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @lib.async_read_tag()) {
+        (1, _) => msg.file_to_generate.push(reader |> @lib.async_read_string())
+        (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
         (15, _) =>
           msg.proto_file.push(
-            (
-              reader |> @protobuf.async_read_message() :
-              @protobuf1.FileDescriptorProto),
+            (reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto),
           )
         (17, _) =>
           msg.source_file_descriptors.push(
-            (
-              reader |> @protobuf.async_read_message() :
-              @protobuf1.FileDescriptorProto),
+            (reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto),
           )
         (3, _) =>
-          msg.compiler_version = (
-              reader |> @protobuf.async_read_message() : Version)
+          msg.compiler_version = (reader |> @lib.async_read_message() : Version)
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @lib.async_read_unknown(wire)
       }
     }
   } catch {
-    @protobuf.EndOfStream => ()
+    @lib.EndOfStream => ()
     err => raise err
   }
   msg
 }
 
 ///|
-pub impl @protobuf.AsyncWrite for CodeGeneratorRequest with write(
+pub impl @lib.AsyncWrite for CodeGeneratorRequest with fn write(
   self : CodeGeneratorRequest,
-  writer : &@protobuf.AsyncWriter,
+  writer : &@lib.AsyncWriter,
 ) -> Unit raise {
   for item in self.file_to_generate {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_string(item)
+    writer |> @lib.async_write_varint(10UL)
+    writer |> @lib.async_write_string(item)
   }
   if self.parameter is Some(v) {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_string(v)
+    writer |> @lib.async_write_varint(18UL)
+    writer |> @lib.async_write_string(v)
   }
   for item in self.proto_file {
-    writer |> @protobuf.async_write_varint(122UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
-    @protobuf.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_varint(122UL)
+    writer |> @lib.async_write_uint32(@lib.size_of(item))
+    @lib.AsyncWrite::write(item, writer)
   }
   for item in self.source_file_descriptors {
-    writer |> @protobuf.async_write_varint(138UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
-    @protobuf.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_varint(138UL)
+    writer |> @lib.async_write_uint32(@lib.size_of(item))
+    @lib.AsyncWrite::write(item, writer)
   }
   if self.compiler_version is Some(v) {
-    writer |> @protobuf.async_write_varint(26UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
-    @protobuf.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_varint(26UL)
+    writer |> @lib.async_write_uint32(@lib.size_of(v))
+    @lib.AsyncWrite::write(v, writer)
   }
 }
 
@@ -438,7 +431,7 @@ pub(all) enum CodeGeneratorResponse_Feature {
 ///|
 pub fn CodeGeneratorResponse_Feature::to_enum(
   self : CodeGeneratorResponse_Feature,
-) -> @protobuf.Enum {
+) -> @lib.Enum {
   match self {
     CodeGeneratorResponse_Feature::FEATURE_NONE => 0
     CodeGeneratorResponse_Feature::FEATURE_PROTO3_OPTIONAL => 1
@@ -448,7 +441,7 @@ pub fn CodeGeneratorResponse_Feature::to_enum(
 
 ///|
 pub fn CodeGeneratorResponse_Feature::from_enum(
-  i : @protobuf.Enum,
+  i : @lib.Enum,
 ) -> CodeGeneratorResponse_Feature {
   match i.0 {
     0 => CodeGeneratorResponse_Feature::FEATURE_NONE
@@ -459,19 +452,19 @@ pub fn CodeGeneratorResponse_Feature::from_enum(
 }
 
 ///|
-pub impl Default for CodeGeneratorResponse_Feature with default() -> CodeGeneratorResponse_Feature {
+pub impl Default for CodeGeneratorResponse_Feature with fn default() -> CodeGeneratorResponse_Feature {
   CodeGeneratorResponse_Feature::FEATURE_NONE
 }
 
 ///|
-pub impl @protobuf.Sized for CodeGeneratorResponse_Feature with size_of(
+pub impl @lib.Sized for CodeGeneratorResponse_Feature with fn size_of(
   self : CodeGeneratorResponse_Feature,
 ) {
-  @protobuf.Sized::size_of(self.to_enum())
+  @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for CodeGeneratorResponse_Feature with from_json(
+pub impl @json.FromJson for CodeGeneratorResponse_Feature with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> CodeGeneratorResponse_Feature raise {
@@ -492,7 +485,7 @@ pub impl @json.FromJson for CodeGeneratorResponse_Feature with from_json(
 }
 
 ///|
-pub impl ToJson for CodeGeneratorResponse_Feature with to_json(
+pub impl ToJson for CodeGeneratorResponse_Feature with fn to_json(
   self : CodeGeneratorResponse_Feature,
 ) -> Json {
   match self {
@@ -509,45 +502,45 @@ pub(all) struct CodeGeneratorResponse_File {
   mut name : String?
   mut insertion_point : String?
   mut content : String?
-  mut generated_code_info : @protobuf1.GeneratedCodeInfo?
+  mut generated_code_info : @protobuf.GeneratedCodeInfo?
 } derive(Eq, Debug)
 
 ///|
-pub impl @protobuf.Sized for CodeGeneratorResponse_File with size_of(self) {
+pub impl @lib.Sized for CodeGeneratorResponse_File with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U +
       ({
-        let size = @protobuf.size_of(v)
-        @protobuf.size_of(size) + size
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
       })
   }
   if self.insertion_point is Some(v) {
     size += 1U +
       ({
-        let size = @protobuf.size_of(v)
-        @protobuf.size_of(size) + size
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
       })
   }
   if self.content is Some(v) {
     size += 1U +
       ({
-        let size = @protobuf.size_of(v)
-        @protobuf.size_of(size) + size
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
       })
   }
   if self.generated_code_info is Some(v) {
     size += 2U +
       ({
-        let size = @protobuf.size_of(v)
-        @protobuf.size_of(size) + size
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
       })
   }
   size
 }
 
 ///|
-pub impl Default for CodeGeneratorResponse_File with default() -> CodeGeneratorResponse_File {
+pub impl Default for CodeGeneratorResponse_File with fn default() -> CodeGeneratorResponse_File {
   CodeGeneratorResponse_File::{
     name: None,
     insertion_point: None,
@@ -561,7 +554,7 @@ pub fn CodeGeneratorResponse_File::new(
   name? : String,
   insertion_point? : String,
   content? : String,
-  generated_code_info? : @protobuf1.GeneratedCodeInfo,
+  generated_code_info? : @protobuf.GeneratedCodeInfo,
 ) -> CodeGeneratorResponse_File {
   CodeGeneratorResponse_File::{
     name,
@@ -572,57 +565,56 @@ pub fn CodeGeneratorResponse_File::new(
 }
 
 ///|
-pub impl @protobuf.Read for CodeGeneratorResponse_File with read_with_limit(
-  reader : @protobuf.LimitedReader[&@protobuf.Reader],
+pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(
+  reader : @lib.LimitedReader[&@lib.Reader],
 ) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
   try {
     for ;; {
-      match (reader |> @protobuf.read_tag()) {
-        (1, _) => msg.name = reader |> @protobuf.read_string() |> Some
-        (2, _) =>
-          msg.insertion_point = reader |> @protobuf.read_string() |> Some
-        (15, _) => msg.content = reader |> @protobuf.read_string() |> Some
+      match (reader |> @lib.read_tag()) {
+        (1, _) => msg.name = reader |> @lib.read_string() |> Some
+        (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
+        (15, _) => msg.content = reader |> @lib.read_string() |> Some
         (16, _) =>
           msg.generated_code_info = (
-              reader |> @protobuf.read_message() : @protobuf1.GeneratedCodeInfo)
+              reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo)
             |> Some
-        (_, wire) => reader |> @protobuf.read_unknown(wire)
+        (_, wire) => reader |> @lib.read_unknown(wire)
       }
     }
   } catch {
-    @protobuf.EndOfStream => ()
+    @lib.EndOfStream => ()
     err => raise err
   }
   msg
 }
 
 ///|
-pub impl @protobuf.Write for CodeGeneratorResponse_File with write(
+pub impl @lib.Write for CodeGeneratorResponse_File with fn write(
   self : CodeGeneratorResponse_File,
-  writer : &@protobuf.Writer,
+  writer : &@lib.Writer,
 ) -> Unit raise {
   if self.name is Some(v) {
-    writer |> @protobuf.write_varint(10UL)
-    writer |> @protobuf.write_string(v)
+    writer |> @lib.write_varint(10UL)
+    writer |> @lib.write_string(v)
   }
   if self.insertion_point is Some(v) {
-    writer |> @protobuf.write_varint(18UL)
-    writer |> @protobuf.write_string(v)
+    writer |> @lib.write_varint(18UL)
+    writer |> @lib.write_string(v)
   }
   if self.content is Some(v) {
-    writer |> @protobuf.write_varint(122UL)
-    writer |> @protobuf.write_string(v)
+    writer |> @lib.write_varint(122UL)
+    writer |> @lib.write_string(v)
   }
   if self.generated_code_info is Some(v) {
-    writer |> @protobuf.write_varint(130UL)
-    writer |> @protobuf.write_uint32(@protobuf.size_of(v))
-    @protobuf.Write::write(v, writer)
+    writer |> @lib.write_varint(130UL)
+    writer |> @lib.write_uint32(@lib.size_of(v))
+    @lib.Write::write(v, writer)
   }
 }
 
 ///|
-pub impl ToJson for CodeGeneratorResponse_File with to_json(self) {
+pub impl ToJson for CodeGeneratorResponse_File with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.name {
     Some(v) => json["name"] = v.to_json()
@@ -644,7 +636,7 @@ pub impl ToJson for CodeGeneratorResponse_File with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for CodeGeneratorResponse_File with from_json(
+pub impl @json.FromJson for CodeGeneratorResponse_File with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> CodeGeneratorResponse_File raise {
@@ -663,60 +655,59 @@ pub impl @json.FromJson for CodeGeneratorResponse_File with from_json(
         message.content = Some(@json.from_json(value, path~))
       ("generatedCodeInfo", value) =>
         message.generated_code_info = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @protobuf.AsyncRead for CodeGeneratorResponse_File with read_with_limit(
-  reader : @protobuf.LimitedReader[&@protobuf.AsyncReader],
+pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(
+  reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
   try {
     for ;; {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.name = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @lib.async_read_tag()) {
+        (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
         (2, _) =>
-          msg.insertion_point = reader |> @protobuf.async_read_string() |> Some
-        (15, _) => msg.content = reader |> @protobuf.async_read_string() |> Some
+          msg.insertion_point = reader |> @lib.async_read_string() |> Some
+        (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
         (16, _) =>
           msg.generated_code_info = (
-              reader |> @protobuf.async_read_message() :
-              @protobuf1.GeneratedCodeInfo)
+              reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo)
             |> Some
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @lib.async_read_unknown(wire)
       }
     }
   } catch {
-    @protobuf.EndOfStream => ()
+    @lib.EndOfStream => ()
     err => raise err
   }
   msg
 }
 
 ///|
-pub impl @protobuf.AsyncWrite for CodeGeneratorResponse_File with write(
+pub impl @lib.AsyncWrite for CodeGeneratorResponse_File with fn write(
   self : CodeGeneratorResponse_File,
-  writer : &@protobuf.AsyncWriter,
+  writer : &@lib.AsyncWriter,
 ) -> Unit raise {
   if self.name is Some(v) {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_string(v)
+    writer |> @lib.async_write_varint(10UL)
+    writer |> @lib.async_write_string(v)
   }
   if self.insertion_point is Some(v) {
-    writer |> @protobuf.async_write_varint(18UL)
-    writer |> @protobuf.async_write_string(v)
+    writer |> @lib.async_write_varint(18UL)
+    writer |> @lib.async_write_string(v)
   }
   if self.content is Some(v) {
-    writer |> @protobuf.async_write_varint(122UL)
-    writer |> @protobuf.async_write_string(v)
+    writer |> @lib.async_write_varint(122UL)
+    writer |> @lib.async_write_string(v)
   }
   if self.generated_code_info is Some(v) {
-    writer |> @protobuf.async_write_varint(130UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(v))
-    @protobuf.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_varint(130UL)
+    writer |> @lib.async_write_uint32(@lib.size_of(v))
+    @lib.AsyncWrite::write(v, writer)
   }
 }
 
@@ -730,33 +721,33 @@ pub(all) struct CodeGeneratorResponse {
 } derive(Eq, Debug)
 
 ///|
-pub impl @protobuf.Sized for CodeGeneratorResponse with size_of(self) {
+pub impl @lib.Sized for CodeGeneratorResponse with fn size_of(self) {
   let mut size = 0U
   if self.error is Some(v) {
     size += 1U +
       ({
-        let size = @protobuf.size_of(v)
-        @protobuf.size_of(size) + size
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
       })
   }
   if self.supported_features is Some(v) {
-    size += 1U + @protobuf.size_of(v)
+    size += 1U + @lib.size_of(v)
   }
   if self.minimum_edition is Some(v) {
-    size += 1U + @protobuf.size_of(v)
+    size += 1U + @lib.size_of(v)
   }
   if self.maximum_edition is Some(v) {
-    size += 1U + @protobuf.size_of(v)
+    size += 1U + @lib.size_of(v)
   }
   for s in self.file {
-    let s = @protobuf.size_of(s)
-    size += 1U + @protobuf.size_of(s) + s
+    let s = @lib.size_of(s)
+    size += 1U + @lib.size_of(s) + s
   }
   size
 }
 
 ///|
-pub impl Default for CodeGeneratorResponse with default() -> CodeGeneratorResponse {
+pub impl Default for CodeGeneratorResponse with fn default() -> CodeGeneratorResponse {
   CodeGeneratorResponse::{
     error: None,
     supported_features: None,
@@ -784,62 +775,61 @@ pub fn CodeGeneratorResponse::new(
 }
 
 ///|
-pub impl @protobuf.Read for CodeGeneratorResponse with read_with_limit(
-  reader : @protobuf.LimitedReader[&@protobuf.Reader],
+pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(
+  reader : @lib.LimitedReader[&@lib.Reader],
 ) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
   try {
     for ;; {
-      match (reader |> @protobuf.read_tag()) {
-        (1, _) => msg.error = reader |> @protobuf.read_string() |> Some
-        (2, _) =>
-          msg.supported_features = reader |> @protobuf.read_uint64() |> Some
-        (3, _) => msg.minimum_edition = reader |> @protobuf.read_int32() |> Some
-        (4, _) => msg.maximum_edition = reader |> @protobuf.read_int32() |> Some
+      match (reader |> @lib.read_tag()) {
+        (1, _) => msg.error = reader |> @lib.read_string() |> Some
+        (2, _) => msg.supported_features = reader |> @lib.read_uint64() |> Some
+        (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
+        (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
         (15, _) =>
           msg.file.push(
-            (reader |> @protobuf.read_message() : CodeGeneratorResponse_File),
+            (reader |> @lib.read_message() : CodeGeneratorResponse_File),
           )
-        (_, wire) => reader |> @protobuf.read_unknown(wire)
+        (_, wire) => reader |> @lib.read_unknown(wire)
       }
     }
   } catch {
-    @protobuf.EndOfStream => ()
+    @lib.EndOfStream => ()
     err => raise err
   }
   msg
 }
 
 ///|
-pub impl @protobuf.Write for CodeGeneratorResponse with write(
+pub impl @lib.Write for CodeGeneratorResponse with fn write(
   self : CodeGeneratorResponse,
-  writer : &@protobuf.Writer,
+  writer : &@lib.Writer,
 ) -> Unit raise {
   if self.error is Some(v) {
-    writer |> @protobuf.write_varint(10UL)
-    writer |> @protobuf.write_string(v)
+    writer |> @lib.write_varint(10UL)
+    writer |> @lib.write_string(v)
   }
   if self.supported_features is Some(v) {
-    writer |> @protobuf.write_varint(16UL)
-    writer |> @protobuf.write_uint64(v)
+    writer |> @lib.write_varint(16UL)
+    writer |> @lib.write_uint64(v)
   }
   if self.minimum_edition is Some(v) {
-    writer |> @protobuf.write_varint(24UL)
-    writer |> @protobuf.write_int32(v)
+    writer |> @lib.write_varint(24UL)
+    writer |> @lib.write_int32(v)
   }
   if self.maximum_edition is Some(v) {
-    writer |> @protobuf.write_varint(32UL)
-    writer |> @protobuf.write_int32(v)
+    writer |> @lib.write_varint(32UL)
+    writer |> @lib.write_int32(v)
   }
   for item in self.file {
-    writer |> @protobuf.write_varint(122UL)
-    writer |> @protobuf.write_uint32(@protobuf.size_of(item))
-    @protobuf.Write::write(item, writer)
+    writer |> @lib.write_varint(122UL)
+    writer |> @lib.write_uint32(@lib.size_of(item))
+    @lib.Write::write(item, writer)
   }
 }
 
 ///|
-pub impl ToJson for CodeGeneratorResponse with to_json(self) {
+pub impl ToJson for CodeGeneratorResponse with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.error {
     Some(v) => json["error"] = v.to_json()
@@ -864,7 +854,7 @@ pub impl ToJson for CodeGeneratorResponse with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for CodeGeneratorResponse with from_json(
+pub impl @json.FromJson for CodeGeneratorResponse with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> CodeGeneratorResponse raise {
@@ -885,69 +875,65 @@ pub impl @json.FromJson for CodeGeneratorResponse with from_json(
         message.maximum_edition = Some(@json.from_json(value, path~))
       ("file", Array(value)) =>
         message.file = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @protobuf.AsyncRead for CodeGeneratorResponse with read_with_limit(
-  reader : @protobuf.LimitedReader[&@protobuf.AsyncReader],
+pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(
+  reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
   try {
     for ;; {
-      match (reader |> @protobuf.async_read_tag()) {
-        (1, _) => msg.error = reader |> @protobuf.async_read_string() |> Some
+      match (reader |> @lib.async_read_tag()) {
+        (1, _) => msg.error = reader |> @lib.async_read_string() |> Some
         (2, _) =>
-          msg.supported_features = reader
-            |> @protobuf.async_read_uint64()
-            |> Some
+          msg.supported_features = reader |> @lib.async_read_uint64() |> Some
         (3, _) =>
-          msg.minimum_edition = reader |> @protobuf.async_read_int32() |> Some
+          msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
         (4, _) =>
-          msg.maximum_edition = reader |> @protobuf.async_read_int32() |> Some
+          msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
         (15, _) =>
           msg.file.push(
-            (
-              reader |> @protobuf.async_read_message() :
-              CodeGeneratorResponse_File),
+            (reader |> @lib.async_read_message() : CodeGeneratorResponse_File),
           )
-        (_, wire) => reader |> @protobuf.async_read_unknown(wire)
+        (_, wire) => reader |> @lib.async_read_unknown(wire)
       }
     }
   } catch {
-    @protobuf.EndOfStream => ()
+    @lib.EndOfStream => ()
     err => raise err
   }
   msg
 }
 
 ///|
-pub impl @protobuf.AsyncWrite for CodeGeneratorResponse with write(
+pub impl @lib.AsyncWrite for CodeGeneratorResponse with fn write(
   self : CodeGeneratorResponse,
-  writer : &@protobuf.AsyncWriter,
+  writer : &@lib.AsyncWriter,
 ) -> Unit raise {
   if self.error is Some(v) {
-    writer |> @protobuf.async_write_varint(10UL)
-    writer |> @protobuf.async_write_string(v)
+    writer |> @lib.async_write_varint(10UL)
+    writer |> @lib.async_write_string(v)
   }
   if self.supported_features is Some(v) {
-    writer |> @protobuf.async_write_varint(16UL)
-    writer |> @protobuf.async_write_uint64(v)
+    writer |> @lib.async_write_varint(16UL)
+    writer |> @lib.async_write_uint64(v)
   }
   if self.minimum_edition is Some(v) {
-    writer |> @protobuf.async_write_varint(24UL)
-    writer |> @protobuf.async_write_int32(v)
+    writer |> @lib.async_write_varint(24UL)
+    writer |> @lib.async_write_int32(v)
   }
   if self.maximum_edition is Some(v) {
-    writer |> @protobuf.async_write_varint(32UL)
-    writer |> @protobuf.async_write_int32(v)
+    writer |> @lib.async_write_varint(32UL)
+    writer |> @lib.async_write_int32(v)
   }
   for item in self.file {
-    writer |> @protobuf.async_write_varint(122UL)
-    writer |> @protobuf.async_write_uint32(@protobuf.size_of(item))
-    @protobuf.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_varint(122UL)
+    writer |> @lib.async_write_uint32(@lib.size_of(item))
+    @lib.AsyncWrite::write(item, writer)
   }
 }

--- a/plugin/src/google/protobuf/compiler/top_test.mbt
+++ b/plugin/src/google/protobuf/compiler/top_test.mbt
@@ -15,7 +15,7 @@ fn new_code_generator_request(
   file_to_generate? : Array[String] = [],
   version? : Version,
   parameter? : String,
-  proto_file? : Array[@protobuf1.FileDescriptorProto] = [],
+  proto_file? : Array[@protobuf.FileDescriptorProto] = [],
 ) -> CodeGeneratorRequest {
   // Create a default CodeGeneratorRequest for testing
   let generator = CodeGeneratorRequest::default()
@@ -45,8 +45,8 @@ async test "CodeGeneratorRequest::size_of/empty_arrays" {
   )
   let size = request_empty_arrays.size_of()
   inspect(size > 0U, content="true")
-  let writer = @buffer.new()
-  @protobuf.Write::write(request_empty_arrays, writer)
+  let writer = Buffer()
+  @lib.Write::write(request_empty_arrays, writer)
   let bytes = writer.to_bytes()
   inspect(
     bytes,
@@ -73,8 +73,8 @@ async test "CodeGeneratorRequest::size_of/large_arrays" {
   )
   let size = request_many_files.size_of()
   inspect(size > 100U, content="true")
-  let writer = @buffer.new()
-  @protobuf.AsyncWrite::write(request_many_files, writer)
+  let writer = Buffer()
+  @lib.AsyncWrite::write(request_many_files, writer)
   let bytes = writer.to_bytes()
   inspect(
     run_protoscope_test(bytes),
@@ -192,8 +192,8 @@ async test "CodeGeneratorRequest::size_of/single_file" {
   ])
   let size = request_single_file.size_of()
   inspect(size > 10U, content="true")
-  let writer = @buffer.new()
-  @protobuf.AsyncWrite::write(request_single_file, writer)
+  let writer = Buffer()
+  @lib.AsyncWrite::write(request_single_file, writer)
   let bytes = writer.to_bytes()
   inspect(
     bytes,
@@ -218,8 +218,8 @@ async test "CodeGeneratorRequest::size_of/with_parameter" {
   )
   let size = request_with_param.size_of()
   inspect(size > 20U, content="true")
-  let writer = @buffer.new()
-  @protobuf.Write::write(request_with_param, writer)
+  let writer = Buffer()
+  @lib.Write::write(request_with_param, writer)
   let bytes = writer.to_bytes()
   inspect(
     bytes,
@@ -244,7 +244,7 @@ async test "CodeGeneratorRequest::size_of/empty_request" {
   let request_empty = new_code_generator_request()
   let size = request_empty.size_of()
   inspect(size > 0U, content="false")
-  let writer = @buffer.new()
+  let writer = Buffer()
   let bytes = writer.to_bytes()
   inspect(
     bytes,
@@ -265,8 +265,8 @@ async test "CodeGeneratorRequest::size_of/medium_files" {
   )
   let size = request_medium_files.size_of()
   inspect(size > 50U, content="true")
-  let writer = @buffer.new()
-  @protobuf.Write::write(request_medium_files, writer)
+  let writer = Buffer()
+  @lib.Write::write(request_medium_files, writer)
   let bytes = writer.to_bytes()
   inspect(
     run_protoscope_test(bytes),
@@ -297,8 +297,8 @@ async test "CodeGeneratorRequest::size_of/special_characters" {
   )
   let size = request_special.size_of()
   inspect(size > 30U, content="true")
-  let writer = @buffer.new()
-  @protobuf.Write::write(request_special, writer)
+  let writer = Buffer()
+  @lib.Write::write(request_special, writer)
   let bytes = writer.to_bytes()
   // Note: The exact bytes will depend on UTF-8 encoding of special characters
   inspect(bytes.length() > 40, content="true")
@@ -324,8 +324,8 @@ async test "CodeGeneratorRequest::size_of/long_parameter" {
   )
   let size = request_long_param.size_of()
   inspect(size > 300U, content="true")
-  let writer = @buffer.new()
-  @protobuf.Write::write(request_long_param, writer)
+  let writer = Buffer()
+  @lib.Write::write(request_long_param, writer)
   let bytes = writer.to_bytes()
   inspect(bytes.length() > 300, content="true")
   inspect(
@@ -356,8 +356,8 @@ async test "coroutine CodeGeneratorRequest::size_of/mixed_filename_lengths" {
   )
   let size = request_mixed.size_of()
   inspect(size > 80U, content="true")
-  let writer = @buffer.new()
-  @protobuf.Write::write(request_mixed, writer)
+  let writer = Buffer()
+  @lib.Write::write(request_mixed, writer)
   let bytes = writer.to_bytes()
   inspect(
     run_protoscope_test(bytes),
@@ -380,8 +380,8 @@ async test "CodeGeneratorRequest::version/other_versions" {
   )
   let size = request_empty_files.size_of()
   inspect(size == 0U, content="false")
-  let writer = @buffer.new()
-  @protobuf.Write::write(request_empty_files, writer)
+  let writer = Buffer()
+  @lib.Write::write(request_empty_files, writer)
   let bytes = writer.to_bytes()
   inspect(
     bytes,

--- a/plugin/src/google/protobuf/pkg.generated.mbti
+++ b/plugin/src/google/protobuf/pkg.generated.mbti
@@ -428,7 +428,6 @@ pub(all) enum FieldDescriptorProto_Type {
 pub fn FieldDescriptorProto_Type::from_enum(@moonbitlang/protobuf.Enum) -> Self
 pub fn FieldDescriptorProto_Type::to_enum(Self) -> @moonbitlang/protobuf.Enum
 pub impl Default for FieldDescriptorProto_Type
-pub impl Show for FieldDescriptorProto_Type
 pub impl ToJson for FieldDescriptorProto_Type
 pub impl @json.FromJson for FieldDescriptorProto_Type
 pub impl @moonbitlang/protobuf.Sized for FieldDescriptorProto_Type

--- a/plugin/src/google/protobuf/top.mbt
+++ b/plugin/src/google/protobuf/top.mbt
@@ -52,17 +52,17 @@ pub fn Edition::from_enum(i : @lib.Enum) -> Edition {
 }
 
 ///|
-pub impl Default for Edition with default() -> Edition {
+pub impl Default for Edition with fn default() -> Edition {
   Edition::EDITION_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for Edition with size_of(self : Edition) {
+pub impl @lib.Sized for Edition with fn size_of(self : Edition) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for Edition with from_json(
+pub impl @json.FromJson for Edition with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> Edition raise {
@@ -99,7 +99,7 @@ pub impl @json.FromJson for Edition with from_json(
 }
 
 ///|
-pub impl ToJson for Edition with to_json(self : Edition) -> Json {
+pub impl ToJson for Edition with fn to_json(self : Edition) -> Json {
   match self {
     Edition::EDITION_UNKNOWN => "EDITION_UNKNOWN"
     Edition::EDITION_LEGACY => "EDITION_LEGACY"
@@ -143,17 +143,19 @@ pub fn SymbolVisibility::from_enum(i : @lib.Enum) -> SymbolVisibility {
 }
 
 ///|
-pub impl Default for SymbolVisibility with default() -> SymbolVisibility {
+pub impl Default for SymbolVisibility with fn default() -> SymbolVisibility {
   SymbolVisibility::VISIBILITY_UNSET
 }
 
 ///|
-pub impl @lib.Sized for SymbolVisibility with size_of(self : SymbolVisibility) {
+pub impl @lib.Sized for SymbolVisibility with fn size_of(
+  self : SymbolVisibility,
+) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for SymbolVisibility with from_json(
+pub impl @json.FromJson for SymbolVisibility with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> SymbolVisibility raise {
@@ -172,7 +174,7 @@ pub impl @json.FromJson for SymbolVisibility with from_json(
 }
 
 ///|
-pub impl ToJson for SymbolVisibility with to_json(self : SymbolVisibility) -> Json {
+pub impl ToJson for SymbolVisibility with fn to_json(self : SymbolVisibility) -> Json {
   match self {
     SymbolVisibility::VISIBILITY_UNSET => "VISIBILITY_UNSET"
     SymbolVisibility::VISIBILITY_LOCAL => "VISIBILITY_LOCAL"
@@ -186,7 +188,7 @@ pub(all) struct FileDescriptorSet {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FileDescriptorSet with size_of(self) {
+pub impl @lib.Sized for FileDescriptorSet with fn size_of(self) {
   let mut size = 0U
   for s in self.file {
     let s = @lib.size_of(s)
@@ -196,7 +198,7 @@ pub impl @lib.Sized for FileDescriptorSet with size_of(self) {
 }
 
 ///|
-pub impl Default for FileDescriptorSet with default() -> FileDescriptorSet {
+pub impl Default for FileDescriptorSet with fn default() -> FileDescriptorSet {
   FileDescriptorSet::{ file: [] }
 }
 
@@ -208,7 +210,7 @@ pub fn FileDescriptorSet::new(
 }
 
 ///|
-pub impl @lib.Read for FileDescriptorSet with read_with_limit(
+pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
@@ -228,7 +230,7 @@ pub impl @lib.Read for FileDescriptorSet with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FileDescriptorSet with write(
+pub impl @lib.Write for FileDescriptorSet with fn write(
   self : FileDescriptorSet,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -240,7 +242,7 @@ pub impl @lib.Write for FileDescriptorSet with write(
 }
 
 ///|
-pub impl ToJson for FileDescriptorSet with to_json(self) {
+pub impl ToJson for FileDescriptorSet with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.file != Default::default() {
     json["file"] = self.file.to_json()
@@ -249,7 +251,7 @@ pub impl ToJson for FileDescriptorSet with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for FileDescriptorSet with from_json(
+pub impl @json.FromJson for FileDescriptorSet with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FileDescriptorSet raise {
@@ -263,14 +265,14 @@ pub impl @json.FromJson for FileDescriptorSet with from_json(
     match (key, value) {
       ("file", Array(value)) =>
         message.file = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for FileDescriptorSet with read_with_limit(
+pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
@@ -292,7 +294,7 @@ pub impl @lib.AsyncRead for FileDescriptorSet with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FileDescriptorSet with write(
+pub impl @lib.AsyncWrite for FileDescriptorSet with fn write(
   self : FileDescriptorSet,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -322,7 +324,7 @@ pub(all) struct FileDescriptorProto {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FileDescriptorProto with size_of(self) {
+pub impl @lib.Sized for FileDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U +
@@ -398,7 +400,7 @@ pub impl @lib.Sized for FileDescriptorProto with size_of(self) {
 }
 
 ///|
-pub impl Default for FileDescriptorProto with default() -> FileDescriptorProto {
+pub impl Default for FileDescriptorProto with fn default() -> FileDescriptorProto {
   FileDescriptorProto::{
     name: None,
     package_: None,
@@ -453,7 +455,7 @@ pub fn FileDescriptorProto::new(
 }
 
 ///|
-pub impl @lib.Read for FileDescriptorProto with read_with_limit(
+pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
@@ -463,8 +465,16 @@ pub impl @lib.Read for FileDescriptorProto with read_with_limit(
         (1, _) => msg.name = reader |> @lib.read_string() |> Some
         (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
         (3, _) => msg.dependency.push(reader |> @lib.read_string())
-        (10, _) => msg.public_dependency.push(reader |> @lib.read_int32())
-        (11, _) => msg.weak_dependency.push(reader |> @lib.read_int32())
+        (10, 2) =>
+          msg.public_dependency.push_iter(
+            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+          )
+        (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
+        (11, 2) =>
+          msg.weak_dependency.push_iter(
+            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+          )
+        (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
         (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
         (4, _) =>
           msg.message_type.push(
@@ -501,7 +511,7 @@ pub impl @lib.Read for FileDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FileDescriptorProto with write(
+pub impl @lib.Write for FileDescriptorProto with fn write(
   self : FileDescriptorProto,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -570,7 +580,7 @@ pub impl @lib.Write for FileDescriptorProto with write(
 }
 
 ///|
-pub impl ToJson for FileDescriptorProto with to_json(self) {
+pub impl ToJson for FileDescriptorProto with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.name {
     Some(v) => json["name"] = v.to_json()
@@ -624,7 +634,7 @@ pub impl ToJson for FileDescriptorProto with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for FileDescriptorProto with from_json(
+pub impl @json.FromJson for FileDescriptorProto with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FileDescriptorProto raise {
@@ -662,14 +672,14 @@ pub impl @json.FromJson for FileDescriptorProto with from_json(
       ("syntax", value) => message.syntax = Some(@json.from_json(value, path~))
       ("edition", value) =>
         message.edition = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for FileDescriptorProto with read_with_limit(
+pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
@@ -679,8 +689,16 @@ pub impl @lib.AsyncRead for FileDescriptorProto with read_with_limit(
         (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
         (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
         (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
-        (10, _) => msg.public_dependency.push(reader |> @lib.async_read_int32())
-        (11, _) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
+        (10, 2) =>
+          msg.public_dependency.push_iter(
+            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+          )
+        (10, 0) => msg.public_dependency.push(reader |> @lib.async_read_int32())
+        (11, 2) =>
+          msg.weak_dependency.push_iter(
+            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+          )
+        (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
         (15, _) =>
           msg.option_dependency.push(reader |> @lib.async_read_string())
         (4, _) =>
@@ -723,7 +741,7 @@ pub impl @lib.AsyncRead for FileDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FileDescriptorProto with write(
+pub impl @lib.AsyncWrite for FileDescriptorProto with fn write(
   self : FileDescriptorProto,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -799,7 +817,7 @@ pub(all) struct DescriptorProto_ExtensionRange {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for DescriptorProto_ExtensionRange with size_of(self) {
+pub impl @lib.Sized for DescriptorProto_ExtensionRange with fn size_of(self) {
   let mut size = 0U
   if self.start is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -818,7 +836,7 @@ pub impl @lib.Sized for DescriptorProto_ExtensionRange with size_of(self) {
 }
 
 ///|
-pub impl Default for DescriptorProto_ExtensionRange with default() -> DescriptorProto_ExtensionRange {
+pub impl Default for DescriptorProto_ExtensionRange with fn default() -> DescriptorProto_ExtensionRange {
   DescriptorProto_ExtensionRange::{ start: None, end: None, options: None }
 }
 
@@ -832,7 +850,7 @@ pub fn DescriptorProto_ExtensionRange::new(
 }
 
 ///|
-pub impl @lib.Read for DescriptorProto_ExtensionRange with read_with_limit(
+pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
@@ -855,7 +873,7 @@ pub impl @lib.Read for DescriptorProto_ExtensionRange with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for DescriptorProto_ExtensionRange with write(
+pub impl @lib.Write for DescriptorProto_ExtensionRange with fn write(
   self : DescriptorProto_ExtensionRange,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -875,7 +893,7 @@ pub impl @lib.Write for DescriptorProto_ExtensionRange with write(
 }
 
 ///|
-pub impl ToJson for DescriptorProto_ExtensionRange with to_json(self) {
+pub impl ToJson for DescriptorProto_ExtensionRange with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.start {
     Some(v) => json["start"] = v.to_json()
@@ -893,7 +911,7 @@ pub impl ToJson for DescriptorProto_ExtensionRange with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for DescriptorProto_ExtensionRange with from_json(
+pub impl @json.FromJson for DescriptorProto_ExtensionRange with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> DescriptorProto_ExtensionRange raise {
@@ -909,14 +927,14 @@ pub impl @json.FromJson for DescriptorProto_ExtensionRange with from_json(
       ("end", value) => message.end = Some(@json.from_json(value, path~))
       ("options", value) =>
         message.options = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with read_with_limit(
+pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
@@ -940,7 +958,7 @@ pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for DescriptorProto_ExtensionRange with write(
+pub impl @lib.AsyncWrite for DescriptorProto_ExtensionRange with fn write(
   self : DescriptorProto_ExtensionRange,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -966,7 +984,7 @@ pub(all) struct DescriptorProto_ReservedRange {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for DescriptorProto_ReservedRange with size_of(self) {
+pub impl @lib.Sized for DescriptorProto_ReservedRange with fn size_of(self) {
   let mut size = 0U
   if self.start is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -978,7 +996,7 @@ pub impl @lib.Sized for DescriptorProto_ReservedRange with size_of(self) {
 }
 
 ///|
-pub impl Default for DescriptorProto_ReservedRange with default() -> DescriptorProto_ReservedRange {
+pub impl Default for DescriptorProto_ReservedRange with fn default() -> DescriptorProto_ReservedRange {
   DescriptorProto_ReservedRange::{ start: None, end: None }
 }
 
@@ -991,7 +1009,7 @@ pub fn DescriptorProto_ReservedRange::new(
 }
 
 ///|
-pub impl @lib.Read for DescriptorProto_ReservedRange with read_with_limit(
+pub impl @lib.Read for DescriptorProto_ReservedRange with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
@@ -1011,7 +1029,7 @@ pub impl @lib.Read for DescriptorProto_ReservedRange with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for DescriptorProto_ReservedRange with write(
+pub impl @lib.Write for DescriptorProto_ReservedRange with fn write(
   self : DescriptorProto_ReservedRange,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1026,7 +1044,7 @@ pub impl @lib.Write for DescriptorProto_ReservedRange with write(
 }
 
 ///|
-pub impl ToJson for DescriptorProto_ReservedRange with to_json(self) {
+pub impl ToJson for DescriptorProto_ReservedRange with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.start {
     Some(v) => json["start"] = v.to_json()
@@ -1040,7 +1058,7 @@ pub impl ToJson for DescriptorProto_ReservedRange with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for DescriptorProto_ReservedRange with from_json(
+pub impl @json.FromJson for DescriptorProto_ReservedRange with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> DescriptorProto_ReservedRange raise {
@@ -1054,14 +1072,14 @@ pub impl @json.FromJson for DescriptorProto_ReservedRange with from_json(
     match (key, value) {
       ("start", value) => message.start = Some(@json.from_json(value, path~))
       ("end", value) => message.end = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with read_with_limit(
+pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
@@ -1081,7 +1099,7 @@ pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for DescriptorProto_ReservedRange with write(
+pub impl @lib.AsyncWrite for DescriptorProto_ReservedRange with fn write(
   self : DescriptorProto_ReservedRange,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1111,7 +1129,7 @@ pub(all) struct DescriptorProto {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for DescriptorProto with size_of(self) {
+pub impl @lib.Sized for DescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U +
@@ -1166,7 +1184,7 @@ pub impl @lib.Sized for DescriptorProto with size_of(self) {
 }
 
 ///|
-pub impl Default for DescriptorProto with default() -> DescriptorProto {
+pub impl Default for DescriptorProto with fn default() -> DescriptorProto {
   DescriptorProto::{
     name: None,
     field: [],
@@ -1212,7 +1230,7 @@ pub fn DescriptorProto::new(
 }
 
 ///|
-pub impl @lib.Read for DescriptorProto with read_with_limit(
+pub impl @lib.Read for DescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
@@ -1265,7 +1283,7 @@ pub impl @lib.Read for DescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for DescriptorProto with write(
+pub impl @lib.Write for DescriptorProto with fn write(
   self : DescriptorProto,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1324,7 +1342,7 @@ pub impl @lib.Write for DescriptorProto with write(
 }
 
 ///|
-pub impl ToJson for DescriptorProto with to_json(self) {
+pub impl ToJson for DescriptorProto with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.name {
     Some(v) => json["name"] = v.to_json()
@@ -1366,7 +1384,7 @@ pub impl ToJson for DescriptorProto with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for DescriptorProto with from_json(
+pub impl @json.FromJson for DescriptorProto with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> DescriptorProto raise {
@@ -1399,14 +1417,14 @@ pub impl @json.FromJson for DescriptorProto with from_json(
         message.reserved_name = value.map(v => @json.from_json(v, path~))
       ("visibility", value) =>
         message.visibility = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for DescriptorProto with read_with_limit(
+pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
@@ -1464,7 +1482,7 @@ pub impl @lib.AsyncRead for DescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for DescriptorProto with write(
+pub impl @lib.AsyncWrite for DescriptorProto with fn write(
   self : DescriptorProto,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1550,19 +1568,19 @@ pub fn ExtensionRangeOptions_VerificationState::from_enum(
 }
 
 ///|
-pub impl Default for ExtensionRangeOptions_VerificationState with default() -> ExtensionRangeOptions_VerificationState {
+pub impl Default for ExtensionRangeOptions_VerificationState with fn default() -> ExtensionRangeOptions_VerificationState {
   ExtensionRangeOptions_VerificationState::DECLARATION
 }
 
 ///|
-pub impl @lib.Sized for ExtensionRangeOptions_VerificationState with size_of(
+pub impl @lib.Sized for ExtensionRangeOptions_VerificationState with fn size_of(
   self : ExtensionRangeOptions_VerificationState,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for ExtensionRangeOptions_VerificationState with from_json(
+pub impl @json.FromJson for ExtensionRangeOptions_VerificationState with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> ExtensionRangeOptions_VerificationState raise {
@@ -1580,7 +1598,7 @@ pub impl @json.FromJson for ExtensionRangeOptions_VerificationState with from_js
 }
 
 ///|
-pub impl ToJson for ExtensionRangeOptions_VerificationState with to_json(
+pub impl ToJson for ExtensionRangeOptions_VerificationState with fn to_json(
   self : ExtensionRangeOptions_VerificationState,
 ) -> Json {
   match self {
@@ -1599,7 +1617,7 @@ pub(all) struct ExtensionRangeOptions_Declaration {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for ExtensionRangeOptions_Declaration with size_of(self) {
+pub impl @lib.Sized for ExtensionRangeOptions_Declaration with fn size_of(self) {
   let mut size = 0U
   if self.number is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -1628,7 +1646,7 @@ pub impl @lib.Sized for ExtensionRangeOptions_Declaration with size_of(self) {
 }
 
 ///|
-pub impl Default for ExtensionRangeOptions_Declaration with default() -> ExtensionRangeOptions_Declaration {
+pub impl Default for ExtensionRangeOptions_Declaration with fn default() -> ExtensionRangeOptions_Declaration {
   ExtensionRangeOptions_Declaration::{
     number: None,
     full_name: None,
@@ -1656,7 +1674,7 @@ pub fn ExtensionRangeOptions_Declaration::new(
 }
 
 ///|
-pub impl @lib.Read for ExtensionRangeOptions_Declaration with read_with_limit(
+pub impl @lib.Read for ExtensionRangeOptions_Declaration with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
@@ -1679,7 +1697,7 @@ pub impl @lib.Read for ExtensionRangeOptions_Declaration with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for ExtensionRangeOptions_Declaration with write(
+pub impl @lib.Write for ExtensionRangeOptions_Declaration with fn write(
   self : ExtensionRangeOptions_Declaration,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1706,7 +1724,7 @@ pub impl @lib.Write for ExtensionRangeOptions_Declaration with write(
 }
 
 ///|
-pub impl ToJson for ExtensionRangeOptions_Declaration with to_json(self) {
+pub impl ToJson for ExtensionRangeOptions_Declaration with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.number {
     Some(v) => json["number"] = v.to_json()
@@ -1732,7 +1750,7 @@ pub impl ToJson for ExtensionRangeOptions_Declaration with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for ExtensionRangeOptions_Declaration with from_json(
+pub impl @json.FromJson for ExtensionRangeOptions_Declaration with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> ExtensionRangeOptions_Declaration raise {
@@ -1752,14 +1770,14 @@ pub impl @json.FromJson for ExtensionRangeOptions_Declaration with from_json(
         message.reserved = Some(@json.from_json(value, path~))
       ("repeated", value) =>
         message.repeated = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with read_with_limit(
+pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
@@ -1782,7 +1800,7 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with read_with_lim
 }
 
 ///|
-pub impl @lib.AsyncWrite for ExtensionRangeOptions_Declaration with write(
+pub impl @lib.AsyncWrite for ExtensionRangeOptions_Declaration with fn write(
   self : ExtensionRangeOptions_Declaration,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -1817,7 +1835,7 @@ pub(all) struct ExtensionRangeOptions {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for ExtensionRangeOptions with size_of(self) {
+pub impl @lib.Sized for ExtensionRangeOptions with fn size_of(self) {
   let mut size = 0U
   for s in self.uninterpreted_option {
     let s = @lib.size_of(s)
@@ -1841,7 +1859,7 @@ pub impl @lib.Sized for ExtensionRangeOptions with size_of(self) {
 }
 
 ///|
-pub impl Default for ExtensionRangeOptions with default() -> ExtensionRangeOptions {
+pub impl Default for ExtensionRangeOptions with fn default() -> ExtensionRangeOptions {
   ExtensionRangeOptions::{
     uninterpreted_option: [],
     declaration: [],
@@ -1866,7 +1884,7 @@ pub fn ExtensionRangeOptions::new(
 }
 
 ///|
-pub impl @lib.Read for ExtensionRangeOptions with read_with_limit(
+pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
@@ -1899,7 +1917,7 @@ pub impl @lib.Read for ExtensionRangeOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for ExtensionRangeOptions with write(
+pub impl @lib.Write for ExtensionRangeOptions with fn write(
   self : ExtensionRangeOptions,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -1925,7 +1943,7 @@ pub impl @lib.Write for ExtensionRangeOptions with write(
 }
 
 ///|
-pub impl ToJson for ExtensionRangeOptions with to_json(self) {
+pub impl ToJson for ExtensionRangeOptions with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.uninterpreted_option != Default::default() {
     json["uninterpretedOption"] = self.uninterpreted_option.to_json()
@@ -1946,7 +1964,7 @@ pub impl ToJson for ExtensionRangeOptions with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for ExtensionRangeOptions with from_json(
+pub impl @json.FromJson for ExtensionRangeOptions with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> ExtensionRangeOptions raise {
@@ -1966,14 +1984,14 @@ pub impl @json.FromJson for ExtensionRangeOptions with from_json(
         message.features = Some(@json.from_json(value, path~))
       ("verification", value) =>
         message.verification = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for ExtensionRangeOptions with read_with_limit(
+pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
@@ -2009,7 +2027,7 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for ExtensionRangeOptions with write(
+pub impl @lib.AsyncWrite for ExtensionRangeOptions with fn write(
   self : ExtensionRangeOptions,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -2110,19 +2128,19 @@ pub fn FieldDescriptorProto_Type::from_enum(
 }
 
 ///|
-pub impl Default for FieldDescriptorProto_Type with default() -> FieldDescriptorProto_Type {
+pub impl Default for FieldDescriptorProto_Type with fn default() -> FieldDescriptorProto_Type {
   FieldDescriptorProto_Type::TYPE_DOUBLE
 }
 
 ///|
-pub impl @lib.Sized for FieldDescriptorProto_Type with size_of(
+pub impl @lib.Sized for FieldDescriptorProto_Type with fn size_of(
   self : FieldDescriptorProto_Type,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FieldDescriptorProto_Type with from_json(
+pub impl @json.FromJson for FieldDescriptorProto_Type with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FieldDescriptorProto_Type raise {
@@ -2171,7 +2189,7 @@ pub impl @json.FromJson for FieldDescriptorProto_Type with from_json(
 }
 
 ///|
-pub impl ToJson for FieldDescriptorProto_Type with to_json(
+pub impl ToJson for FieldDescriptorProto_Type with fn to_json(
   self : FieldDescriptorProto_Type,
 ) -> Json {
   match self {
@@ -2194,31 +2212,6 @@ pub impl ToJson for FieldDescriptorProto_Type with to_json(
     FieldDescriptorProto_Type::TYPE_SINT32 => "TYPE_SINT32"
     FieldDescriptorProto_Type::TYPE_SINT64 => "TYPE_SINT64"
   }
-}
-
-///|
-pub impl Show for FieldDescriptorProto_Type with output(self, logger) {
-  let name = match self {
-    FieldDescriptorProto_Type::TYPE_DOUBLE => "TYPE_DOUBLE"
-    FieldDescriptorProto_Type::TYPE_FLOAT => "TYPE_FLOAT"
-    FieldDescriptorProto_Type::TYPE_INT64 => "TYPE_INT64"
-    FieldDescriptorProto_Type::TYPE_UINT64 => "TYPE_UINT64"
-    FieldDescriptorProto_Type::TYPE_INT32 => "TYPE_INT32"
-    FieldDescriptorProto_Type::TYPE_FIXED64 => "TYPE_FIXED64"
-    FieldDescriptorProto_Type::TYPE_FIXED32 => "TYPE_FIXED32"
-    FieldDescriptorProto_Type::TYPE_BOOL => "TYPE_BOOL"
-    FieldDescriptorProto_Type::TYPE_STRING => "TYPE_STRING"
-    FieldDescriptorProto_Type::TYPE_GROUP => "TYPE_GROUP"
-    FieldDescriptorProto_Type::TYPE_MESSAGE => "TYPE_MESSAGE"
-    FieldDescriptorProto_Type::TYPE_BYTES => "TYPE_BYTES"
-    FieldDescriptorProto_Type::TYPE_UINT32 => "TYPE_UINT32"
-    FieldDescriptorProto_Type::TYPE_ENUM => "TYPE_ENUM"
-    FieldDescriptorProto_Type::TYPE_SFIXED32 => "TYPE_SFIXED32"
-    FieldDescriptorProto_Type::TYPE_SFIXED64 => "TYPE_SFIXED64"
-    FieldDescriptorProto_Type::TYPE_SINT32 => "TYPE_SINT32"
-    FieldDescriptorProto_Type::TYPE_SINT64 => "TYPE_SINT64"
-  }
-  logger.write_string(name)
 }
 
 ///|
@@ -2252,19 +2245,19 @@ pub fn FieldDescriptorProto_Label::from_enum(
 }
 
 ///|
-pub impl Default for FieldDescriptorProto_Label with default() -> FieldDescriptorProto_Label {
+pub impl Default for FieldDescriptorProto_Label with fn default() -> FieldDescriptorProto_Label {
   FieldDescriptorProto_Label::LABEL_OPTIONAL
 }
 
 ///|
-pub impl @lib.Sized for FieldDescriptorProto_Label with size_of(
+pub impl @lib.Sized for FieldDescriptorProto_Label with fn size_of(
   self : FieldDescriptorProto_Label,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FieldDescriptorProto_Label with from_json(
+pub impl @json.FromJson for FieldDescriptorProto_Label with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FieldDescriptorProto_Label raise {
@@ -2283,7 +2276,7 @@ pub impl @json.FromJson for FieldDescriptorProto_Label with from_json(
 }
 
 ///|
-pub impl ToJson for FieldDescriptorProto_Label with to_json(
+pub impl ToJson for FieldDescriptorProto_Label with fn to_json(
   self : FieldDescriptorProto_Label,
 ) -> Json {
   match self {
@@ -2309,7 +2302,7 @@ pub(all) struct FieldDescriptorProto {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FieldDescriptorProto with size_of(self) {
+pub impl @lib.Sized for FieldDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U +
@@ -2372,7 +2365,7 @@ pub impl @lib.Sized for FieldDescriptorProto with size_of(self) {
 }
 
 ///|
-pub impl Default for FieldDescriptorProto with default() -> FieldDescriptorProto {
+pub impl Default for FieldDescriptorProto with fn default() -> FieldDescriptorProto {
   FieldDescriptorProto::{
     name: None,
     number: None,
@@ -2418,7 +2411,7 @@ pub fn FieldDescriptorProto::new(
 }
 
 ///|
-pub impl @lib.Read for FieldDescriptorProto with read_with_limit(
+pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
@@ -2456,7 +2449,7 @@ pub impl @lib.Read for FieldDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FieldDescriptorProto with write(
+pub impl @lib.Write for FieldDescriptorProto with fn write(
   self : FieldDescriptorProto,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -2508,7 +2501,7 @@ pub impl @lib.Write for FieldDescriptorProto with write(
 }
 
 ///|
-pub impl ToJson for FieldDescriptorProto with to_json(self) {
+pub impl ToJson for FieldDescriptorProto with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.name {
     Some(v) => json["name"] = v.to_json()
@@ -2558,7 +2551,7 @@ pub impl ToJson for FieldDescriptorProto with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for FieldDescriptorProto with from_json(
+pub impl @json.FromJson for FieldDescriptorProto with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FieldDescriptorProto raise {
@@ -2588,14 +2581,14 @@ pub impl @json.FromJson for FieldDescriptorProto with from_json(
         message.options = Some(@json.from_json(value, path~))
       ("proto3Optional", value) =>
         message.proto3_optional = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for FieldDescriptorProto with read_with_limit(
+pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
@@ -2635,7 +2628,7 @@ pub impl @lib.AsyncRead for FieldDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FieldDescriptorProto with write(
+pub impl @lib.AsyncWrite for FieldDescriptorProto with fn write(
   self : FieldDescriptorProto,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -2693,7 +2686,7 @@ pub(all) struct OneofDescriptorProto {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for OneofDescriptorProto with size_of(self) {
+pub impl @lib.Sized for OneofDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U +
@@ -2713,7 +2706,7 @@ pub impl @lib.Sized for OneofDescriptorProto with size_of(self) {
 }
 
 ///|
-pub impl Default for OneofDescriptorProto with default() -> OneofDescriptorProto {
+pub impl Default for OneofDescriptorProto with fn default() -> OneofDescriptorProto {
   OneofDescriptorProto::{ name: None, options: None }
 }
 
@@ -2726,7 +2719,7 @@ pub fn OneofDescriptorProto::new(
 }
 
 ///|
-pub impl @lib.Read for OneofDescriptorProto with read_with_limit(
+pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
@@ -2747,7 +2740,7 @@ pub impl @lib.Read for OneofDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for OneofDescriptorProto with write(
+pub impl @lib.Write for OneofDescriptorProto with fn write(
   self : OneofDescriptorProto,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -2763,7 +2756,7 @@ pub impl @lib.Write for OneofDescriptorProto with write(
 }
 
 ///|
-pub impl ToJson for OneofDescriptorProto with to_json(self) {
+pub impl ToJson for OneofDescriptorProto with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.name {
     Some(v) => json["name"] = v.to_json()
@@ -2777,7 +2770,7 @@ pub impl ToJson for OneofDescriptorProto with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for OneofDescriptorProto with from_json(
+pub impl @json.FromJson for OneofDescriptorProto with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> OneofDescriptorProto raise {
@@ -2792,14 +2785,14 @@ pub impl @json.FromJson for OneofDescriptorProto with from_json(
       ("name", value) => message.name = Some(@json.from_json(value, path~))
       ("options", value) =>
         message.options = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for OneofDescriptorProto with read_with_limit(
+pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
@@ -2821,7 +2814,7 @@ pub impl @lib.AsyncRead for OneofDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for OneofDescriptorProto with write(
+pub impl @lib.AsyncWrite for OneofDescriptorProto with fn write(
   self : OneofDescriptorProto,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -2843,7 +2836,9 @@ pub(all) struct EnumDescriptorProto_EnumReservedRange {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for EnumDescriptorProto_EnumReservedRange with size_of(self) {
+pub impl @lib.Sized for EnumDescriptorProto_EnumReservedRange with fn size_of(
+  self,
+) {
   let mut size = 0U
   if self.start is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -2855,7 +2850,7 @@ pub impl @lib.Sized for EnumDescriptorProto_EnumReservedRange with size_of(self)
 }
 
 ///|
-pub impl Default for EnumDescriptorProto_EnumReservedRange with default() -> EnumDescriptorProto_EnumReservedRange {
+pub impl Default for EnumDescriptorProto_EnumReservedRange with fn default() -> EnumDescriptorProto_EnumReservedRange {
   EnumDescriptorProto_EnumReservedRange::{ start: None, end: None }
 }
 
@@ -2868,7 +2863,7 @@ pub fn EnumDescriptorProto_EnumReservedRange::new(
 }
 
 ///|
-pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with read_with_limit(
+pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
@@ -2888,7 +2883,7 @@ pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with read_with_limi
 }
 
 ///|
-pub impl @lib.Write for EnumDescriptorProto_EnumReservedRange with write(
+pub impl @lib.Write for EnumDescriptorProto_EnumReservedRange with fn write(
   self : EnumDescriptorProto_EnumReservedRange,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -2903,7 +2898,7 @@ pub impl @lib.Write for EnumDescriptorProto_EnumReservedRange with write(
 }
 
 ///|
-pub impl ToJson for EnumDescriptorProto_EnumReservedRange with to_json(self) {
+pub impl ToJson for EnumDescriptorProto_EnumReservedRange with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.start {
     Some(v) => json["start"] = v.to_json()
@@ -2917,7 +2912,7 @@ pub impl ToJson for EnumDescriptorProto_EnumReservedRange with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for EnumDescriptorProto_EnumReservedRange with from_json(
+pub impl @json.FromJson for EnumDescriptorProto_EnumReservedRange with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> EnumDescriptorProto_EnumReservedRange raise {
@@ -2931,14 +2926,14 @@ pub impl @json.FromJson for EnumDescriptorProto_EnumReservedRange with from_json
     match (key, value) {
       ("start", value) => message.start = Some(@json.from_json(value, path~))
       ("end", value) => message.end = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with read_with_limit(
+pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
@@ -2958,7 +2953,7 @@ pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with read_with
 }
 
 ///|
-pub impl @lib.AsyncWrite for EnumDescriptorProto_EnumReservedRange with write(
+pub impl @lib.AsyncWrite for EnumDescriptorProto_EnumReservedRange with fn write(
   self : EnumDescriptorProto_EnumReservedRange,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -2983,7 +2978,7 @@ pub(all) struct EnumDescriptorProto {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for EnumDescriptorProto with size_of(self) {
+pub impl @lib.Sized for EnumDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U +
@@ -3018,7 +3013,7 @@ pub impl @lib.Sized for EnumDescriptorProto with size_of(self) {
 }
 
 ///|
-pub impl Default for EnumDescriptorProto with default() -> EnumDescriptorProto {
+pub impl Default for EnumDescriptorProto with fn default() -> EnumDescriptorProto {
   EnumDescriptorProto::{
     name: None,
     value: [],
@@ -3049,7 +3044,7 @@ pub fn EnumDescriptorProto::new(
 }
 
 ///|
-pub impl @lib.Read for EnumDescriptorProto with read_with_limit(
+pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
@@ -3086,7 +3081,7 @@ pub impl @lib.Read for EnumDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for EnumDescriptorProto with write(
+pub impl @lib.Write for EnumDescriptorProto with fn write(
   self : EnumDescriptorProto,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -3120,7 +3115,7 @@ pub impl @lib.Write for EnumDescriptorProto with write(
 }
 
 ///|
-pub impl ToJson for EnumDescriptorProto with to_json(self) {
+pub impl ToJson for EnumDescriptorProto with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.name {
     Some(v) => json["name"] = v.to_json()
@@ -3147,7 +3142,7 @@ pub impl ToJson for EnumDescriptorProto with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for EnumDescriptorProto with from_json(
+pub impl @json.FromJson for EnumDescriptorProto with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> EnumDescriptorProto raise {
@@ -3170,14 +3165,14 @@ pub impl @json.FromJson for EnumDescriptorProto with from_json(
         message.reserved_name = value.map(v => @json.from_json(v, path~))
       ("visibility", value) =>
         message.visibility = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for EnumDescriptorProto with read_with_limit(
+pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
@@ -3215,7 +3210,7 @@ pub impl @lib.AsyncRead for EnumDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for EnumDescriptorProto with write(
+pub impl @lib.AsyncWrite for EnumDescriptorProto with fn write(
   self : EnumDescriptorProto,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -3256,7 +3251,7 @@ pub(all) struct EnumValueDescriptorProto {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for EnumValueDescriptorProto with size_of(self) {
+pub impl @lib.Sized for EnumValueDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U +
@@ -3279,7 +3274,7 @@ pub impl @lib.Sized for EnumValueDescriptorProto with size_of(self) {
 }
 
 ///|
-pub impl Default for EnumValueDescriptorProto with default() -> EnumValueDescriptorProto {
+pub impl Default for EnumValueDescriptorProto with fn default() -> EnumValueDescriptorProto {
   EnumValueDescriptorProto::{ name: None, number: None, options: None }
 }
 
@@ -3293,7 +3288,7 @@ pub fn EnumValueDescriptorProto::new(
 }
 
 ///|
-pub impl @lib.Read for EnumValueDescriptorProto with read_with_limit(
+pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
@@ -3316,7 +3311,7 @@ pub impl @lib.Read for EnumValueDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for EnumValueDescriptorProto with write(
+pub impl @lib.Write for EnumValueDescriptorProto with fn write(
   self : EnumValueDescriptorProto,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -3336,7 +3331,7 @@ pub impl @lib.Write for EnumValueDescriptorProto with write(
 }
 
 ///|
-pub impl ToJson for EnumValueDescriptorProto with to_json(self) {
+pub impl ToJson for EnumValueDescriptorProto with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.name {
     Some(v) => json["name"] = v.to_json()
@@ -3354,7 +3349,7 @@ pub impl ToJson for EnumValueDescriptorProto with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for EnumValueDescriptorProto with from_json(
+pub impl @json.FromJson for EnumValueDescriptorProto with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> EnumValueDescriptorProto raise {
@@ -3370,14 +3365,14 @@ pub impl @json.FromJson for EnumValueDescriptorProto with from_json(
       ("number", value) => message.number = Some(@json.from_json(value, path~))
       ("options", value) =>
         message.options = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for EnumValueDescriptorProto with read_with_limit(
+pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
@@ -3400,7 +3395,7 @@ pub impl @lib.AsyncRead for EnumValueDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for EnumValueDescriptorProto with write(
+pub impl @lib.AsyncWrite for EnumValueDescriptorProto with fn write(
   self : EnumValueDescriptorProto,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -3427,7 +3422,7 @@ pub(all) struct ServiceDescriptorProto {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for ServiceDescriptorProto with size_of(self) {
+pub impl @lib.Sized for ServiceDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U +
@@ -3451,7 +3446,7 @@ pub impl @lib.Sized for ServiceDescriptorProto with size_of(self) {
 }
 
 ///|
-pub impl Default for ServiceDescriptorProto with default() -> ServiceDescriptorProto {
+pub impl Default for ServiceDescriptorProto with fn default() -> ServiceDescriptorProto {
   ServiceDescriptorProto::{ name: None, method_: [], options: None }
 }
 
@@ -3465,7 +3460,7 @@ pub fn ServiceDescriptorProto::new(
 }
 
 ///|
-pub impl @lib.Read for ServiceDescriptorProto with read_with_limit(
+pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
@@ -3490,7 +3485,7 @@ pub impl @lib.Read for ServiceDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for ServiceDescriptorProto with write(
+pub impl @lib.Write for ServiceDescriptorProto with fn write(
   self : ServiceDescriptorProto,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -3511,7 +3506,7 @@ pub impl @lib.Write for ServiceDescriptorProto with write(
 }
 
 ///|
-pub impl ToJson for ServiceDescriptorProto with to_json(self) {
+pub impl ToJson for ServiceDescriptorProto with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.name {
     Some(v) => json["name"] = v.to_json()
@@ -3528,7 +3523,7 @@ pub impl ToJson for ServiceDescriptorProto with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for ServiceDescriptorProto with from_json(
+pub impl @json.FromJson for ServiceDescriptorProto with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> ServiceDescriptorProto raise {
@@ -3545,14 +3540,14 @@ pub impl @json.FromJson for ServiceDescriptorProto with from_json(
         message.method_ = value.map(v => @json.from_json(v, path~))
       ("options", value) =>
         message.options = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for ServiceDescriptorProto with read_with_limit(
+pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
@@ -3578,7 +3573,7 @@ pub impl @lib.AsyncRead for ServiceDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for ServiceDescriptorProto with write(
+pub impl @lib.AsyncWrite for ServiceDescriptorProto with fn write(
   self : ServiceDescriptorProto,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -3609,7 +3604,7 @@ pub(all) struct MethodDescriptorProto {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for MethodDescriptorProto with size_of(self) {
+pub impl @lib.Sized for MethodDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U +
@@ -3649,7 +3644,7 @@ pub impl @lib.Sized for MethodDescriptorProto with size_of(self) {
 }
 
 ///|
-pub impl Default for MethodDescriptorProto with default() -> MethodDescriptorProto {
+pub impl Default for MethodDescriptorProto with fn default() -> MethodDescriptorProto {
   MethodDescriptorProto::{
     name: None,
     input_type: None,
@@ -3680,7 +3675,7 @@ pub fn MethodDescriptorProto::new(
 }
 
 ///|
-pub impl @lib.Read for MethodDescriptorProto with read_with_limit(
+pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
@@ -3705,7 +3700,7 @@ pub impl @lib.Read for MethodDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for MethodDescriptorProto with write(
+pub impl @lib.Write for MethodDescriptorProto with fn write(
   self : MethodDescriptorProto,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -3737,7 +3732,7 @@ pub impl @lib.Write for MethodDescriptorProto with write(
 }
 
 ///|
-pub impl ToJson for MethodDescriptorProto with to_json(self) {
+pub impl ToJson for MethodDescriptorProto with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.name {
     Some(v) => json["name"] = v.to_json()
@@ -3767,7 +3762,7 @@ pub impl ToJson for MethodDescriptorProto with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for MethodDescriptorProto with from_json(
+pub impl @json.FromJson for MethodDescriptorProto with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> MethodDescriptorProto raise {
@@ -3790,14 +3785,14 @@ pub impl @json.FromJson for MethodDescriptorProto with from_json(
         message.client_streaming = Some(@json.from_json(value, path~))
       ("serverStreaming", value) =>
         message.server_streaming = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for MethodDescriptorProto with read_with_limit(
+pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
@@ -3825,7 +3820,7 @@ pub impl @lib.AsyncRead for MethodDescriptorProto with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for MethodDescriptorProto with write(
+pub impl @lib.AsyncWrite for MethodDescriptorProto with fn write(
   self : MethodDescriptorProto,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -3887,19 +3882,19 @@ pub fn FileOptions_OptimizeMode::from_enum(
 }
 
 ///|
-pub impl Default for FileOptions_OptimizeMode with default() -> FileOptions_OptimizeMode {
+pub impl Default for FileOptions_OptimizeMode with fn default() -> FileOptions_OptimizeMode {
   FileOptions_OptimizeMode::SPEED
 }
 
 ///|
-pub impl @lib.Sized for FileOptions_OptimizeMode with size_of(
+pub impl @lib.Sized for FileOptions_OptimizeMode with fn size_of(
   self : FileOptions_OptimizeMode,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FileOptions_OptimizeMode with from_json(
+pub impl @json.FromJson for FileOptions_OptimizeMode with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FileOptions_OptimizeMode raise {
@@ -3918,7 +3913,7 @@ pub impl @json.FromJson for FileOptions_OptimizeMode with from_json(
 }
 
 ///|
-pub impl ToJson for FileOptions_OptimizeMode with to_json(
+pub impl ToJson for FileOptions_OptimizeMode with fn to_json(
   self : FileOptions_OptimizeMode,
 ) -> Json {
   match self {
@@ -3954,7 +3949,7 @@ pub(all) struct FileOptions {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FileOptions with size_of(self) {
+pub impl @lib.Sized for FileOptions with fn size_of(self) {
   let mut size = 0U
   if self.java_package is Some(v) {
     size += 1U +
@@ -4068,7 +4063,7 @@ pub impl @lib.Sized for FileOptions with size_of(self) {
 }
 
 ///|
-pub impl Default for FileOptions with default() -> FileOptions {
+pub impl Default for FileOptions with fn default() -> FileOptions {
   FileOptions::{
     java_package: None,
     java_outer_classname: None,
@@ -4144,7 +4139,7 @@ pub fn FileOptions::new(
 }
 
 ///|
-pub impl @lib.Read for FileOptions with read_with_limit(
+pub impl @lib.Read for FileOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FileOptions raise {
   let msg = FileOptions::default()
@@ -4196,7 +4191,7 @@ pub impl @lib.Read for FileOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FileOptions with write(
+pub impl @lib.Write for FileOptions with fn write(
   self : FileOptions,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -4289,7 +4284,7 @@ pub impl @lib.Write for FileOptions with write(
 }
 
 ///|
-pub impl ToJson for FileOptions with to_json(self) {
+pub impl ToJson for FileOptions with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.java_package {
     Some(v) => json["javaPackage"] = v.to_json()
@@ -4379,7 +4374,7 @@ pub impl ToJson for FileOptions with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for FileOptions with from_json(
+pub impl @json.FromJson for FileOptions with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FileOptions raise {
@@ -4433,14 +4428,14 @@ pub impl @json.FromJson for FileOptions with from_json(
         message.features = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) =>
         message.uninterpreted_option = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for FileOptions with read_with_limit(
+pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FileOptions raise {
   let msg = FileOptions::default()
@@ -4505,7 +4500,7 @@ pub impl @lib.AsyncRead for FileOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FileOptions with write(
+pub impl @lib.AsyncWrite for FileOptions with fn write(
   self : FileOptions,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -4609,7 +4604,7 @@ pub(all) struct MessageOptions {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for MessageOptions with size_of(self) {
+pub impl @lib.Sized for MessageOptions with fn size_of(self) {
   let mut size = 0U
   if self.message_set_wire_format is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -4641,7 +4636,7 @@ pub impl @lib.Sized for MessageOptions with size_of(self) {
 }
 
 ///|
-pub impl Default for MessageOptions with default() -> MessageOptions {
+pub impl Default for MessageOptions with fn default() -> MessageOptions {
   MessageOptions::{
     message_set_wire_format: Some(false),
     no_standard_descriptor_accessor: Some(false),
@@ -4675,7 +4670,7 @@ pub fn MessageOptions::new(
 }
 
 ///|
-pub impl @lib.Read for MessageOptions with read_with_limit(
+pub impl @lib.Read for MessageOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MessageOptions raise {
   let msg = MessageOptions::default()
@@ -4711,7 +4706,7 @@ pub impl @lib.Read for MessageOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for MessageOptions with write(
+pub impl @lib.Write for MessageOptions with fn write(
   self : MessageOptions,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -4748,7 +4743,7 @@ pub impl @lib.Write for MessageOptions with write(
 }
 
 ///|
-pub impl ToJson for MessageOptions with to_json(self) {
+pub impl ToJson for MessageOptions with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.message_set_wire_format {
     Some(v) if v != false => json["messageSetWireFormat"] = v.to_json()
@@ -4781,7 +4776,7 @@ pub impl ToJson for MessageOptions with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for MessageOptions with from_json(
+pub impl @json.FromJson for MessageOptions with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> MessageOptions raise {
@@ -4809,14 +4804,14 @@ pub impl @json.FromJson for MessageOptions with from_json(
         message.features = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) =>
         message.uninterpreted_option = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for MessageOptions with read_with_limit(
+pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MessageOptions raise {
   let msg = MessageOptions::default()
@@ -4853,7 +4848,7 @@ pub impl @lib.AsyncRead for MessageOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for MessageOptions with write(
+pub impl @lib.AsyncWrite for MessageOptions with fn write(
   self : MessageOptions,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -4916,19 +4911,19 @@ pub fn FieldOptions_CType::from_enum(i : @lib.Enum) -> FieldOptions_CType {
 }
 
 ///|
-pub impl Default for FieldOptions_CType with default() -> FieldOptions_CType {
+pub impl Default for FieldOptions_CType with fn default() -> FieldOptions_CType {
   FieldOptions_CType::STRING
 }
 
 ///|
-pub impl @lib.Sized for FieldOptions_CType with size_of(
+pub impl @lib.Sized for FieldOptions_CType with fn size_of(
   self : FieldOptions_CType,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FieldOptions_CType with from_json(
+pub impl @json.FromJson for FieldOptions_CType with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FieldOptions_CType raise {
@@ -4947,7 +4942,9 @@ pub impl @json.FromJson for FieldOptions_CType with from_json(
 }
 
 ///|
-pub impl ToJson for FieldOptions_CType with to_json(self : FieldOptions_CType) -> Json {
+pub impl ToJson for FieldOptions_CType with fn to_json(
+  self : FieldOptions_CType,
+) -> Json {
   match self {
     FieldOptions_CType::STRING => "STRING"
     FieldOptions_CType::CORD => "CORD"
@@ -4982,19 +4979,19 @@ pub fn FieldOptions_JSType::from_enum(i : @lib.Enum) -> FieldOptions_JSType {
 }
 
 ///|
-pub impl Default for FieldOptions_JSType with default() -> FieldOptions_JSType {
+pub impl Default for FieldOptions_JSType with fn default() -> FieldOptions_JSType {
   FieldOptions_JSType::JS_NORMAL
 }
 
 ///|
-pub impl @lib.Sized for FieldOptions_JSType with size_of(
+pub impl @lib.Sized for FieldOptions_JSType with fn size_of(
   self : FieldOptions_JSType,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FieldOptions_JSType with from_json(
+pub impl @json.FromJson for FieldOptions_JSType with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FieldOptions_JSType raise {
@@ -5013,7 +5010,9 @@ pub impl @json.FromJson for FieldOptions_JSType with from_json(
 }
 
 ///|
-pub impl ToJson for FieldOptions_JSType with to_json(self : FieldOptions_JSType) -> Json {
+pub impl ToJson for FieldOptions_JSType with fn to_json(
+  self : FieldOptions_JSType,
+) -> Json {
   match self {
     FieldOptions_JSType::JS_NORMAL => "JS_NORMAL"
     FieldOptions_JSType::JS_STRING => "JS_STRING"
@@ -5052,19 +5051,19 @@ pub fn FieldOptions_OptionRetention::from_enum(
 }
 
 ///|
-pub impl Default for FieldOptions_OptionRetention with default() -> FieldOptions_OptionRetention {
+pub impl Default for FieldOptions_OptionRetention with fn default() -> FieldOptions_OptionRetention {
   FieldOptions_OptionRetention::RETENTION_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for FieldOptions_OptionRetention with size_of(
+pub impl @lib.Sized for FieldOptions_OptionRetention with fn size_of(
   self : FieldOptions_OptionRetention,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FieldOptions_OptionRetention with from_json(
+pub impl @json.FromJson for FieldOptions_OptionRetention with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FieldOptions_OptionRetention raise {
@@ -5085,7 +5084,7 @@ pub impl @json.FromJson for FieldOptions_OptionRetention with from_json(
 }
 
 ///|
-pub impl ToJson for FieldOptions_OptionRetention with to_json(
+pub impl ToJson for FieldOptions_OptionRetention with fn to_json(
   self : FieldOptions_OptionRetention,
 ) -> Json {
   match self {
@@ -5147,19 +5146,19 @@ pub fn FieldOptions_OptionTargetType::from_enum(
 }
 
 ///|
-pub impl Default for FieldOptions_OptionTargetType with default() -> FieldOptions_OptionTargetType {
+pub impl Default for FieldOptions_OptionTargetType with fn default() -> FieldOptions_OptionTargetType {
   FieldOptions_OptionTargetType::TARGET_TYPE_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for FieldOptions_OptionTargetType with size_of(
+pub impl @lib.Sized for FieldOptions_OptionTargetType with fn size_of(
   self : FieldOptions_OptionTargetType,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FieldOptions_OptionTargetType with from_json(
+pub impl @json.FromJson for FieldOptions_OptionTargetType with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FieldOptions_OptionTargetType raise {
@@ -5202,7 +5201,7 @@ pub impl @json.FromJson for FieldOptions_OptionTargetType with from_json(
 }
 
 ///|
-pub impl ToJson for FieldOptions_OptionTargetType with to_json(
+pub impl ToJson for FieldOptions_OptionTargetType with fn to_json(
   self : FieldOptions_OptionTargetType,
 ) -> Json {
   match self {
@@ -5228,7 +5227,7 @@ pub(all) struct FieldOptions_EditionDefault {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FieldOptions_EditionDefault with size_of(self) {
+pub impl @lib.Sized for FieldOptions_EditionDefault with fn size_of(self) {
   let mut size = 0U
   if self.edition is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -5244,7 +5243,7 @@ pub impl @lib.Sized for FieldOptions_EditionDefault with size_of(self) {
 }
 
 ///|
-pub impl Default for FieldOptions_EditionDefault with default() -> FieldOptions_EditionDefault {
+pub impl Default for FieldOptions_EditionDefault with fn default() -> FieldOptions_EditionDefault {
   FieldOptions_EditionDefault::{ edition: None, value: None }
 }
 
@@ -5257,7 +5256,7 @@ pub fn FieldOptions_EditionDefault::new(
 }
 
 ///|
-pub impl @lib.Read for FieldOptions_EditionDefault with read_with_limit(
+pub impl @lib.Read for FieldOptions_EditionDefault with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
@@ -5278,7 +5277,7 @@ pub impl @lib.Read for FieldOptions_EditionDefault with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FieldOptions_EditionDefault with write(
+pub impl @lib.Write for FieldOptions_EditionDefault with fn write(
   self : FieldOptions_EditionDefault,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -5293,7 +5292,7 @@ pub impl @lib.Write for FieldOptions_EditionDefault with write(
 }
 
 ///|
-pub impl ToJson for FieldOptions_EditionDefault with to_json(self) {
+pub impl ToJson for FieldOptions_EditionDefault with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.edition {
     Some(v) => json["edition"] = v.to_json()
@@ -5307,7 +5306,7 @@ pub impl ToJson for FieldOptions_EditionDefault with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for FieldOptions_EditionDefault with from_json(
+pub impl @json.FromJson for FieldOptions_EditionDefault with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FieldOptions_EditionDefault raise {
@@ -5322,14 +5321,14 @@ pub impl @json.FromJson for FieldOptions_EditionDefault with from_json(
       ("edition", value) =>
         message.edition = Some(@json.from_json(value, path~))
       ("value", value) => message.value = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for FieldOptions_EditionDefault with read_with_limit(
+pub impl @lib.AsyncRead for FieldOptions_EditionDefault with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
@@ -5353,7 +5352,7 @@ pub impl @lib.AsyncRead for FieldOptions_EditionDefault with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FieldOptions_EditionDefault with write(
+pub impl @lib.AsyncWrite for FieldOptions_EditionDefault with fn write(
   self : FieldOptions_EditionDefault,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -5376,7 +5375,7 @@ pub(all) struct FieldOptions_FeatureSupport {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FieldOptions_FeatureSupport with size_of(self) {
+pub impl @lib.Sized for FieldOptions_FeatureSupport with fn size_of(self) {
   let mut size = 0U
   if self.edition_introduced is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -5398,7 +5397,7 @@ pub impl @lib.Sized for FieldOptions_FeatureSupport with size_of(self) {
 }
 
 ///|
-pub impl Default for FieldOptions_FeatureSupport with default() -> FieldOptions_FeatureSupport {
+pub impl Default for FieldOptions_FeatureSupport with fn default() -> FieldOptions_FeatureSupport {
   FieldOptions_FeatureSupport::{
     edition_introduced: None,
     edition_deprecated: None,
@@ -5423,7 +5422,7 @@ pub fn FieldOptions_FeatureSupport::new(
 }
 
 ///|
-pub impl @lib.Read for FieldOptions_FeatureSupport with read_with_limit(
+pub impl @lib.Read for FieldOptions_FeatureSupport with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
@@ -5457,7 +5456,7 @@ pub impl @lib.Read for FieldOptions_FeatureSupport with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FieldOptions_FeatureSupport with write(
+pub impl @lib.Write for FieldOptions_FeatureSupport with fn write(
   self : FieldOptions_FeatureSupport,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -5480,7 +5479,7 @@ pub impl @lib.Write for FieldOptions_FeatureSupport with write(
 }
 
 ///|
-pub impl ToJson for FieldOptions_FeatureSupport with to_json(self) {
+pub impl ToJson for FieldOptions_FeatureSupport with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.edition_introduced {
     Some(v) => json["editionIntroduced"] = v.to_json()
@@ -5502,7 +5501,7 @@ pub impl ToJson for FieldOptions_FeatureSupport with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for FieldOptions_FeatureSupport with from_json(
+pub impl @json.FromJson for FieldOptions_FeatureSupport with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FieldOptions_FeatureSupport raise {
@@ -5522,14 +5521,14 @@ pub impl @json.FromJson for FieldOptions_FeatureSupport with from_json(
         message.deprecation_warning = Some(@json.from_json(value, path~))
       ("editionRemoved", value) =>
         message.edition_removed = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with read_with_limit(
+pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
@@ -5564,7 +5563,7 @@ pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FieldOptions_FeatureSupport with write(
+pub impl @lib.AsyncWrite for FieldOptions_FeatureSupport with fn write(
   self : FieldOptions_FeatureSupport,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -5605,7 +5604,7 @@ pub(all) struct FieldOptions {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FieldOptions with size_of(self) {
+pub impl @lib.Sized for FieldOptions with fn size_of(self) {
   let mut size = 0U
   if self.ctype is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -5664,7 +5663,7 @@ pub impl @lib.Sized for FieldOptions with size_of(self) {
 }
 
 ///|
-pub impl Default for FieldOptions with default() -> FieldOptions {
+pub impl Default for FieldOptions with fn default() -> FieldOptions {
   FieldOptions::{
     ctype: Some(FieldOptions_CType::STRING),
     packed: None,
@@ -5719,7 +5718,7 @@ pub fn FieldOptions::new(
 }
 
 ///|
-pub impl @lib.Read for FieldOptions with read_with_limit(
+pub impl @lib.Read for FieldOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldOptions raise {
   let msg = FieldOptions::default()
@@ -5747,7 +5746,13 @@ pub impl @lib.Read for FieldOptions with read_with_limit(
             |> @lib.read_enum()
             |> FieldOptions_OptionRetention::from_enum
             |> Some
-        (19, _) =>
+        (19, 2) => {
+          let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+          for item in packed {
+            msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
+          }
+        }
+        (19, 0) =>
           msg.targets.push(
             reader
             |> @lib.read_enum()
@@ -5778,7 +5783,7 @@ pub impl @lib.Read for FieldOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FieldOptions with write(
+pub impl @lib.Write for FieldOptions with fn write(
   self : FieldOptions,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -5845,7 +5850,7 @@ pub impl @lib.Write for FieldOptions with write(
 }
 
 ///|
-pub impl ToJson for FieldOptions with to_json(self) {
+pub impl ToJson for FieldOptions with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.ctype {
     Some(v) if v != FieldOptions_CType::STRING => json["ctype"] = v.to_json()
@@ -5905,7 +5910,7 @@ pub impl ToJson for FieldOptions with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for FieldOptions with from_json(
+pub impl @json.FromJson for FieldOptions with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FieldOptions raise {
@@ -5938,14 +5943,14 @@ pub impl @json.FromJson for FieldOptions with from_json(
         message.feature_support = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) =>
         message.uninterpreted_option = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for FieldOptions with read_with_limit(
+pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldOptions raise {
   let msg = FieldOptions::default()
@@ -5974,7 +5979,14 @@ pub impl @lib.AsyncRead for FieldOptions with read_with_limit(
             |> @lib.async_read_enum()
             |> FieldOptions_OptionRetention::from_enum
             |> Some
-        (19, _) =>
+        (19, 2) => {
+          let packed = reader
+            |> @lib.async_read_packed(@lib.async_read_enum, None)
+          for item in packed {
+            msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
+          }
+        }
+        (19, 0) =>
           msg.targets.push(
             reader
             |> @lib.async_read_enum()
@@ -6006,7 +6018,7 @@ pub impl @lib.AsyncRead for FieldOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FieldOptions with write(
+pub impl @lib.AsyncWrite for FieldOptions with fn write(
   self : FieldOptions,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -6079,7 +6091,7 @@ pub(all) struct OneofOptions {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for OneofOptions with size_of(self) {
+pub impl @lib.Sized for OneofOptions with fn size_of(self) {
   let mut size = 0U
   if self.features is Some(v) {
     size += 1U +
@@ -6096,7 +6108,7 @@ pub impl @lib.Sized for OneofOptions with size_of(self) {
 }
 
 ///|
-pub impl Default for OneofOptions with default() -> OneofOptions {
+pub impl Default for OneofOptions with fn default() -> OneofOptions {
   OneofOptions::{ features: None, uninterpreted_option: [] }
 }
 
@@ -6109,7 +6121,7 @@ pub fn OneofOptions::new(
 }
 
 ///|
-pub impl @lib.Read for OneofOptions with read_with_limit(
+pub impl @lib.Read for OneofOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> OneofOptions raise {
   let msg = OneofOptions::default()
@@ -6133,7 +6145,7 @@ pub impl @lib.Read for OneofOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for OneofOptions with write(
+pub impl @lib.Write for OneofOptions with fn write(
   self : OneofOptions,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -6150,7 +6162,7 @@ pub impl @lib.Write for OneofOptions with write(
 }
 
 ///|
-pub impl ToJson for OneofOptions with to_json(self) {
+pub impl ToJson for OneofOptions with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.features {
     Some(v) => json["features"] = v.to_json()
@@ -6163,7 +6175,7 @@ pub impl ToJson for OneofOptions with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for OneofOptions with from_json(
+pub impl @json.FromJson for OneofOptions with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> OneofOptions raise {
@@ -6177,14 +6189,14 @@ pub impl @json.FromJson for OneofOptions with from_json(
         message.features = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) =>
         message.uninterpreted_option = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for OneofOptions with read_with_limit(
+pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> OneofOptions raise {
   let msg = OneofOptions::default()
@@ -6209,7 +6221,7 @@ pub impl @lib.AsyncRead for OneofOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for OneofOptions with write(
+pub impl @lib.AsyncWrite for OneofOptions with fn write(
   self : OneofOptions,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -6235,7 +6247,7 @@ pub(all) struct EnumOptions {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for EnumOptions with size_of(self) {
+pub impl @lib.Sized for EnumOptions with fn size_of(self) {
   let mut size = 0U
   if self.allow_alias is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -6261,7 +6273,7 @@ pub impl @lib.Sized for EnumOptions with size_of(self) {
 }
 
 ///|
-pub impl Default for EnumOptions with default() -> EnumOptions {
+pub impl Default for EnumOptions with fn default() -> EnumOptions {
   EnumOptions::{
     allow_alias: None,
     deprecated: Some(false),
@@ -6289,7 +6301,7 @@ pub fn EnumOptions::new(
 }
 
 ///|
-pub impl @lib.Read for EnumOptions with read_with_limit(
+pub impl @lib.Read for EnumOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumOptions raise {
   let msg = EnumOptions::default()
@@ -6319,7 +6331,7 @@ pub impl @lib.Read for EnumOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for EnumOptions with write(
+pub impl @lib.Write for EnumOptions with fn write(
   self : EnumOptions,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -6348,7 +6360,7 @@ pub impl @lib.Write for EnumOptions with write(
 }
 
 ///|
-pub impl ToJson for EnumOptions with to_json(self) {
+pub impl ToJson for EnumOptions with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.allow_alias {
     Some(v) => json["allowAlias"] = v.to_json()
@@ -6373,7 +6385,7 @@ pub impl ToJson for EnumOptions with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for EnumOptions with from_json(
+pub impl @json.FromJson for EnumOptions with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> EnumOptions raise {
@@ -6395,14 +6407,14 @@ pub impl @json.FromJson for EnumOptions with from_json(
         message.features = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) =>
         message.uninterpreted_option = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for EnumOptions with read_with_limit(
+pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumOptions raise {
   let msg = EnumOptions::default()
@@ -6433,7 +6445,7 @@ pub impl @lib.AsyncRead for EnumOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for EnumOptions with write(
+pub impl @lib.AsyncWrite for EnumOptions with fn write(
   self : EnumOptions,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -6471,7 +6483,7 @@ pub(all) struct EnumValueOptions {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for EnumValueOptions with size_of(self) {
+pub impl @lib.Sized for EnumValueOptions with fn size_of(self) {
   let mut size = 0U
   if self.deprecated is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -6501,7 +6513,7 @@ pub impl @lib.Sized for EnumValueOptions with size_of(self) {
 }
 
 ///|
-pub impl Default for EnumValueOptions with default() -> EnumValueOptions {
+pub impl Default for EnumValueOptions with fn default() -> EnumValueOptions {
   EnumValueOptions::{
     deprecated: Some(false),
     features: None,
@@ -6529,7 +6541,7 @@ pub fn EnumValueOptions::new(
 }
 
 ///|
-pub impl @lib.Read for EnumValueOptions with read_with_limit(
+pub impl @lib.Read for EnumValueOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
@@ -6559,7 +6571,7 @@ pub impl @lib.Read for EnumValueOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for EnumValueOptions with write(
+pub impl @lib.Write for EnumValueOptions with fn write(
   self : EnumValueOptions,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -6589,7 +6601,7 @@ pub impl @lib.Write for EnumValueOptions with write(
 }
 
 ///|
-pub impl ToJson for EnumValueOptions with to_json(self) {
+pub impl ToJson for EnumValueOptions with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.deprecated {
     Some(v) if v != false => json["deprecated"] = v.to_json()
@@ -6614,7 +6626,7 @@ pub impl ToJson for EnumValueOptions with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for EnumValueOptions with from_json(
+pub impl @json.FromJson for EnumValueOptions with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> EnumValueOptions raise {
@@ -6636,14 +6648,14 @@ pub impl @json.FromJson for EnumValueOptions with from_json(
         message.feature_support = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) =>
         message.uninterpreted_option = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for EnumValueOptions with read_with_limit(
+pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
@@ -6674,7 +6686,7 @@ pub impl @lib.AsyncRead for EnumValueOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for EnumValueOptions with write(
+pub impl @lib.AsyncWrite for EnumValueOptions with fn write(
   self : EnumValueOptions,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -6711,7 +6723,7 @@ pub(all) struct ServiceOptions {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for ServiceOptions with size_of(self) {
+pub impl @lib.Sized for ServiceOptions with fn size_of(self) {
   let mut size = 0U
   if self.features is Some(v) {
     size += 2U +
@@ -6731,7 +6743,7 @@ pub impl @lib.Sized for ServiceOptions with size_of(self) {
 }
 
 ///|
-pub impl Default for ServiceOptions with default() -> ServiceOptions {
+pub impl Default for ServiceOptions with fn default() -> ServiceOptions {
   ServiceOptions::{
     features: None,
     deprecated: Some(false),
@@ -6749,7 +6761,7 @@ pub fn ServiceOptions::new(
 }
 
 ///|
-pub impl @lib.Read for ServiceOptions with read_with_limit(
+pub impl @lib.Read for ServiceOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
@@ -6774,7 +6786,7 @@ pub impl @lib.Read for ServiceOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for ServiceOptions with write(
+pub impl @lib.Write for ServiceOptions with fn write(
   self : ServiceOptions,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -6795,7 +6807,7 @@ pub impl @lib.Write for ServiceOptions with write(
 }
 
 ///|
-pub impl ToJson for ServiceOptions with to_json(self) {
+pub impl ToJson for ServiceOptions with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.features {
     Some(v) => json["features"] = v.to_json()
@@ -6812,7 +6824,7 @@ pub impl ToJson for ServiceOptions with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for ServiceOptions with from_json(
+pub impl @json.FromJson for ServiceOptions with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> ServiceOptions raise {
@@ -6828,14 +6840,14 @@ pub impl @json.FromJson for ServiceOptions with from_json(
         message.deprecated = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) =>
         message.uninterpreted_option = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for ServiceOptions with read_with_limit(
+pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
@@ -6861,7 +6873,7 @@ pub impl @lib.AsyncRead for ServiceOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for ServiceOptions with write(
+pub impl @lib.AsyncWrite for ServiceOptions with fn write(
   self : ServiceOptions,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -6912,19 +6924,19 @@ pub fn MethodOptions_IdempotencyLevel::from_enum(
 }
 
 ///|
-pub impl Default for MethodOptions_IdempotencyLevel with default() -> MethodOptions_IdempotencyLevel {
+pub impl Default for MethodOptions_IdempotencyLevel with fn default() -> MethodOptions_IdempotencyLevel {
   MethodOptions_IdempotencyLevel::IDEMPOTENCY_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for MethodOptions_IdempotencyLevel with size_of(
+pub impl @lib.Sized for MethodOptions_IdempotencyLevel with fn size_of(
   self : MethodOptions_IdempotencyLevel,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for MethodOptions_IdempotencyLevel with from_json(
+pub impl @json.FromJson for MethodOptions_IdempotencyLevel with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> MethodOptions_IdempotencyLevel raise {
@@ -6944,7 +6956,7 @@ pub impl @json.FromJson for MethodOptions_IdempotencyLevel with from_json(
 }
 
 ///|
-pub impl ToJson for MethodOptions_IdempotencyLevel with to_json(
+pub impl ToJson for MethodOptions_IdempotencyLevel with fn to_json(
   self : MethodOptions_IdempotencyLevel,
 ) -> Json {
   match self {
@@ -6963,7 +6975,7 @@ pub(all) struct MethodOptions {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for MethodOptions with size_of(self) {
+pub impl @lib.Sized for MethodOptions with fn size_of(self) {
   let mut size = 0U
   if self.deprecated is Some(v) {
     size += 2U + @lib.size_of(v)
@@ -6986,7 +6998,7 @@ pub impl @lib.Sized for MethodOptions with size_of(self) {
 }
 
 ///|
-pub impl Default for MethodOptions with default() -> MethodOptions {
+pub impl Default for MethodOptions with fn default() -> MethodOptions {
   MethodOptions::{
     deprecated: Some(false),
     idempotency_level: Some(MethodOptions_IdempotencyLevel::IDEMPOTENCY_UNKNOWN),
@@ -7011,7 +7023,7 @@ pub fn MethodOptions::new(
 }
 
 ///|
-pub impl @lib.Read for MethodOptions with read_with_limit(
+pub impl @lib.Read for MethodOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MethodOptions raise {
   let msg = MethodOptions::default()
@@ -7041,7 +7053,7 @@ pub impl @lib.Read for MethodOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for MethodOptions with write(
+pub impl @lib.Write for MethodOptions with fn write(
   self : MethodOptions,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -7066,7 +7078,7 @@ pub impl @lib.Write for MethodOptions with write(
 }
 
 ///|
-pub impl ToJson for MethodOptions with to_json(self) {
+pub impl ToJson for MethodOptions with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.deprecated {
     Some(v) if v != false => json["deprecated"] = v.to_json()
@@ -7088,7 +7100,7 @@ pub impl ToJson for MethodOptions with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for MethodOptions with from_json(
+pub impl @json.FromJson for MethodOptions with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> MethodOptions raise {
@@ -7106,14 +7118,14 @@ pub impl @json.FromJson for MethodOptions with from_json(
         message.features = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) =>
         message.uninterpreted_option = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for MethodOptions with read_with_limit(
+pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MethodOptions raise {
   let msg = MethodOptions::default()
@@ -7144,7 +7156,7 @@ pub impl @lib.AsyncRead for MethodOptions with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for MethodOptions with write(
+pub impl @lib.AsyncWrite for MethodOptions with fn write(
   self : MethodOptions,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -7175,7 +7187,7 @@ pub(all) struct UninterpretedOption_NamePart {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for UninterpretedOption_NamePart with size_of(self) {
+pub impl @lib.Sized for UninterpretedOption_NamePart with fn size_of(self) {
   let mut size = 0U
   size += 1U +
     ({
@@ -7187,7 +7199,7 @@ pub impl @lib.Sized for UninterpretedOption_NamePart with size_of(self) {
 }
 
 ///|
-pub impl Default for UninterpretedOption_NamePart with default() -> UninterpretedOption_NamePart {
+pub impl Default for UninterpretedOption_NamePart with fn default() -> UninterpretedOption_NamePart {
   UninterpretedOption_NamePart::{
     name_part: String::default(),
     is_extension: Bool::default(),
@@ -7203,7 +7215,7 @@ pub fn UninterpretedOption_NamePart::new(
 }
 
 ///|
-pub impl @lib.Read for UninterpretedOption_NamePart with read_with_limit(
+pub impl @lib.Read for UninterpretedOption_NamePart with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
@@ -7223,7 +7235,7 @@ pub impl @lib.Read for UninterpretedOption_NamePart with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for UninterpretedOption_NamePart with write(
+pub impl @lib.Write for UninterpretedOption_NamePart with fn write(
   self : UninterpretedOption_NamePart,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -7234,7 +7246,7 @@ pub impl @lib.Write for UninterpretedOption_NamePart with write(
 }
 
 ///|
-pub impl ToJson for UninterpretedOption_NamePart with to_json(self) {
+pub impl ToJson for UninterpretedOption_NamePart with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.name_part != Default::default() {
     json["namePart"] = self.name_part.to_json()
@@ -7246,7 +7258,7 @@ pub impl ToJson for UninterpretedOption_NamePart with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for UninterpretedOption_NamePart with from_json(
+pub impl @json.FromJson for UninterpretedOption_NamePart with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> UninterpretedOption_NamePart raise {
@@ -7261,14 +7273,14 @@ pub impl @json.FromJson for UninterpretedOption_NamePart with from_json(
       ("namePart", value) => message.name_part = @json.from_json(value, path~)
       ("isExtension", value) =>
         message.is_extension = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for UninterpretedOption_NamePart with read_with_limit(
+pub impl @lib.AsyncRead for UninterpretedOption_NamePart with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
@@ -7288,7 +7300,7 @@ pub impl @lib.AsyncRead for UninterpretedOption_NamePart with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for UninterpretedOption_NamePart with write(
+pub impl @lib.AsyncWrite for UninterpretedOption_NamePart with fn write(
   self : UninterpretedOption_NamePart,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -7310,7 +7322,7 @@ pub(all) struct UninterpretedOption {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for UninterpretedOption with size_of(self) {
+pub impl @lib.Sized for UninterpretedOption with fn size_of(self) {
   let mut size = 0U
   for s in self.name {
     let s = @lib.size_of(s)
@@ -7350,7 +7362,7 @@ pub impl @lib.Sized for UninterpretedOption with size_of(self) {
 }
 
 ///|
-pub impl Default for UninterpretedOption with default() -> UninterpretedOption {
+pub impl Default for UninterpretedOption with fn default() -> UninterpretedOption {
   UninterpretedOption::{
     name: [],
     identifier_value: None,
@@ -7384,7 +7396,7 @@ pub fn UninterpretedOption::new(
 }
 
 ///|
-pub impl @lib.Read for UninterpretedOption with read_with_limit(
+pub impl @lib.Read for UninterpretedOption with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
@@ -7412,7 +7424,7 @@ pub impl @lib.Read for UninterpretedOption with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for UninterpretedOption with write(
+pub impl @lib.Write for UninterpretedOption with fn write(
   self : UninterpretedOption,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -7448,7 +7460,7 @@ pub impl @lib.Write for UninterpretedOption with write(
 }
 
 ///|
-pub impl ToJson for UninterpretedOption with to_json(self) {
+pub impl ToJson for UninterpretedOption with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.name != Default::default() {
     json["name"] = self.name.to_json()
@@ -7481,7 +7493,7 @@ pub impl ToJson for UninterpretedOption with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for UninterpretedOption with from_json(
+pub impl @json.FromJson for UninterpretedOption with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> UninterpretedOption raise {
@@ -7507,14 +7519,14 @@ pub impl @json.FromJson for UninterpretedOption with from_json(
         message.string_value = Some(@lib.base64_decode(value))
       ("aggregateValue", value) =>
         message.aggregate_value = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for UninterpretedOption with read_with_limit(
+pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
@@ -7546,7 +7558,7 @@ pub impl @lib.AsyncRead for UninterpretedOption with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for UninterpretedOption with write(
+pub impl @lib.AsyncWrite for UninterpretedOption with fn write(
   self : UninterpretedOption,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -7615,19 +7627,19 @@ pub fn FeatureSet_FieldPresence::from_enum(
 }
 
 ///|
-pub impl Default for FeatureSet_FieldPresence with default() -> FeatureSet_FieldPresence {
+pub impl Default for FeatureSet_FieldPresence with fn default() -> FeatureSet_FieldPresence {
   FeatureSet_FieldPresence::FIELD_PRESENCE_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for FeatureSet_FieldPresence with size_of(
+pub impl @lib.Sized for FeatureSet_FieldPresence with fn size_of(
   self : FeatureSet_FieldPresence,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FeatureSet_FieldPresence with from_json(
+pub impl @json.FromJson for FeatureSet_FieldPresence with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FeatureSet_FieldPresence raise {
@@ -7649,7 +7661,7 @@ pub impl @json.FromJson for FeatureSet_FieldPresence with from_json(
 }
 
 ///|
-pub impl ToJson for FeatureSet_FieldPresence with to_json(
+pub impl ToJson for FeatureSet_FieldPresence with fn to_json(
   self : FeatureSet_FieldPresence,
 ) -> Json {
   match self {
@@ -7687,19 +7699,19 @@ pub fn FeatureSet_EnumType::from_enum(i : @lib.Enum) -> FeatureSet_EnumType {
 }
 
 ///|
-pub impl Default for FeatureSet_EnumType with default() -> FeatureSet_EnumType {
+pub impl Default for FeatureSet_EnumType with fn default() -> FeatureSet_EnumType {
   FeatureSet_EnumType::ENUM_TYPE_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for FeatureSet_EnumType with size_of(
+pub impl @lib.Sized for FeatureSet_EnumType with fn size_of(
   self : FeatureSet_EnumType,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FeatureSet_EnumType with from_json(
+pub impl @json.FromJson for FeatureSet_EnumType with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FeatureSet_EnumType raise {
@@ -7718,7 +7730,9 @@ pub impl @json.FromJson for FeatureSet_EnumType with from_json(
 }
 
 ///|
-pub impl ToJson for FeatureSet_EnumType with to_json(self : FeatureSet_EnumType) -> Json {
+pub impl ToJson for FeatureSet_EnumType with fn to_json(
+  self : FeatureSet_EnumType,
+) -> Json {
   match self {
     FeatureSet_EnumType::ENUM_TYPE_UNKNOWN => "ENUM_TYPE_UNKNOWN"
     FeatureSet_EnumType::OPEN => "OPEN"
@@ -7757,19 +7771,19 @@ pub fn FeatureSet_RepeatedFieldEncoding::from_enum(
 }
 
 ///|
-pub impl Default for FeatureSet_RepeatedFieldEncoding with default() -> FeatureSet_RepeatedFieldEncoding {
+pub impl Default for FeatureSet_RepeatedFieldEncoding with fn default() -> FeatureSet_RepeatedFieldEncoding {
   FeatureSet_RepeatedFieldEncoding::REPEATED_FIELD_ENCODING_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for FeatureSet_RepeatedFieldEncoding with size_of(
+pub impl @lib.Sized for FeatureSet_RepeatedFieldEncoding with fn size_of(
   self : FeatureSet_RepeatedFieldEncoding,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FeatureSet_RepeatedFieldEncoding with from_json(
+pub impl @json.FromJson for FeatureSet_RepeatedFieldEncoding with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FeatureSet_RepeatedFieldEncoding raise {
@@ -7790,7 +7804,7 @@ pub impl @json.FromJson for FeatureSet_RepeatedFieldEncoding with from_json(
 }
 
 ///|
-pub impl ToJson for FeatureSet_RepeatedFieldEncoding with to_json(
+pub impl ToJson for FeatureSet_RepeatedFieldEncoding with fn to_json(
   self : FeatureSet_RepeatedFieldEncoding,
 ) -> Json {
   match self {
@@ -7832,19 +7846,19 @@ pub fn FeatureSet_Utf8Validation::from_enum(
 }
 
 ///|
-pub impl Default for FeatureSet_Utf8Validation with default() -> FeatureSet_Utf8Validation {
+pub impl Default for FeatureSet_Utf8Validation with fn default() -> FeatureSet_Utf8Validation {
   FeatureSet_Utf8Validation::UTF8_VALIDATION_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for FeatureSet_Utf8Validation with size_of(
+pub impl @lib.Sized for FeatureSet_Utf8Validation with fn size_of(
   self : FeatureSet_Utf8Validation,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FeatureSet_Utf8Validation with from_json(
+pub impl @json.FromJson for FeatureSet_Utf8Validation with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FeatureSet_Utf8Validation raise {
@@ -7864,7 +7878,7 @@ pub impl @json.FromJson for FeatureSet_Utf8Validation with from_json(
 }
 
 ///|
-pub impl ToJson for FeatureSet_Utf8Validation with to_json(
+pub impl ToJson for FeatureSet_Utf8Validation with fn to_json(
   self : FeatureSet_Utf8Validation,
 ) -> Json {
   match self {
@@ -7906,19 +7920,19 @@ pub fn FeatureSet_MessageEncoding::from_enum(
 }
 
 ///|
-pub impl Default for FeatureSet_MessageEncoding with default() -> FeatureSet_MessageEncoding {
+pub impl Default for FeatureSet_MessageEncoding with fn default() -> FeatureSet_MessageEncoding {
   FeatureSet_MessageEncoding::MESSAGE_ENCODING_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for FeatureSet_MessageEncoding with size_of(
+pub impl @lib.Sized for FeatureSet_MessageEncoding with fn size_of(
   self : FeatureSet_MessageEncoding,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FeatureSet_MessageEncoding with from_json(
+pub impl @json.FromJson for FeatureSet_MessageEncoding with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FeatureSet_MessageEncoding raise {
@@ -7938,7 +7952,7 @@ pub impl @json.FromJson for FeatureSet_MessageEncoding with from_json(
 }
 
 ///|
-pub impl ToJson for FeatureSet_MessageEncoding with to_json(
+pub impl ToJson for FeatureSet_MessageEncoding with fn to_json(
   self : FeatureSet_MessageEncoding,
 ) -> Json {
   match self {
@@ -7978,19 +7992,19 @@ pub fn FeatureSet_JsonFormat::from_enum(i : @lib.Enum) -> FeatureSet_JsonFormat 
 }
 
 ///|
-pub impl Default for FeatureSet_JsonFormat with default() -> FeatureSet_JsonFormat {
+pub impl Default for FeatureSet_JsonFormat with fn default() -> FeatureSet_JsonFormat {
   FeatureSet_JsonFormat::JSON_FORMAT_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for FeatureSet_JsonFormat with size_of(
+pub impl @lib.Sized for FeatureSet_JsonFormat with fn size_of(
   self : FeatureSet_JsonFormat,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FeatureSet_JsonFormat with from_json(
+pub impl @json.FromJson for FeatureSet_JsonFormat with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FeatureSet_JsonFormat raise {
@@ -8009,7 +8023,7 @@ pub impl @json.FromJson for FeatureSet_JsonFormat with from_json(
 }
 
 ///|
-pub impl ToJson for FeatureSet_JsonFormat with to_json(
+pub impl ToJson for FeatureSet_JsonFormat with fn to_json(
   self : FeatureSet_JsonFormat,
 ) -> Json {
   match self {
@@ -8050,19 +8064,19 @@ pub fn FeatureSet_EnforceNamingStyle::from_enum(
 }
 
 ///|
-pub impl Default for FeatureSet_EnforceNamingStyle with default() -> FeatureSet_EnforceNamingStyle {
+pub impl Default for FeatureSet_EnforceNamingStyle with fn default() -> FeatureSet_EnforceNamingStyle {
   FeatureSet_EnforceNamingStyle::ENFORCE_NAMING_STYLE_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for FeatureSet_EnforceNamingStyle with size_of(
+pub impl @lib.Sized for FeatureSet_EnforceNamingStyle with fn size_of(
   self : FeatureSet_EnforceNamingStyle,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FeatureSet_EnforceNamingStyle with from_json(
+pub impl @json.FromJson for FeatureSet_EnforceNamingStyle with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FeatureSet_EnforceNamingStyle raise {
@@ -8082,7 +8096,7 @@ pub impl @json.FromJson for FeatureSet_EnforceNamingStyle with from_json(
 }
 
 ///|
-pub impl ToJson for FeatureSet_EnforceNamingStyle with to_json(
+pub impl ToJson for FeatureSet_EnforceNamingStyle with fn to_json(
   self : FeatureSet_EnforceNamingStyle,
 ) -> Json {
   match self {
@@ -8132,19 +8146,19 @@ pub fn FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum(
 }
 
 ///|
-pub impl Default for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with default() -> FeatureSet_VisibilityFeature_DefaultSymbolVisibility {
+pub impl Default for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with fn default() -> FeatureSet_VisibilityFeature_DefaultSymbolVisibility {
   FeatureSet_VisibilityFeature_DefaultSymbolVisibility::DEFAULT_SYMBOL_VISIBILITY_UNKNOWN
 }
 
 ///|
-pub impl @lib.Sized for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with size_of(
+pub impl @lib.Sized for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with fn size_of(
   self : FeatureSet_VisibilityFeature_DefaultSymbolVisibility,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with from_json(
+pub impl @json.FromJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FeatureSet_VisibilityFeature_DefaultSymbolVisibility raise {
@@ -8177,7 +8191,7 @@ pub impl @json.FromJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility
 }
 
 ///|
-pub impl ToJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with to_json(
+pub impl ToJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with fn to_json(
   self : FeatureSet_VisibilityFeature_DefaultSymbolVisibility,
 ) -> Json {
   match self {
@@ -8197,12 +8211,12 @@ pub impl ToJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with to
 pub(all) struct FeatureSet_VisibilityFeature {} derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FeatureSet_VisibilityFeature with size_of(_) {
+pub impl @lib.Sized for FeatureSet_VisibilityFeature with fn size_of(_) {
   0
 }
 
 ///|
-pub impl Default for FeatureSet_VisibilityFeature with default() -> FeatureSet_VisibilityFeature {
+pub impl Default for FeatureSet_VisibilityFeature with fn default() -> FeatureSet_VisibilityFeature {
   FeatureSet_VisibilityFeature::{  }
 }
 
@@ -8212,32 +8226,34 @@ pub fn FeatureSet_VisibilityFeature::new() -> FeatureSet_VisibilityFeature {
 }
 
 ///|
-pub impl @lib.Read for FeatureSet_VisibilityFeature with read_with_limit(_) -> FeatureSet_VisibilityFeature noraise {
+pub impl @lib.Read for FeatureSet_VisibilityFeature with fn read_with_limit(_) -> FeatureSet_VisibilityFeature noraise {
   FeatureSet_VisibilityFeature::default()
 }
 
 ///|
-pub impl @lib.Write for FeatureSet_VisibilityFeature with write(_, _) -> Unit noraise {
+pub impl @lib.Write for FeatureSet_VisibilityFeature with fn write(_, _) -> Unit noraise {
 
 }
 
 ///|
-pub impl ToJson for FeatureSet_VisibilityFeature with to_json(_) {
+pub impl ToJson for FeatureSet_VisibilityFeature with fn to_json(_) {
   {}
 }
 
 ///|
-pub impl @json.FromJson for FeatureSet_VisibilityFeature with from_json(_, _) -> FeatureSet_VisibilityFeature noraise {
+pub impl @json.FromJson for FeatureSet_VisibilityFeature with fn from_json(_, _) -> FeatureSet_VisibilityFeature noraise {
   FeatureSet_VisibilityFeature::default()
 }
 
 ///|
-pub impl @lib.AsyncRead for FeatureSet_VisibilityFeature with read_with_limit(_) -> FeatureSet_VisibilityFeature noraise {
+pub impl @lib.AsyncRead for FeatureSet_VisibilityFeature with fn read_with_limit(
+  _,
+) -> FeatureSet_VisibilityFeature noraise {
   FeatureSet_VisibilityFeature::default()
 }
 
 ///|
-pub impl @lib.AsyncWrite for FeatureSet_VisibilityFeature with write(_, _) -> Unit noraise {
+pub impl @lib.AsyncWrite for FeatureSet_VisibilityFeature with fn write(_, _) -> Unit noraise {
 
 }
 
@@ -8254,7 +8270,7 @@ pub(all) struct FeatureSet {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FeatureSet with size_of(self) {
+pub impl @lib.Sized for FeatureSet with fn size_of(self) {
   let mut size = 0U
   if self.field_presence is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -8284,7 +8300,7 @@ pub impl @lib.Sized for FeatureSet with size_of(self) {
 }
 
 ///|
-pub impl Default for FeatureSet with default() -> FeatureSet {
+pub impl Default for FeatureSet with fn default() -> FeatureSet {
   FeatureSet::{
     field_presence: None,
     enum_type: None,
@@ -8321,7 +8337,7 @@ pub fn FeatureSet::new(
 }
 
 ///|
-pub impl @lib.Read for FeatureSet with read_with_limit(
+pub impl @lib.Read for FeatureSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FeatureSet raise {
   let msg = FeatureSet::default()
@@ -8379,7 +8395,7 @@ pub impl @lib.Read for FeatureSet with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FeatureSet with write(
+pub impl @lib.Write for FeatureSet with fn write(
   self : FeatureSet,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -8418,7 +8434,7 @@ pub impl @lib.Write for FeatureSet with write(
 }
 
 ///|
-pub impl ToJson for FeatureSet with to_json(self) {
+pub impl ToJson for FeatureSet with fn to_json(self) {
   let json : Map[String, Json] = {}
   match self.field_presence {
     Some(v) => json["fieldPresence"] = v.to_json()
@@ -8456,7 +8472,7 @@ pub impl ToJson for FeatureSet with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for FeatureSet with from_json(
+pub impl @json.FromJson for FeatureSet with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FeatureSet raise {
@@ -8482,14 +8498,14 @@ pub impl @json.FromJson for FeatureSet with from_json(
         message.enforce_naming_style = Some(@json.from_json(value, path~))
       ("defaultSymbolVisibility", value) =>
         message.default_symbol_visibility = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for FeatureSet with read_with_limit(
+pub impl @lib.AsyncRead for FeatureSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FeatureSet raise {
   let msg = FeatureSet::default()
@@ -8547,7 +8563,7 @@ pub impl @lib.AsyncRead for FeatureSet with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FeatureSet with write(
+pub impl @lib.AsyncWrite for FeatureSet with fn write(
   self : FeatureSet,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -8593,7 +8609,7 @@ pub(all) struct FeatureSetDefaults_FeatureSetEditionDefault {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FeatureSetDefaults_FeatureSetEditionDefault with size_of(
+pub impl @lib.Sized for FeatureSetDefaults_FeatureSetEditionDefault with fn size_of(
   self,
 ) {
   let mut size = 0U
@@ -8618,7 +8634,7 @@ pub impl @lib.Sized for FeatureSetDefaults_FeatureSetEditionDefault with size_of
 }
 
 ///|
-pub impl Default for FeatureSetDefaults_FeatureSetEditionDefault with default() -> FeatureSetDefaults_FeatureSetEditionDefault {
+pub impl Default for FeatureSetDefaults_FeatureSetEditionDefault with fn default() -> FeatureSetDefaults_FeatureSetEditionDefault {
   FeatureSetDefaults_FeatureSetEditionDefault::{
     edition: None,
     overridable_features: None,
@@ -8640,7 +8656,7 @@ pub fn FeatureSetDefaults_FeatureSetEditionDefault::new(
 }
 
 ///|
-pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with read_with_limit(
+pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
@@ -8666,7 +8682,7 @@ pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with read_wit
 }
 
 ///|
-pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with write(
+pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with fn write(
   self : FeatureSetDefaults_FeatureSetEditionDefault,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -8687,7 +8703,7 @@ pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with write(
 }
 
 ///|
-pub impl ToJson for FeatureSetDefaults_FeatureSetEditionDefault with to_json(
+pub impl ToJson for FeatureSetDefaults_FeatureSetEditionDefault with fn to_json(
   self,
 ) {
   let json : Map[String, Json] = {}
@@ -8707,7 +8723,7 @@ pub impl ToJson for FeatureSetDefaults_FeatureSetEditionDefault with to_json(
 }
 
 ///|
-pub impl @json.FromJson for FeatureSetDefaults_FeatureSetEditionDefault with from_json(
+pub impl @json.FromJson for FeatureSetDefaults_FeatureSetEditionDefault with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
@@ -8727,14 +8743,14 @@ pub impl @json.FromJson for FeatureSetDefaults_FeatureSetEditionDefault with fro
         message.overridable_features = Some(@json.from_json(value, path~))
       ("fixedFeatures", value) =>
         message.fixed_features = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with read_with_limit(
+pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
@@ -8764,7 +8780,7 @@ pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with rea
 }
 
 ///|
-pub impl @lib.AsyncWrite for FeatureSetDefaults_FeatureSetEditionDefault with write(
+pub impl @lib.AsyncWrite for FeatureSetDefaults_FeatureSetEditionDefault with fn write(
   self : FeatureSetDefaults_FeatureSetEditionDefault,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -8792,7 +8808,7 @@ pub(all) struct FeatureSetDefaults {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for FeatureSetDefaults with size_of(self) {
+pub impl @lib.Sized for FeatureSetDefaults with fn size_of(self) {
   let mut size = 0U
   for s in self.defaults {
     let s = @lib.size_of(s)
@@ -8808,7 +8824,7 @@ pub impl @lib.Sized for FeatureSetDefaults with size_of(self) {
 }
 
 ///|
-pub impl Default for FeatureSetDefaults with default() -> FeatureSetDefaults {
+pub impl Default for FeatureSetDefaults with fn default() -> FeatureSetDefaults {
   FeatureSetDefaults::{
     defaults: [],
     minimum_edition: None,
@@ -8826,7 +8842,7 @@ pub fn FeatureSetDefaults::new(
 }
 
 ///|
-pub impl @lib.Read for FeatureSetDefaults with read_with_limit(
+pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
@@ -8860,7 +8876,7 @@ pub impl @lib.Read for FeatureSetDefaults with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for FeatureSetDefaults with write(
+pub impl @lib.Write for FeatureSetDefaults with fn write(
   self : FeatureSetDefaults,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -8880,7 +8896,7 @@ pub impl @lib.Write for FeatureSetDefaults with write(
 }
 
 ///|
-pub impl ToJson for FeatureSetDefaults with to_json(self) {
+pub impl ToJson for FeatureSetDefaults with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.defaults != Default::default() {
     json["defaults"] = self.defaults.to_json()
@@ -8897,7 +8913,7 @@ pub impl ToJson for FeatureSetDefaults with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for FeatureSetDefaults with from_json(
+pub impl @json.FromJson for FeatureSetDefaults with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> FeatureSetDefaults raise {
@@ -8915,14 +8931,14 @@ pub impl @json.FromJson for FeatureSetDefaults with from_json(
         message.minimum_edition = Some(@json.from_json(value, path~))
       ("maximumEdition", value) =>
         message.maximum_edition = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for FeatureSetDefaults with read_with_limit(
+pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
@@ -8956,7 +8972,7 @@ pub impl @lib.AsyncRead for FeatureSetDefaults with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for FeatureSetDefaults with write(
+pub impl @lib.AsyncWrite for FeatureSetDefaults with fn write(
   self : FeatureSetDefaults,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -8985,22 +9001,18 @@ pub(all) struct SourceCodeInfo_Location {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for SourceCodeInfo_Location with size_of(self) {
+pub impl @lib.Sized for SourceCodeInfo_Location with fn size_of(self) {
   let mut size = 0U
-  size += {
-    let mut size = 1U
-    for v in self.path {
-      size += @lib.size_of(v)
-    }
-    @lib.size_of(size) + size
-  }
-  size += {
-    let mut size = 1U
-    for v in self.span {
-      size += @lib.size_of(v)
-    }
-    @lib.size_of(size) + size
-  }
+  size += 1U +
+    ({
+      let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+      @lib.size_of(size) + size
+    })
+  size += 1U +
+    ({
+      let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+      @lib.size_of(size) + size
+    })
   if self.leading_comments is Some(v) {
     size += 1U +
       ({
@@ -9023,7 +9035,7 @@ pub impl @lib.Sized for SourceCodeInfo_Location with size_of(self) {
 }
 
 ///|
-pub impl Default for SourceCodeInfo_Location with default() -> SourceCodeInfo_Location {
+pub impl Default for SourceCodeInfo_Location with fn default() -> SourceCodeInfo_Location {
   SourceCodeInfo_Location::{
     path: [],
     span: [],
@@ -9051,21 +9063,23 @@ pub fn SourceCodeInfo_Location::new(
 }
 
 ///|
-pub impl @lib.Read for SourceCodeInfo_Location with read_with_limit(
+pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
   try {
     for ;; {
       match (reader |> @lib.read_tag()) {
-        (1, _) =>
+        (1, 2) =>
           msg.path.push_iter(
             (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
           )
-        (2, _) =>
+        (1, 0) => msg.path.push(reader |> @lib.read_int32())
+        (2, 2) =>
           msg.span.push_iter(
             (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
           )
+        (2, 0) => msg.span.push(reader |> @lib.read_int32())
         (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
         (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
         (6, _) =>
@@ -9081,7 +9095,7 @@ pub impl @lib.Read for SourceCodeInfo_Location with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for SourceCodeInfo_Location with write(
+pub impl @lib.Write for SourceCodeInfo_Location with fn write(
   self : SourceCodeInfo_Location,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -9112,7 +9126,7 @@ pub impl @lib.Write for SourceCodeInfo_Location with write(
 }
 
 ///|
-pub impl ToJson for SourceCodeInfo_Location with to_json(self) {
+pub impl ToJson for SourceCodeInfo_Location with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.path != Default::default() {
     json["path"] = self.path.to_json()
@@ -9135,7 +9149,7 @@ pub impl ToJson for SourceCodeInfo_Location with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for SourceCodeInfo_Location with from_json(
+pub impl @json.FromJson for SourceCodeInfo_Location with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> SourceCodeInfo_Location raise {
@@ -9159,28 +9173,30 @@ pub impl @json.FromJson for SourceCodeInfo_Location with from_json(
         message.leading_detached_comments = value.map(v => {
           @json.from_json(v, path~)
         })
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for SourceCodeInfo_Location with read_with_limit(
+pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
   try {
     for ;; {
       match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
+        (1, 2) =>
           msg.path.push_iter(
             (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
           )
-        (2, _) =>
+        (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+        (2, 2) =>
           msg.span.push_iter(
             (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
           )
+        (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
         (3, _) =>
           msg.leading_comments = reader |> @lib.async_read_string() |> Some
         (4, _) =>
@@ -9198,7 +9214,7 @@ pub impl @lib.AsyncRead for SourceCodeInfo_Location with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for SourceCodeInfo_Location with write(
+pub impl @lib.AsyncWrite for SourceCodeInfo_Location with fn write(
   self : SourceCodeInfo_Location,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -9234,7 +9250,7 @@ pub(all) struct SourceCodeInfo {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for SourceCodeInfo with size_of(self) {
+pub impl @lib.Sized for SourceCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.location {
     let s = @lib.size_of(s)
@@ -9244,7 +9260,7 @@ pub impl @lib.Sized for SourceCodeInfo with size_of(self) {
 }
 
 ///|
-pub impl Default for SourceCodeInfo with default() -> SourceCodeInfo {
+pub impl Default for SourceCodeInfo with fn default() -> SourceCodeInfo {
   SourceCodeInfo::{ location: [] }
 }
 
@@ -9256,7 +9272,7 @@ pub fn SourceCodeInfo::new(
 }
 
 ///|
-pub impl @lib.Read for SourceCodeInfo with read_with_limit(
+pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
@@ -9278,7 +9294,7 @@ pub impl @lib.Read for SourceCodeInfo with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for SourceCodeInfo with write(
+pub impl @lib.Write for SourceCodeInfo with fn write(
   self : SourceCodeInfo,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -9290,7 +9306,7 @@ pub impl @lib.Write for SourceCodeInfo with write(
 }
 
 ///|
-pub impl ToJson for SourceCodeInfo with to_json(self) {
+pub impl ToJson for SourceCodeInfo with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.location != Default::default() {
     json["location"] = self.location.to_json()
@@ -9299,7 +9315,7 @@ pub impl ToJson for SourceCodeInfo with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for SourceCodeInfo with from_json(
+pub impl @json.FromJson for SourceCodeInfo with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> SourceCodeInfo raise {
@@ -9311,14 +9327,14 @@ pub impl @json.FromJson for SourceCodeInfo with from_json(
     match (key, value) {
       ("location", Array(value)) =>
         message.location = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for SourceCodeInfo with read_with_limit(
+pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
@@ -9340,7 +9356,7 @@ pub impl @lib.AsyncRead for SourceCodeInfo with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for SourceCodeInfo with write(
+pub impl @lib.AsyncWrite for SourceCodeInfo with fn write(
   self : SourceCodeInfo,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -9382,19 +9398,19 @@ pub fn GeneratedCodeInfo_Annotation_Semantic::from_enum(
 }
 
 ///|
-pub impl Default for GeneratedCodeInfo_Annotation_Semantic with default() -> GeneratedCodeInfo_Annotation_Semantic {
+pub impl Default for GeneratedCodeInfo_Annotation_Semantic with fn default() -> GeneratedCodeInfo_Annotation_Semantic {
   GeneratedCodeInfo_Annotation_Semantic::NONE
 }
 
 ///|
-pub impl @lib.Sized for GeneratedCodeInfo_Annotation_Semantic with size_of(
+pub impl @lib.Sized for GeneratedCodeInfo_Annotation_Semantic with fn size_of(
   self : GeneratedCodeInfo_Annotation_Semantic,
 ) {
   @lib.Sized::size_of(self.to_enum())
 }
 
 ///|
-pub impl @json.FromJson for GeneratedCodeInfo_Annotation_Semantic with from_json(
+pub impl @json.FromJson for GeneratedCodeInfo_Annotation_Semantic with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> GeneratedCodeInfo_Annotation_Semantic raise {
@@ -9413,7 +9429,7 @@ pub impl @json.FromJson for GeneratedCodeInfo_Annotation_Semantic with from_json
 }
 
 ///|
-pub impl ToJson for GeneratedCodeInfo_Annotation_Semantic with to_json(
+pub impl ToJson for GeneratedCodeInfo_Annotation_Semantic with fn to_json(
   self : GeneratedCodeInfo_Annotation_Semantic,
 ) -> Json {
   match self {
@@ -9433,15 +9449,13 @@ pub(all) struct GeneratedCodeInfo_Annotation {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for GeneratedCodeInfo_Annotation with size_of(self) {
+pub impl @lib.Sized for GeneratedCodeInfo_Annotation with fn size_of(self) {
   let mut size = 0U
-  size += {
-    let mut size = 1U
-    for v in self.path {
-      size += @lib.size_of(v)
-    }
-    @lib.size_of(size) + size
-  }
+  size += 1U +
+    ({
+      let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+      @lib.size_of(size) + size
+    })
   if self.source_file is Some(v) {
     size += 1U +
       ({
@@ -9462,7 +9476,7 @@ pub impl @lib.Sized for GeneratedCodeInfo_Annotation with size_of(self) {
 }
 
 ///|
-pub impl Default for GeneratedCodeInfo_Annotation with default() -> GeneratedCodeInfo_Annotation {
+pub impl Default for GeneratedCodeInfo_Annotation with fn default() -> GeneratedCodeInfo_Annotation {
   GeneratedCodeInfo_Annotation::{
     path: [],
     source_file: None,
@@ -9484,17 +9498,18 @@ pub fn GeneratedCodeInfo_Annotation::new(
 }
 
 ///|
-pub impl @lib.Read for GeneratedCodeInfo_Annotation with read_with_limit(
+pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
   try {
     for ;; {
       match (reader |> @lib.read_tag()) {
-        (1, _) =>
+        (1, 2) =>
           msg.path.push_iter(
             (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
           )
+        (1, 0) => msg.path.push(reader |> @lib.read_int32())
         (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
         (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
         (4, _) => msg.end = reader |> @lib.read_int32() |> Some
@@ -9514,7 +9529,7 @@ pub impl @lib.Read for GeneratedCodeInfo_Annotation with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for GeneratedCodeInfo_Annotation with write(
+pub impl @lib.Write for GeneratedCodeInfo_Annotation with fn write(
   self : GeneratedCodeInfo_Annotation,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -9543,7 +9558,7 @@ pub impl @lib.Write for GeneratedCodeInfo_Annotation with write(
 }
 
 ///|
-pub impl ToJson for GeneratedCodeInfo_Annotation with to_json(self) {
+pub impl ToJson for GeneratedCodeInfo_Annotation with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.path != Default::default() {
     json["path"] = self.path.to_json()
@@ -9568,7 +9583,7 @@ pub impl ToJson for GeneratedCodeInfo_Annotation with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for GeneratedCodeInfo_Annotation with from_json(
+pub impl @json.FromJson for GeneratedCodeInfo_Annotation with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> GeneratedCodeInfo_Annotation raise {
@@ -9588,24 +9603,25 @@ pub impl @json.FromJson for GeneratedCodeInfo_Annotation with from_json(
       ("end", value) => message.end = Some(@json.from_json(value, path~))
       ("semantic", value) =>
         message.semantic = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with read_with_limit(
+pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
   try {
     for ;; {
       match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
+        (1, 2) =>
           msg.path.push_iter(
             (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
           )
+        (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
         (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
         (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
         (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
@@ -9625,7 +9641,7 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for GeneratedCodeInfo_Annotation with write(
+pub impl @lib.AsyncWrite for GeneratedCodeInfo_Annotation with fn write(
   self : GeneratedCodeInfo_Annotation,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
@@ -9659,7 +9675,7 @@ pub(all) struct GeneratedCodeInfo {
 } derive(Eq, Debug)
 
 ///|
-pub impl @lib.Sized for GeneratedCodeInfo with size_of(self) {
+pub impl @lib.Sized for GeneratedCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.annotation {
     let s = @lib.size_of(s)
@@ -9669,7 +9685,7 @@ pub impl @lib.Sized for GeneratedCodeInfo with size_of(self) {
 }
 
 ///|
-pub impl Default for GeneratedCodeInfo with default() -> GeneratedCodeInfo {
+pub impl Default for GeneratedCodeInfo with fn default() -> GeneratedCodeInfo {
   GeneratedCodeInfo::{ annotation: [] }
 }
 
@@ -9681,7 +9697,7 @@ pub fn GeneratedCodeInfo::new(
 }
 
 ///|
-pub impl @lib.Read for GeneratedCodeInfo with read_with_limit(
+pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
@@ -9703,7 +9719,7 @@ pub impl @lib.Read for GeneratedCodeInfo with read_with_limit(
 }
 
 ///|
-pub impl @lib.Write for GeneratedCodeInfo with write(
+pub impl @lib.Write for GeneratedCodeInfo with fn write(
   self : GeneratedCodeInfo,
   writer : &@lib.Writer,
 ) -> Unit raise {
@@ -9715,7 +9731,7 @@ pub impl @lib.Write for GeneratedCodeInfo with write(
 }
 
 ///|
-pub impl ToJson for GeneratedCodeInfo with to_json(self) {
+pub impl ToJson for GeneratedCodeInfo with fn to_json(self) {
   let json : Map[String, Json] = {}
   if self.annotation != Default::default() {
     json["annotation"] = self.annotation.to_json()
@@ -9724,7 +9740,7 @@ pub impl ToJson for GeneratedCodeInfo with to_json(self) {
 }
 
 ///|
-pub impl @json.FromJson for GeneratedCodeInfo with from_json(
+pub impl @json.FromJson for GeneratedCodeInfo with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> GeneratedCodeInfo raise {
@@ -9738,14 +9754,14 @@ pub impl @json.FromJson for GeneratedCodeInfo with from_json(
     match (key, value) {
       ("annotation", Array(value)) =>
         message.annotation = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
 
 ///|
-pub impl @lib.AsyncRead for GeneratedCodeInfo with read_with_limit(
+pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
@@ -9767,7 +9783,7 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo with read_with_limit(
 }
 
 ///|
-pub impl @lib.AsyncWrite for GeneratedCodeInfo with write(
+pub impl @lib.AsyncWrite for GeneratedCodeInfo with fn write(
   self : GeneratedCodeInfo,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {

--- a/scripts/gen_codec_tests.py
+++ b/scripts/gen_codec_tests.py
@@ -641,14 +641,14 @@ def render_simple_test(cases) -> str:
                     "  let bytes = @protobuf.base64_decode(b64)",
                     "  let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader",
                     "  let (tag, wire_type) = reader |> @protobuf.read_tag()",
-                    "  assert_eq(tag, 1U)",
-                    f"  assert_eq(wire_type, {wire_type}U)",
+                    "  @debug.assert_eq(tag, 1U)",
+                    f"  @debug.assert_eq(wire_type, {wire_type}U)",
                     f"  let value = {read_expr}",
                     "  value.reinterpret_as_uint()",
                     "}",
                     "",
                     f"fn encode_{name}_bits(bits : {moon_type}) -> String raise {{",
-                    "  let writer = @buffer.new()",
+                    "  let writer = Buffer()",
                     f"  writer |> @protobuf.write_tag((1U, {wire_type}U))",
                     "  let value = Float::reinterpret_from_int(bits.reinterpret_as_int())",
                     f"  writer |> {spec['write']}(value)",
@@ -667,14 +667,14 @@ def render_simple_test(cases) -> str:
                     "  let bytes = @protobuf.base64_decode(b64)",
                     "  let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader",
                     "  let (tag, wire_type) = reader |> @protobuf.read_tag()",
-                    "  assert_eq(tag, 1U)",
-                    f"  assert_eq(wire_type, {wire_type}U)",
+                    "  @debug.assert_eq(tag, 1U)",
+                    f"  @debug.assert_eq(wire_type, {wire_type}U)",
                     f"  let value = {read_expr}",
                     "  value.reinterpret_as_uint64()",
                     "}",
                     "",
                     f"fn encode_{name}_bits(bits : {moon_type}) -> String raise {{",
-                    "  let writer = @buffer.new()",
+                    "  let writer = Buffer()",
                     f"  writer |> @protobuf.write_tag((1U, {wire_type}U))",
                     "  let value = Int64::reinterpret_as_double(bits.reinterpret_as_int64())",
                     f"  writer |> {spec['write']}(value)",
@@ -693,13 +693,13 @@ def render_simple_test(cases) -> str:
                     "  let bytes = @protobuf.base64_decode(b64)",
                     "  let reader = @protobuf.BytesReader::from_bytes(bytes) as &@protobuf.Reader",
                     "  let (tag, wire_type) = reader |> @protobuf.read_tag()",
-                    "  assert_eq(tag, 1U)",
-                    f"  assert_eq(wire_type, {wire_type}U)",
+                    "  @debug.assert_eq(tag, 1U)",
+                    f"  @debug.assert_eq(wire_type, {wire_type}U)",
                     f"  {read_expr}",
                     "}",
                     "",
                     f"fn encode_{name}(value : {moon_type}) -> String raise {{",
-                    "  let writer = @buffer.new()",
+                    "  let writer = Buffer()",
                     f"  writer |> @protobuf.write_tag((1U, {wire_type}U))",
                 ]
             )
@@ -736,22 +736,22 @@ def render_simple_test(cases) -> str:
         if spec.get("float_bits"):
             lines.extend(
                 [
-                    f"    assert_eq(decode_{name}_bits(b64), expected)",
-                    f"    assert_eq(encode_{name}_bits(expected), b64)",
+                    f"    @debug.assert_eq(decode_{name}_bits(b64), expected)",
+                    f"    @debug.assert_eq(encode_{name}_bits(expected), b64)",
                 ]
             )
         elif spec.get("double_bits"):
             lines.extend(
                 [
-                    f"    assert_eq(decode_{name}_bits(b64), expected)",
-                    f"    assert_eq(encode_{name}_bits(expected), b64)",
+                    f"    @debug.assert_eq(decode_{name}_bits(b64), expected)",
+                    f"    @debug.assert_eq(encode_{name}_bits(expected), b64)",
                 ]
             )
         else:
             lines.extend(
                 [
-                    f"    assert_eq(decode_{name}(b64), expected)",
-                    f"    assert_eq(encode_{name}(expected), b64)",
+                    f"    @debug.assert_eq(decode_{name}(b64), expected)",
+                    f"    @debug.assert_eq(encode_{name}(expected), b64)",
                 ]
             )
 
@@ -1020,7 +1020,7 @@ def render_middle_test(cases) -> str:
         "          3 => {",
         "            let packed = reader",
         "              |> @protobuf.read_packed(",
-        "                fn(r) { r |> @protobuf.read_sint32() },",
+        "                fn(r) raise { r |> @protobuf.read_sint32() },",
         "                None,",
         "              )",
         "            for value in packed {",
@@ -1042,7 +1042,7 @@ def render_middle_test(cases) -> str:
         "",
         "fn encode_middle_nested(value : (Int64, Bool, String)) -> Bytes raise {",
         "  let (count, flag, note) = value",
-        "  let writer = @buffer.new()",
+        "  let writer = Buffer()",
         "  if count != 0L {",
         "    writer |> @protobuf.write_tag((1U, 0U))",
         "    writer |> @protobuf.write_int64(count)",
@@ -1059,7 +1059,7 @@ def render_middle_test(cases) -> str:
         "}",
         "",
         "fn encode_middle(case : MiddleCase) -> String raise {",
-        "  let writer = @buffer.new()",
+        "  let writer = Buffer()",
         "  if case.id != 0 {",
         "    writer |> @protobuf.write_tag((1U, 0U))",
         "    writer |> @protobuf.write_int32(case.id)",
@@ -1069,7 +1069,7 @@ def render_middle_test(cases) -> str:
         "    writer |> @protobuf.write_int32(value)",
         "  }",
         "  if case.packed_values.length() > 0 {",
-        "    let packed_writer = @buffer.new()",
+        "    let packed_writer = Buffer()",
         "    for value in case.packed_values {",
         "      packed_writer |> @protobuf.write_sint32(value)",
         "    }",
@@ -1149,15 +1149,15 @@ def render_middle_test(cases) -> str:
             "  ]",
             "  for case in cases {",
             "    let decoded = decode_middle(case.b64)",
-            "    assert_eq(decoded.id, case.id)",
-            "    assert_eq(decoded.values, case.values)",
-            "    assert_eq(decoded.packed_values, case.packed_values)",
-            "    assert_eq(decoded.label, case.label)",
-            "    assert_eq(decoded.data, case.data)",
-            "    assert_eq(decoded.nested, case.nested)",
-            "    assert_eq(decoded.status, case.status)",
-            "    assert_eq(decoded.tags, case.tags)",
-            "    assert_eq(encode_middle(case), case.b64)",
+            "    @debug.assert_eq(decoded.id, case.id)",
+            "    @debug.assert_eq(decoded.values, case.values)",
+            "    @debug.assert_eq(decoded.packed_values, case.packed_values)",
+            "    @debug.assert_eq(decoded.label, case.label)",
+            "    @debug.assert_eq(decoded.data, case.data)",
+            "    @debug.assert_eq(decoded.nested, case.nested)",
+            "    @debug.assert_eq(decoded.status, case.status)",
+            "    @debug.assert_eq(decoded.tags, case.tags)",
+            "    @debug.assert_eq(encode_middle(case), case.b64)",
             "  }",
             "}",
             "",
@@ -1485,7 +1485,7 @@ def render_difficult_test(cases) -> str:
         "          4 => {",
         "            let packed = reader",
         "              |> @protobuf.read_packed(",
-        "                fn(r) { r |> @protobuf.read_double() },",
+        "                fn(r) raise { r |> @protobuf.read_double() },",
         "                Some(8U),",
         "              )",
         "            for score in packed {",
@@ -1507,7 +1507,7 @@ def render_difficult_test(cases) -> str:
         "",
         "fn encode_item(item : (String, Bytes, UInt64)) -> Bytes raise {",
         "  let (name, raw, code) = item",
-        "  let writer = @buffer.new()",
+        "  let writer = Buffer()",
         "  if name != \"\" {",
         "    writer |> @protobuf.write_tag((1U, 2U))",
         "    writer |> @protobuf.write_string(name)",
@@ -1525,7 +1525,7 @@ def render_difficult_test(cases) -> str:
         "",
         "fn encode_count(entry : (String, Int)) -> Bytes raise {",
         "  let (key, value) = entry",
-        "  let writer = @buffer.new()",
+        "  let writer = Buffer()",
         "  if key != \"\" {",
         "    writer |> @protobuf.write_tag((1U, 2U))",
         "    writer |> @protobuf.write_string(key)",
@@ -1536,7 +1536,7 @@ def render_difficult_test(cases) -> str:
         "}",
         "",
         "fn encode_difficult(case : DifficultCase) -> String raise {",
-        "  let writer = @buffer.new()",
+        "  let writer = Buffer()",
         "  if case.big != 0UL {",
         "    writer |> @protobuf.write_tag((1U, 0U))",
         "    writer |> @protobuf.write_uint64(case.big)",
@@ -1550,7 +1550,7 @@ def render_difficult_test(cases) -> str:
         "    writer |> @protobuf.write_double(case.ratio)",
         "  }",
         "  if case.scores.length() > 0 {",
-        "    let packed_writer = @buffer.new()",
+        "    let packed_writer = Buffer()",
         "    for score in case.scores {",
         "      packed_writer |> @protobuf.write_double(score)",
         "    }",
@@ -1630,16 +1630,16 @@ def render_difficult_test(cases) -> str:
             "  ]",
             "  for case in cases {",
             "    let decoded = decode_difficult(case.b64)",
-            "    assert_eq(decoded.big, case.big)",
-            "    assert_eq(decoded.zigzag, case.zigzag)",
-            "    assert_eq(decoded.ratio, case.ratio)",
-            "    assert_eq(decoded.scores, case.scores)",
-            "    assert_eq(decoded.items, case.items)",
-            "    assert_eq(decoded.counts, case.counts)",
-            "    assert_eq(decoded.choice_text, case.choice_text)",
-            "    assert_eq(decoded.choice_number, case.choice_number)",
-            "    assert_eq(decoded.payload, case.payload)",
-            "    assert_eq(encode_difficult(case), case.b64)",
+            "    @debug.assert_eq(decoded.big, case.big)",
+            "    @debug.assert_eq(decoded.zigzag, case.zigzag)",
+            "    @debug.assert_eq(decoded.ratio, case.ratio)",
+            "    @debug.assert_eq(decoded.scores, case.scores)",
+            "    @debug.assert_eq(decoded.items, case.items)",
+            "    @debug.assert_eq(decoded.counts, case.counts)",
+            "    @debug.assert_eq(decoded.choice_text, case.choice_text)",
+            "    @debug.assert_eq(decoded.choice_number, case.choice_number)",
+            "    @debug.assert_eq(decoded.payload, case.payload)",
+            "    @debug.assert_eq(encode_difficult(case), case.b64)",
             "  }",
             "}",
             "",
@@ -1698,15 +1698,35 @@ def render_bad_test(cases) -> str:
             ]
         )
         if case["action"] == "read_tag":
-            lines.append(
-                f"  inspect(try? (reader |> @protobuf.read_tag()), content=\"{case['expect']}\")"
+            lines.extend(
+                [
+                    "  debug_inspect(",
+                    "    try reader |> @protobuf.read_tag()",
+                    "    catch {",
+                    "      err => Err(err)",
+                    "    } noraise {",
+                    "      value => Ok(value)",
+                    "    },",
+                    f"    content=\"{case['expect']}\",",
+                    "  )",
+                ]
             )
         else:
             lines.append("  let (tag, wire_type) = reader |> @protobuf.read_tag()")
-            lines.append("  assert_eq(tag, 1U)")
-            lines.append("  assert_eq(wire_type, 2U)")
-            lines.append(
-                f"  inspect(try? (reader |> @protobuf.read_string()), content=\"{case['expect']}\")"
+            lines.append("  @debug.assert_eq(tag, 1U)")
+            lines.append("  @debug.assert_eq(wire_type, 2U)")
+            lines.extend(
+                [
+                    "  debug_inspect(",
+                    "    try reader |> @protobuf.read_string()",
+                    "    catch {",
+                    "      err => Err(err)",
+                    "    } noraise {",
+                    "      value => Ok(value)",
+                    "    },",
+                    f"    content=\"{case['expect']}\",",
+                    "  )",
+                ]
             )
         lines.extend(["}", ""])
     return "\n".join(lines)

--- a/scripts/workflow.py
+++ b/scripts/workflow.py
@@ -89,13 +89,17 @@ def print_output(result: subprocess.CompletedProcess[str]) -> None:
             print("==============")
 
 
+def is_known_snapshot_import_failure(result: subprocess.CompletedProcess[str]) -> bool:
+    return "Cannot find import 'username/__snapshot/google/protobuf'" in result.stderr
+
+
 def moon_work_env(work_file: Path) -> dict[str, str]:
     return {**os.environ, "MOON_WORK": str(work_file.resolve())}
 
 
 def build_plugin() -> None:
     moon(
-        ["build", "--target", "native"],
+        ["build", "--target", "native", "--deny-warn"],
         cwd=CLI_DIR,
         description="Building protoc-gen-mbt plugin",
     )
@@ -112,10 +116,17 @@ def run_protoc(
     proto_files: Sequence[str],
     username: str = "username",
     include_path: str | None = None,
+    options: Sequence[str] = (),
 ) -> None:
     proto_paths = [f"--proto_path={proto_dir}"]
     if include_path:
         proto_paths.append(f"--proto_path={include_path}")
+    mbt_options = [
+        "paths=source_relative",
+        f"project_name={project_name}",
+        f"username={username}",
+        *options,
+    ]
 
     run(
         [
@@ -123,8 +134,7 @@ def run_protoc(
             f"--plugin=protoc-gen-mbt={PLUGIN_EXE}",
             *proto_paths,
             f"--mbt_out={output_dir}",
-            "--mbt_opt="
-            f"paths=source_relative,project_name={project_name},username={username}",
+            f"--mbt_opt={','.join(mbt_options)}",
             *proto_files,
         ],
         description=f"Generating {project_name} with protoc",
@@ -143,11 +153,7 @@ def generate_plugin(_: argparse.Namespace) -> None:
         project_name="plugin",
         proto_files=["plugin.proto", "google/protobuf/descriptor.proto"],
         username="moonbitlang",
-    )
-    moon(
-        ["fmt", "moon.mod.json"],
-        cwd=PLUGIN_DIR,
-        description="Converting generated module config",
+        options=["emit_package_files=false"],
     )
     moon(
         ["-C", str(PLUGIN_DIR), "add", "moonbitlang/async@0.18.0"],
@@ -155,8 +161,8 @@ def generate_plugin(_: argparse.Namespace) -> None:
         description="Adding async dependency to plugin module",
     )
     for args, description in (
-        (["check", "--target", "native"], "Running moon check (native)"),
-        (["test", "--target", "native"], "Running moon test (native)"),
+        (["check", "--target", "native", "--deny-warn"], "Running moon check (native)"),
+        (["test", "--target", "native", "--deny-warn"], "Running moon test (native)"),
         (["fmt"], "Running moon fmt"),
         (["info", "--target", "native"], "Running moon info (native)"),
     ):
@@ -182,15 +188,24 @@ def snapshot_test(args: argparse.Namespace) -> None:
                 include_path=args.include_path,
             )
             result = moon(
-                ["check", "src", "--target", "native"],
+                ["check", "src", "--target", "native", "--deny-warn"],
                 cwd=proto_dir / "__snapshot",
                 env=moon_work_env(proto_dir / "moon.work"),
                 description=f"Checking generated snapshot for {proto_dir}/{proto_file}",
                 check=False,
             )
             if result.returncode != 0:
-                logger.warning("moon check failed for %s/%s", proto_dir, proto_file)
-                print_output(result)
+                if is_known_snapshot_import_failure(result):
+                    logger.warning("moon check failed for %s/%s", proto_dir, proto_file)
+                    print_output(result)
+                else:
+                    print_output(result)
+                    raise subprocess.CalledProcessError(
+                        result.returncode,
+                        result.args,
+                        output=result.stdout,
+                        stderr=result.stderr,
+                    )
 
     logger.info("Code generation completed")
     if args.update:
@@ -265,7 +280,7 @@ def reader_test(args: argparse.Namespace) -> None:
     logger.info("Go binary built successfully")
 
     logger.info("Running reader test...")
-    test_args = ["test", "src", "--target", "all"]
+    test_args = ["test", "src", "--target", "all", "--deny-warn"]
     if args.update:
         result = moon(
             test_args,
@@ -278,7 +293,7 @@ def reader_test(args: argparse.Namespace) -> None:
             logger.warning("Initial reader test failed before update")
             print_output(result)
             moon(
-                ["test", "src", "--target", "native", "--update"],
+                ["test", "src", "--target", "native", "--update", "--deny-warn"],
                 cwd=runner_dir,
                 env=reader_env,
                 description="Updating reader test snapshots",

--- a/test/reader/gen_proto2/src/top.mbt
+++ b/test/reader/gen_proto2/src/top.mbt
@@ -127,7 +127,7 @@ pub impl @json.FromJson for BarMessageP2 with fn from_json(
   for key, value in obj {
     match (key, value) {
       ("bInt32", value) => message.b_int32 = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -966,7 +966,7 @@ pub impl @json.FromJson for FooMessageP2 with fn from_json(
         message.f_repeated_packed_enum = value.map(v => {
           @json.from_json(v, path~)
         })
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -1327,7 +1327,7 @@ pub impl @json.FromJson for MapEntryP2 with fn from_json(
     match (key, value) {
       ("key", value) => message.key = @json.from_json(value, path~)
       ("value", value) => message.value = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -1511,7 +1511,7 @@ pub impl @json.FromJson for BazMessageP2_Nested_NestedMessage with fn from_json(
   for key, value in obj {
     match (key, value) {
       ("fNested", value) => message.f_nested = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -1634,7 +1634,7 @@ pub impl @json.FromJson for BazMessageP2_Nested with fn from_json(
     match (key, value) {
       ("fNested", value) =>
         message.f_nested = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -1795,7 +1795,7 @@ pub impl @json.FromJson for BazMessageP2 with fn from_json(
       ("bInt64", value) => message.b_int64 = Some(@json.from_json(value, path~))
       ("bString", value) =>
         message.b_string = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -1928,7 +1928,7 @@ pub impl @json.FromJson for RepeatedMessageP2 with fn from_json(
     match (key, value) {
       ("barMessage", Array(value)) =>
         message.bar_message = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -127,7 +127,7 @@ pub impl @json.FromJson for BarMessage with fn from_json(
   for key, value in obj {
     match (key, value) {
       ("bInt32", value) => message.b_int32 = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -250,7 +250,7 @@ pub impl @json.FromJson for FooMessage_FMapEntry with fn from_json(
     match (key, value) {
       ("key", value) => message.key = @json.from_json(value, path~)
       ("value", value) => message.value = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -1001,7 +1001,7 @@ pub impl @json.FromJson for FooMessage with fn from_json(
       ("f1", value) => message.test_oneof = @json.from_json(value, path~)
       ("f2", value) => message.test_oneof = @json.from_json(value, path~)
       ("f3", value) => message.test_oneof = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -1402,7 +1402,7 @@ pub impl @json.FromJson for BazMessage_Nested_NestedMessage with fn from_json(
   for key, value in obj {
     match (key, value) {
       ("fNested", value) => message.f_nested = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -1518,7 +1518,7 @@ pub impl @json.FromJson for BazMessage_Nested with fn from_json(
   for key, value in obj {
     match (key, value) {
       ("fNested", value) => message.f_nested = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -1663,7 +1663,7 @@ pub impl @json.FromJson for BazMessage with fn from_json(
       ("nested", value) => message.nested = @json.from_json(value, path~)
       ("bInt64", value) => message.b_int64 = @json.from_json(value, path~)
       ("bString", value) => message.b_string = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -1786,7 +1786,7 @@ pub impl @json.FromJson for RepeatedMessage with fn from_json(
     match (key, value) {
       ("barMessage", Array(value)) =>
         message.bar_message = value.map(v => @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -1897,7 +1897,7 @@ pub impl @json.FromJson for EmptyMessage with fn from_json(
   for key, value in obj {
     match (key, value) {
       ("field", value) => message.field = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -2013,7 +2013,7 @@ pub impl @json.FromJson for EmptyMessageWithField with fn from_json(
     match (key, value) {
       ("emptyMessage", value) =>
         message.empty_message = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
@@ -2210,7 +2210,7 @@ pub impl @json.FromJson for OnlyOneOfField with fn from_json(
       ("f1", value) => message.test_oneof = @json.from_json(value, path~)
       ("f2", value) => message.test_oneof = @json.from_json(value, path~)
       ("f3", value) => message.test_oneof = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -15,13 +15,13 @@ pub fn FooEnum::from_enum(i : @lib.Enum) -> FooEnum {
     _ => Default::default()
   }
 }
-pub impl Default for FooEnum with default() -> FooEnum {
+pub impl Default for FooEnum with fn default() -> FooEnum {
   FooEnum::FIRST_VALUE
 }
-pub impl @lib.Sized for FooEnum with size_of(self : FooEnum) {
+pub impl @lib.Sized for FooEnum with fn size_of(self : FooEnum) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FooEnum with from_json(json: Json, path: @json.JsonPath) -> FooEnum raise {
+pub impl @json.FromJson for FooEnum with fn from_json(json: Json, path: @json.JsonPath) -> FooEnum raise {
   match json {
     String("FIRST_VALUE") => FooEnum::FIRST_VALUE
     String("SECOND_VALUE") => FooEnum::SECOND_VALUE
@@ -30,7 +30,7 @@ pub impl @json.FromJson for FooEnum with from_json(json: Json, path: @json.JsonP
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FooEnum with to_json(self : FooEnum) -> Json {
+pub impl ToJson for FooEnum with fn to_json(self : FooEnum) -> Json {
   match self {
     FooEnum::FIRST_VALUE => "FIRST_VALUE"
     FooEnum::SECOND_VALUE => "SECOND_VALUE"
@@ -39,12 +39,12 @@ pub impl ToJson for FooEnum with to_json(self : FooEnum) -> Json {
 pub(all) struct BarMessage {
   mut b_int32 : Int
 } derive(Eq, Debug)
-pub impl @lib.Sized for BarMessage with size_of(self) {
+pub impl @lib.Sized for BarMessage with fn size_of(self) {
   let mut size = 0U
   size += 1U + @lib.size_of(self.b_int32)
   size
 }
-pub impl Default for BarMessage with default() -> BarMessage {
+pub impl Default for BarMessage with fn default() -> BarMessage {
   BarMessage::{
     b_int32 : Int::default(),
   }
@@ -54,7 +54,7 @@ pub fn BarMessage::new(b_int32 : Int) -> BarMessage {
     b_int32,
   }
 }
-pub impl @lib.Read for BarMessage with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BarMessage raise {
+pub impl @lib.Read for BarMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BarMessage raise {
   let msg = BarMessage::default()
   try {
     for ;; {
@@ -69,18 +69,18 @@ pub impl @lib.Read for BarMessage with read_with_limit(reader : @lib.LimitedRead
   }
   msg
 }
-pub impl @lib.Write for BarMessage with write(self: BarMessage, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for BarMessage with fn write(self: BarMessage, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(8UL);
   writer |> @lib.write_int32(self.b_int32)
 }
-pub impl ToJson for BarMessage with to_json(self) {
+pub impl ToJson for BarMessage with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.b_int32 != Default::default() {
   json["bInt32"] = self.b_int32.to_json()
   }
   Json::object(json)
 }
-pub impl @json.FromJson for BarMessage with from_json(json: Json, path: @json.JsonPath) -> BarMessage raise {
+pub impl @json.FromJson for BarMessage with fn from_json(json: Json, path: @json.JsonPath) -> BarMessage raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for BarMessage"))
   }
@@ -88,12 +88,12 @@ pub impl @json.FromJson for BarMessage with from_json(json: Json, path: @json.Js
   for key, value in obj {
     match (key, value) {
       ("bInt32", value) => message.b_int32 = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for BarMessage with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BarMessage raise {
+pub impl @lib.AsyncRead for BarMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BarMessage raise {
   let msg = BarMessage::default()
   try {
     for ;; {
@@ -108,7 +108,7 @@ pub impl @lib.AsyncRead for BarMessage with read_with_limit(reader : @lib.Limite
   }
   msg
 }
-pub impl @lib.AsyncWrite for BarMessage with write(self: BarMessage, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for BarMessage with fn write(self: BarMessage, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(8UL);
   writer |> @lib.async_write_int32(self.b_int32)
 }
@@ -116,13 +116,13 @@ pub(all) struct FooMessage_FMapEntry {
   mut key : String
   mut value : Int
 } derive(Eq, Debug)
-pub impl @lib.Sized for FooMessage_FMapEntry with size_of(self) {
+pub impl @lib.Sized for FooMessage_FMapEntry with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
   size += 1U + @lib.size_of(self.value)
   size
 }
-pub impl Default for FooMessage_FMapEntry with default() -> FooMessage_FMapEntry {
+pub impl Default for FooMessage_FMapEntry with fn default() -> FooMessage_FMapEntry {
   FooMessage_FMapEntry::{
     key : String::default(),
     value : Int::default(),
@@ -134,7 +134,7 @@ pub fn FooMessage_FMapEntry::new(key : String, value : Int) -> FooMessage_FMapEn
     value,
   }
 }
-pub impl @lib.Read for FooMessage_FMapEntry with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FooMessage_FMapEntry raise {
+pub impl @lib.Read for FooMessage_FMapEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
   try {
     for ;; {
@@ -150,13 +150,13 @@ pub impl @lib.Read for FooMessage_FMapEntry with read_with_limit(reader : @lib.L
   }
   msg
 }
-pub impl @lib.Write for FooMessage_FMapEntry with write(self: FooMessage_FMapEntry, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FooMessage_FMapEntry with fn write(self: FooMessage_FMapEntry, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.key)
   writer |> @lib.write_varint(16UL);
   writer |> @lib.write_int32(self.value)
 }
-pub impl ToJson for FooMessage_FMapEntry with to_json(self) {
+pub impl ToJson for FooMessage_FMapEntry with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.key != Default::default() {
   json["key"] = self.key.to_json()
@@ -166,7 +166,7 @@ pub impl ToJson for FooMessage_FMapEntry with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for FooMessage_FMapEntry with from_json(json: Json, path: @json.JsonPath) -> FooMessage_FMapEntry raise {
+pub impl @json.FromJson for FooMessage_FMapEntry with fn from_json(json: Json, path: @json.JsonPath) -> FooMessage_FMapEntry raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FooMessage_FMapEntry"))
   }
@@ -175,12 +175,12 @@ pub impl @json.FromJson for FooMessage_FMapEntry with from_json(json: Json, path
     match (key, value) {
       ("key", value) => message.key = @json.from_json(value, path~)
       ("value", value) => message.value = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FooMessage_FMapEntry with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FooMessage_FMapEntry raise {
+pub impl @lib.AsyncRead for FooMessage_FMapEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
   try {
     for ;; {
@@ -196,7 +196,7 @@ pub impl @lib.AsyncRead for FooMessage_FMapEntry with read_with_limit(reader : @
   }
   msg
 }
-pub impl @lib.AsyncWrite for FooMessage_FMapEntry with write(self: FooMessage_FMapEntry, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FooMessage_FMapEntry with fn write(self: FooMessage_FMapEntry, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.key)
   writer |> @lib.async_write_varint(16UL);
@@ -238,10 +238,10 @@ pub(all) enum FooMessage_TestOneof {
   F3(String)
   NotSet
 } derive(Eq, Debug)
-pub impl Default for FooMessage_TestOneof with default() -> FooMessage_TestOneof {
+pub impl Default for FooMessage_TestOneof with fn default() -> FooMessage_TestOneof {
   NotSet
 }
-pub impl @json.FromJson for FooMessage_TestOneof with from_json(json: Json, path: @json.JsonPath) -> FooMessage_TestOneof raise {
+pub impl @json.FromJson for FooMessage_TestOneof with fn from_json(json: Json, path: @json.JsonPath) -> FooMessage_TestOneof raise {
   try { FooMessage_TestOneof::F1(json |> @json.from_json(path~)) } catch {
     _ => ()
   } noraise {
@@ -259,7 +259,7 @@ pub impl @json.FromJson for FooMessage_TestOneof with from_json(json: Json, path
   }
 FooMessage_TestOneof::NotSet
 }
-pub impl ToJson for FooMessage_TestOneof with to_json(self : FooMessage_TestOneof) -> Json {
+pub impl ToJson for FooMessage_TestOneof with fn to_json(self : FooMessage_TestOneof) -> Json {
   match self {
     FooMessage_TestOneof::F1(v) => v.to_json()
     FooMessage_TestOneof::F2(v) => v.to_json()
@@ -267,7 +267,7 @@ pub impl ToJson for FooMessage_TestOneof with to_json(self : FooMessage_TestOneo
     FooMessage_TestOneof::NotSet => Json::null()
   }
 }
-pub impl @lib.Sized for FooMessage with size_of(self) {
+pub impl @lib.Sized for FooMessage with fn size_of(self) {
   let mut size = 0U
   size += 1U + @lib.size_of(self.f_int32)
   size += 1U + @lib.size_of(self.f_int64)
@@ -316,7 +316,7 @@ pub impl @lib.Sized for FooMessage with size_of(self) {
   }
   size
 }
-pub impl Default for FooMessage with default() -> FooMessage {
+pub impl Default for FooMessage with fn default() -> FooMessage {
   FooMessage::{
     f_int32 : Int::default(),
     f_int64 : Int64::default(),
@@ -380,7 +380,7 @@ pub fn FooMessage::new(f_int32 : Int, f_int64 : Int64, f_uint32 : UInt, f_uint64
     test_oneof,
   }
 }
-pub impl @lib.Read for FooMessage with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FooMessage raise {
+pub impl @lib.Read for FooMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FooMessage raise {
   let msg = FooMessage::default()
   try {
     for ;; {
@@ -427,7 +427,7 @@ pub impl @lib.Read for FooMessage with read_with_limit(reader : @lib.LimitedRead
   }
   msg
 }
-pub impl @lib.Write for FooMessage with write(self: FooMessage, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(8UL);
   writer |> @lib.write_int32(self.f_int32)
   writer |> @lib.write_varint(16UL);
@@ -538,7 +538,7 @@ pub impl @lib.Write for FooMessage with write(self: FooMessage, writer : &@lib.W
     FooMessage_TestOneof::NotSet => ()
   }
 }
-pub impl ToJson for FooMessage with to_json(self) {
+pub impl ToJson for FooMessage with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.f_int32 != Default::default() {
   json["fInt32"] = self.f_int32.to_json()
@@ -630,7 +630,7 @@ pub impl ToJson for FooMessage with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for FooMessage with from_json(json: Json, path: @json.JsonPath) -> FooMessage raise {
+pub impl @json.FromJson for FooMessage with fn from_json(json: Json, path: @json.JsonPath) -> FooMessage raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FooMessage"))
   }
@@ -672,12 +672,12 @@ Float::from_double(@json.from_json(v, path~)))
       ("f1", value) => message.test_oneof = @json.from_json(value, path~)
       ("f2", value) => message.test_oneof = @json.from_json(value, path~)
       ("f3", value) => message.test_oneof = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FooMessage with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FooMessage raise {
+pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FooMessage raise {
   let msg = FooMessage::default()
   try {
     for ;; {
@@ -724,7 +724,7 @@ pub impl @lib.AsyncRead for FooMessage with read_with_limit(reader : @lib.Limite
   }
   msg
 }
-pub impl @lib.AsyncWrite for FooMessage with write(self: FooMessage, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(8UL);
   writer |> @lib.async_write_int32(self.f_int32)
   writer |> @lib.async_write_varint(16UL);
@@ -855,13 +855,13 @@ pub fn BazMessage_Nested_NestedEnum::from_enum(i : @lib.Enum) -> BazMessage_Nest
     _ => Default::default()
   }
 }
-pub impl Default for BazMessage_Nested_NestedEnum with default() -> BazMessage_Nested_NestedEnum {
+pub impl Default for BazMessage_Nested_NestedEnum with fn default() -> BazMessage_Nested_NestedEnum {
   BazMessage_Nested_NestedEnum::Foo
 }
-pub impl @lib.Sized for BazMessage_Nested_NestedEnum with size_of(self : BazMessage_Nested_NestedEnum) {
+pub impl @lib.Sized for BazMessage_Nested_NestedEnum with fn size_of(self : BazMessage_Nested_NestedEnum) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for BazMessage_Nested_NestedEnum with from_json(json: Json, path: @json.JsonPath) -> BazMessage_Nested_NestedEnum raise {
+pub impl @json.FromJson for BazMessage_Nested_NestedEnum with fn from_json(json: Json, path: @json.JsonPath) -> BazMessage_Nested_NestedEnum raise {
   match json {
     String("Foo") => BazMessage_Nested_NestedEnum::Foo
     String("Bar") => BazMessage_Nested_NestedEnum::Bar
@@ -872,7 +872,7 @@ pub impl @json.FromJson for BazMessage_Nested_NestedEnum with from_json(json: Js
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for BazMessage_Nested_NestedEnum with to_json(self : BazMessage_Nested_NestedEnum) -> Json {
+pub impl ToJson for BazMessage_Nested_NestedEnum with fn to_json(self : BazMessage_Nested_NestedEnum) -> Json {
   match self {
     BazMessage_Nested_NestedEnum::Foo => "Foo"
     BazMessage_Nested_NestedEnum::Bar => "Bar"
@@ -882,12 +882,12 @@ pub impl ToJson for BazMessage_Nested_NestedEnum with to_json(self : BazMessage_
 pub(all) struct BazMessage_Nested_NestedMessage {
   mut f_nested : Int
 } derive(Eq, Debug)
-pub impl @lib.Sized for BazMessage_Nested_NestedMessage with size_of(self) {
+pub impl @lib.Sized for BazMessage_Nested_NestedMessage with fn size_of(self) {
   let mut size = 0U
   size += 1U + @lib.size_of(self.f_nested)
   size
 }
-pub impl Default for BazMessage_Nested_NestedMessage with default() -> BazMessage_Nested_NestedMessage {
+pub impl Default for BazMessage_Nested_NestedMessage with fn default() -> BazMessage_Nested_NestedMessage {
   BazMessage_Nested_NestedMessage::{
     f_nested : Int::default(),
   }
@@ -897,7 +897,7 @@ pub fn BazMessage_Nested_NestedMessage::new(f_nested : Int) -> BazMessage_Nested
     f_nested,
   }
 }
-pub impl @lib.Read for BazMessage_Nested_NestedMessage with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage_Nested_NestedMessage raise {
+pub impl @lib.Read for BazMessage_Nested_NestedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
   try {
     for ;; {
@@ -912,18 +912,18 @@ pub impl @lib.Read for BazMessage_Nested_NestedMessage with read_with_limit(read
   }
   msg
 }
-pub impl @lib.Write for BazMessage_Nested_NestedMessage with write(self: BazMessage_Nested_NestedMessage, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for BazMessage_Nested_NestedMessage with fn write(self: BazMessage_Nested_NestedMessage, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(8UL);
   writer |> @lib.write_int32(self.f_nested)
 }
-pub impl ToJson for BazMessage_Nested_NestedMessage with to_json(self) {
+pub impl ToJson for BazMessage_Nested_NestedMessage with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.f_nested != Default::default() {
   json["fNested"] = self.f_nested.to_json()
   }
   Json::object(json)
 }
-pub impl @json.FromJson for BazMessage_Nested_NestedMessage with from_json(json: Json, path: @json.JsonPath) -> BazMessage_Nested_NestedMessage raise {
+pub impl @json.FromJson for BazMessage_Nested_NestedMessage with fn from_json(json: Json, path: @json.JsonPath) -> BazMessage_Nested_NestedMessage raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for BazMessage_Nested_NestedMessage"))
   }
@@ -931,12 +931,12 @@ pub impl @json.FromJson for BazMessage_Nested_NestedMessage with from_json(json:
   for key, value in obj {
     match (key, value) {
       ("fNested", value) => message.f_nested = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage_Nested_NestedMessage raise {
+pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
   try {
     for ;; {
@@ -951,19 +951,19 @@ pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with read_with_limit
   }
   msg
 }
-pub impl @lib.AsyncWrite for BazMessage_Nested_NestedMessage with write(self: BazMessage_Nested_NestedMessage, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for BazMessage_Nested_NestedMessage with fn write(self: BazMessage_Nested_NestedMessage, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(8UL);
   writer |> @lib.async_write_int32(self.f_nested)
 }
 pub(all) struct BazMessage_Nested {
   mut f_nested : BazMessage_Nested_NestedMessage 
 } derive(Eq, Debug)
-pub impl @lib.Sized for BazMessage_Nested with size_of(self) {
+pub impl @lib.Sized for BazMessage_Nested with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.f_nested); @lib.size_of(size) + size }
   size
 }
-pub impl Default for BazMessage_Nested with default() -> BazMessage_Nested {
+pub impl Default for BazMessage_Nested with fn default() -> BazMessage_Nested {
   BazMessage_Nested::{
     f_nested : BazMessage_Nested_NestedMessage::default(),
   }
@@ -973,7 +973,7 @@ pub fn BazMessage_Nested::new(f_nested : BazMessage_Nested_NestedMessage) -> Baz
     f_nested,
   }
 }
-pub impl @lib.Read for BazMessage_Nested with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage_Nested raise {
+pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
   try {
     for ;; {
@@ -988,18 +988,18 @@ pub impl @lib.Read for BazMessage_Nested with read_with_limit(reader : @lib.Limi
   }
   msg
 }
-pub impl @lib.Write for BazMessage_Nested with write(self: BazMessage_Nested, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_uint32(@lib.size_of(self.f_nested)); @lib.Write::write(self.f_nested, writer)
 }
-pub impl ToJson for BazMessage_Nested with to_json(self) {
+pub impl ToJson for BazMessage_Nested with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.f_nested != Default::default() {
   json["fNested"] = self.f_nested.to_json()
   }
   Json::object(json)
 }
-pub impl @json.FromJson for BazMessage_Nested with from_json(json: Json, path: @json.JsonPath) -> BazMessage_Nested raise {
+pub impl @json.FromJson for BazMessage_Nested with fn from_json(json: Json, path: @json.JsonPath) -> BazMessage_Nested raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for BazMessage_Nested"))
   }
@@ -1007,12 +1007,12 @@ pub impl @json.FromJson for BazMessage_Nested with from_json(json: Json, path: @
   for key, value in obj {
     match (key, value) {
       ("fNested", value) => message.f_nested = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for BazMessage_Nested with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage_Nested raise {
+pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
   try {
     for ;; {
@@ -1027,7 +1027,7 @@ pub impl @lib.AsyncRead for BazMessage_Nested with read_with_limit(reader : @lib
   }
   msg
 }
-pub impl @lib.AsyncWrite for BazMessage_Nested with write(self: BazMessage_Nested, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_uint32(@lib.size_of(self.f_nested)); @lib.AsyncWrite::write(self.f_nested, writer)
 }
@@ -1036,14 +1036,14 @@ pub(all) struct BazMessage {
   mut b_int64 : Int64
   mut b_string : String
 } derive(Eq, Debug)
-pub impl @lib.Sized for BazMessage with size_of(self) {
+pub impl @lib.Sized for BazMessage with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.nested); @lib.size_of(size) + size }
   size += 1U + @lib.size_of(self.b_int64)
   size += 1U + { let size = @lib.size_of(self.b_string); @lib.size_of(size) + size }
   size
 }
-pub impl Default for BazMessage with default() -> BazMessage {
+pub impl Default for BazMessage with fn default() -> BazMessage {
   BazMessage::{
     nested : BazMessage_Nested::default(),
     b_int64 : Int64::default(),
@@ -1057,7 +1057,7 @@ pub fn BazMessage::new(nested : BazMessage_Nested, b_int64 : Int64, b_string : S
     b_string,
   }
 }
-pub impl @lib.Read for BazMessage with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage raise {
+pub impl @lib.Read for BazMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage raise {
   let msg = BazMessage::default()
   try {
     for ;; {
@@ -1074,7 +1074,7 @@ pub impl @lib.Read for BazMessage with read_with_limit(reader : @lib.LimitedRead
   }
   msg
 }
-pub impl @lib.Write for BazMessage with write(self: BazMessage, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for BazMessage with fn write(self: BazMessage, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_uint32(@lib.size_of(self.nested)); @lib.Write::write(self.nested, writer)
   writer |> @lib.write_varint(16UL);
@@ -1082,7 +1082,7 @@ pub impl @lib.Write for BazMessage with write(self: BazMessage, writer : &@lib.W
   writer |> @lib.write_varint(26UL);
   writer |> @lib.write_string(self.b_string)
 }
-pub impl ToJson for BazMessage with to_json(self) {
+pub impl ToJson for BazMessage with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.nested != Default::default() {
   json["nested"] = self.nested.to_json()
@@ -1095,7 +1095,7 @@ pub impl ToJson for BazMessage with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for BazMessage with from_json(json: Json, path: @json.JsonPath) -> BazMessage raise {
+pub impl @json.FromJson for BazMessage with fn from_json(json: Json, path: @json.JsonPath) -> BazMessage raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for BazMessage"))
   }
@@ -1105,12 +1105,12 @@ pub impl @json.FromJson for BazMessage with from_json(json: Json, path: @json.Js
       ("nested", value) => message.nested = @json.from_json(value, path~)
       ("bInt64", value) => message.b_int64 = @json.from_json(value, path~)
       ("bString", value) => message.b_string = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for BazMessage with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage raise {
+pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage raise {
   let msg = BazMessage::default()
   try {
     for ;; {
@@ -1127,7 +1127,7 @@ pub impl @lib.AsyncRead for BazMessage with read_with_limit(reader : @lib.Limite
   }
   msg
 }
-pub impl @lib.AsyncWrite for BazMessage with write(self: BazMessage, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for BazMessage with fn write(self: BazMessage, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_uint32(@lib.size_of(self.nested)); @lib.AsyncWrite::write(self.nested, writer)
   writer |> @lib.async_write_varint(16UL);
@@ -1138,7 +1138,7 @@ pub impl @lib.AsyncWrite for BazMessage with write(self: BazMessage, writer : &@
 pub(all) struct RepeatedMessage {
   mut bar_message : Array[BarMessage]
 } derive(Eq, Debug)
-pub impl @lib.Sized for RepeatedMessage with size_of(self) {
+pub impl @lib.Sized for RepeatedMessage with fn size_of(self) {
   let mut size = 0U
   for s in self.bar_message {
     let s = @lib.size_of(s)
@@ -1146,7 +1146,7 @@ pub impl @lib.Sized for RepeatedMessage with size_of(self) {
   }
   size
 }
-pub impl Default for RepeatedMessage with default() -> RepeatedMessage {
+pub impl Default for RepeatedMessage with fn default() -> RepeatedMessage {
   RepeatedMessage::{
     bar_message : [],
   }
@@ -1156,7 +1156,7 @@ pub fn RepeatedMessage::new(bar_message : Array[BarMessage]) -> RepeatedMessage 
     bar_message,
   }
 }
-pub impl @lib.Read for RepeatedMessage with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> RepeatedMessage raise {
+pub impl @lib.Read for RepeatedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
   try {
     for ;; {
@@ -1171,21 +1171,21 @@ pub impl @lib.Read for RepeatedMessage with read_with_limit(reader : @lib.Limite
   }
   msg
 }
-pub impl @lib.Write for RepeatedMessage with write(self: RepeatedMessage, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for RepeatedMessage with fn write(self: RepeatedMessage, writer : &@lib.Writer) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
 
   }
 }
-pub impl ToJson for RepeatedMessage with to_json(self) {
+pub impl ToJson for RepeatedMessage with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.bar_message != Default::default() {
   json["barMessage"] = self.bar_message.to_json()
   }
   Json::object(json)
 }
-pub impl @json.FromJson for RepeatedMessage with from_json(json: Json, path: @json.JsonPath) -> RepeatedMessage raise {
+pub impl @json.FromJson for RepeatedMessage with fn from_json(json: Json, path: @json.JsonPath) -> RepeatedMessage raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for RepeatedMessage"))
   }
@@ -1194,12 +1194,12 @@ pub impl @json.FromJson for RepeatedMessage with from_json(json: Json, path: @js
     match (key, value) {
       ("barMessage", Array(value)) => message.bar_message = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for RepeatedMessage with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> RepeatedMessage raise {
+pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
   try {
     for ;; {
@@ -1214,7 +1214,7 @@ pub impl @lib.AsyncRead for RepeatedMessage with read_with_limit(reader : @lib.L
   }
   msg
 }
-pub impl @lib.AsyncWrite for RepeatedMessage with write(self: RepeatedMessage, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for RepeatedMessage with fn write(self: RepeatedMessage, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -2,13 +2,13 @@ pub(all) struct Hello_MetadataEntry {
   mut key : String
   mut value : String
 } derive(Eq, Debug)
-pub impl @lib.Sized for Hello_MetadataEntry with size_of(self) {
+pub impl @lib.Sized for Hello_MetadataEntry with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
   size += 1U + { let size = @lib.size_of(self.value); @lib.size_of(size) + size }
   size
 }
-pub impl Default for Hello_MetadataEntry with default() -> Hello_MetadataEntry {
+pub impl Default for Hello_MetadataEntry with fn default() -> Hello_MetadataEntry {
   Hello_MetadataEntry::{
     key : String::default(),
     value : String::default(),
@@ -20,7 +20,7 @@ pub fn Hello_MetadataEntry::new(key : String, value : String) -> Hello_MetadataE
     value,
   }
 }
-pub impl @lib.Read for Hello_MetadataEntry with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello_MetadataEntry raise {
+pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
   try {
     for ;; {
@@ -36,13 +36,13 @@ pub impl @lib.Read for Hello_MetadataEntry with read_with_limit(reader : @lib.Li
   }
   msg
 }
-pub impl @lib.Write for Hello_MetadataEntry with write(self: Hello_MetadataEntry, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.key)
   writer |> @lib.write_varint(18UL);
   writer |> @lib.write_string(self.value)
 }
-pub impl ToJson for Hello_MetadataEntry with to_json(self) {
+pub impl ToJson for Hello_MetadataEntry with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.key != Default::default() {
   json["key"] = self.key.to_json()
@@ -52,7 +52,7 @@ pub impl ToJson for Hello_MetadataEntry with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Hello_MetadataEntry with from_json(json: Json, path: @json.JsonPath) -> Hello_MetadataEntry raise {
+pub impl @json.FromJson for Hello_MetadataEntry with fn from_json(json: Json, path: @json.JsonPath) -> Hello_MetadataEntry raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Hello_MetadataEntry"))
   }
@@ -61,12 +61,12 @@ pub impl @json.FromJson for Hello_MetadataEntry with from_json(json: Json, path:
     match (key, value) {
       ("key", value) => message.key = @json.from_json(value, path~)
       ("value", value) => message.value = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Hello_MetadataEntry with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello_MetadataEntry raise {
+pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
   try {
     for ;; {
@@ -82,7 +82,7 @@ pub impl @lib.AsyncRead for Hello_MetadataEntry with read_with_limit(reader : @l
   }
   msg
 }
-pub impl @lib.AsyncWrite for Hello_MetadataEntry with write(self: Hello_MetadataEntry, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.key)
   writer |> @lib.async_write_varint(18UL);
@@ -95,7 +95,7 @@ pub(all) struct Hello {
   mut metadata : Map[String, String]
   mut friend : Hello?
 } derive(Eq, Debug)
-pub impl @lib.Sized for Hello with size_of(self) {
+pub impl @lib.Sized for Hello with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
   size += 1U + @lib.size_of(self.age)
@@ -113,7 +113,7 @@ pub impl @lib.Sized for Hello with size_of(self) {
   }
   size
 }
-pub impl Default for Hello with default() -> Hello {
+pub impl Default for Hello with fn default() -> Hello {
   Hello::{
     name : String::default(),
     age : Int::default(),
@@ -131,7 +131,7 @@ pub fn Hello::new(name : String, age : Int, hobbies : Array[String], metadata : 
     friend,
   }
 }
-pub impl @lib.Read for Hello with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello raise {
+pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello raise {
   let msg = Hello::default()
   try {
     for ;; {
@@ -150,7 +150,7 @@ pub impl @lib.Read for Hello with read_with_limit(reader : @lib.LimitedReader[&@
   }
   msg
 }
-pub impl @lib.Write for Hello with write(self: Hello, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.name)
   writer |> @lib.write_varint(16UL);
@@ -181,7 +181,7 @@ pub impl @lib.Write for Hello with write(self: Hello, writer : &@lib.Writer) -> 
 
   }
 }
-pub impl ToJson for Hello with to_json(self) {
+pub impl ToJson for Hello with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.name != Default::default() {
   json["name"] = self.name.to_json()
@@ -201,7 +201,7 @@ pub impl ToJson for Hello with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for Hello with from_json(json: Json, path: @json.JsonPath) -> Hello raise {
+pub impl @json.FromJson for Hello with fn from_json(json: Json, path: @json.JsonPath) -> Hello raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Hello"))
   }
@@ -214,12 +214,12 @@ pub impl @json.FromJson for Hello with from_json(json: Json, path: @json.JsonPat
 @json.from_json(v, path~))
       ("metadata", _) => message.metadata = @json.from_json(value, path~)
       ("friend", value) => message.friend = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Hello with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello raise {
+pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello raise {
   let msg = Hello::default()
   try {
     for ;; {
@@ -238,7 +238,7 @@ pub impl @lib.AsyncRead for Hello with read_with_limit(reader : @lib.LimitedRead
   }
   msg
 }
-pub impl @lib.AsyncWrite for Hello with write(self: Hello, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.name)
   writer |> @lib.async_write_varint(16UL);

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
@@ -1,12 +1,12 @@
 pub(all) struct Test {
   mut test_hello : @lib1.Hello 
 } derive(Eq, Debug)
-pub impl @lib.Sized for Test with size_of(self) {
+pub impl @lib.Sized for Test with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.test_hello); @lib.size_of(size) + size }
   size
 }
-pub impl Default for Test with default() -> Test {
+pub impl Default for Test with fn default() -> Test {
   Test::{
     test_hello : @lib1.Hello::default(),
   }
@@ -16,7 +16,7 @@ pub fn Test::new(test_hello : @lib1.Hello) -> Test {
     test_hello,
   }
 }
-pub impl @lib.Read for Test with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
+pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
   try {
     for ;; {
@@ -31,18 +31,18 @@ pub impl @lib.Read for Test with read_with_limit(reader : @lib.LimitedReader[&@l
   }
   msg
 }
-pub impl @lib.Write for Test with write(self: Test, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_uint32(@lib.size_of(self.test_hello)); @lib.Write::write(self.test_hello, writer)
 }
-pub impl ToJson for Test with to_json(self) {
+pub impl ToJson for Test with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.test_hello != Default::default() {
   json["testHello"] = self.test_hello.to_json()
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Test with from_json(json: Json, path: @json.JsonPath) -> Test raise {
+pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonPath) -> Test raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Test"))
   }
@@ -50,12 +50,12 @@ pub impl @json.FromJson for Test with from_json(json: Json, path: @json.JsonPath
   for key, value in obj {
     match (key, value) {
       ("testHello", value) => message.test_hello = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Test with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
+pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
   try {
     for ;; {
@@ -70,7 +70,7 @@ pub impl @lib.AsyncRead for Test with read_with_limit(reader : @lib.LimitedReade
   }
   msg
 }
-pub impl @lib.AsyncWrite for Test with write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_uint32(@lib.size_of(self.test_hello)); @lib.AsyncWrite::write(self.test_hello, writer)
 }

--- a/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
@@ -1,12 +1,12 @@
 pub(all) struct Test {
   mut created_at : @protobuf.Timestamp 
 } derive(Eq, Debug)
-pub impl @lib.Sized for Test with size_of(self) {
+pub impl @lib.Sized for Test with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.created_at); @lib.size_of(size) + size }
   size
 }
-pub impl Default for Test with default() -> Test {
+pub impl Default for Test with fn default() -> Test {
   Test::{
     created_at : @protobuf.Timestamp::default(),
   }
@@ -16,7 +16,7 @@ pub fn Test::new(created_at : @protobuf.Timestamp) -> Test {
     created_at,
   }
 }
-pub impl @lib.Read for Test with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
+pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
   try {
     for ;; {
@@ -31,18 +31,18 @@ pub impl @lib.Read for Test with read_with_limit(reader : @lib.LimitedReader[&@l
   }
   msg
 }
-pub impl @lib.Write for Test with write(self: Test, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_uint32(@lib.size_of(self.created_at)); @lib.Write::write(self.created_at, writer)
 }
-pub impl ToJson for Test with to_json(self) {
+pub impl ToJson for Test with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.created_at != Default::default() {
   json["createdAt"] = self.created_at.to_json()
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Test with from_json(json: Json, path: @json.JsonPath) -> Test raise {
+pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonPath) -> Test raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Test"))
   }
@@ -50,12 +50,12 @@ pub impl @json.FromJson for Test with from_json(json: Json, path: @json.JsonPath
   for key, value in obj {
     match (key, value) {
       ("createdAt", value) => message.created_at = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Test with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
+pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
   try {
     for ;; {
@@ -70,7 +70,7 @@ pub impl @lib.AsyncRead for Test with read_with_limit(reader : @lib.LimitedReade
   }
   msg
 }
-pub impl @lib.AsyncWrite for Test with write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_uint32(@lib.size_of(self.created_at)); @lib.AsyncWrite::write(self.created_at, writer)
 }

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -2,13 +2,13 @@ pub(all) struct Hello_MetadataEntry {
   mut key : String
   mut value : String
 } derive(Eq, Debug)
-pub impl @lib.Sized for Hello_MetadataEntry with size_of(self) {
+pub impl @lib.Sized for Hello_MetadataEntry with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
   size += 1U + { let size = @lib.size_of(self.value); @lib.size_of(size) + size }
   size
 }
-pub impl Default for Hello_MetadataEntry with default() -> Hello_MetadataEntry {
+pub impl Default for Hello_MetadataEntry with fn default() -> Hello_MetadataEntry {
   Hello_MetadataEntry::{
     key : String::default(),
     value : String::default(),
@@ -20,7 +20,7 @@ pub fn Hello_MetadataEntry::new(key : String, value : String) -> Hello_MetadataE
     value,
   }
 }
-pub impl @lib.Read for Hello_MetadataEntry with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello_MetadataEntry raise {
+pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
   try {
     for ;; {
@@ -36,13 +36,13 @@ pub impl @lib.Read for Hello_MetadataEntry with read_with_limit(reader : @lib.Li
   }
   msg
 }
-pub impl @lib.Write for Hello_MetadataEntry with write(self: Hello_MetadataEntry, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.key)
   writer |> @lib.write_varint(18UL);
   writer |> @lib.write_string(self.value)
 }
-pub impl ToJson for Hello_MetadataEntry with to_json(self) {
+pub impl ToJson for Hello_MetadataEntry with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.key != Default::default() {
   json["key"] = self.key.to_json()
@@ -52,7 +52,7 @@ pub impl ToJson for Hello_MetadataEntry with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Hello_MetadataEntry with from_json(json: Json, path: @json.JsonPath) -> Hello_MetadataEntry raise {
+pub impl @json.FromJson for Hello_MetadataEntry with fn from_json(json: Json, path: @json.JsonPath) -> Hello_MetadataEntry raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Hello_MetadataEntry"))
   }
@@ -61,12 +61,12 @@ pub impl @json.FromJson for Hello_MetadataEntry with from_json(json: Json, path:
     match (key, value) {
       ("key", value) => message.key = @json.from_json(value, path~)
       ("value", value) => message.value = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Hello_MetadataEntry with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello_MetadataEntry raise {
+pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
   try {
     for ;; {
@@ -82,7 +82,7 @@ pub impl @lib.AsyncRead for Hello_MetadataEntry with read_with_limit(reader : @l
   }
   msg
 }
-pub impl @lib.AsyncWrite for Hello_MetadataEntry with write(self: Hello_MetadataEntry, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.key)
   writer |> @lib.async_write_varint(18UL);
@@ -95,7 +95,7 @@ pub(all) struct Hello {
   mut metadata : Map[String, String]
   mut friend : Hello?
 } derive(Eq, Debug)
-pub impl @lib.Sized for Hello with size_of(self) {
+pub impl @lib.Sized for Hello with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
   size += 1U + @lib.size_of(self.age)
@@ -113,7 +113,7 @@ pub impl @lib.Sized for Hello with size_of(self) {
   }
   size
 }
-pub impl Default for Hello with default() -> Hello {
+pub impl Default for Hello with fn default() -> Hello {
   Hello::{
     name : String::default(),
     age : Int::default(),
@@ -131,7 +131,7 @@ pub fn Hello::new(name : String, age : Int, hobbies : Array[String], metadata : 
     friend,
   }
 }
-pub impl @lib.Read for Hello with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello raise {
+pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello raise {
   let msg = Hello::default()
   try {
     for ;; {
@@ -150,7 +150,7 @@ pub impl @lib.Read for Hello with read_with_limit(reader : @lib.LimitedReader[&@
   }
   msg
 }
-pub impl @lib.Write for Hello with write(self: Hello, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.name)
   writer |> @lib.write_varint(16UL);
@@ -181,7 +181,7 @@ pub impl @lib.Write for Hello with write(self: Hello, writer : &@lib.Writer) -> 
 
   }
 }
-pub impl ToJson for Hello with to_json(self) {
+pub impl ToJson for Hello with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.name != Default::default() {
   json["name"] = self.name.to_json()
@@ -201,7 +201,7 @@ pub impl ToJson for Hello with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for Hello with from_json(json: Json, path: @json.JsonPath) -> Hello raise {
+pub impl @json.FromJson for Hello with fn from_json(json: Json, path: @json.JsonPath) -> Hello raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Hello"))
   }
@@ -214,12 +214,12 @@ pub impl @json.FromJson for Hello with from_json(json: Json, path: @json.JsonPat
 @json.from_json(v, path~))
       ("metadata", _) => message.metadata = @json.from_json(value, path~)
       ("friend", value) => message.friend = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Hello with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello raise {
+pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello raise {
   let msg = Hello::default()
   try {
     for ;; {
@@ -238,7 +238,7 @@ pub impl @lib.AsyncRead for Hello with read_with_limit(reader : @lib.LimitedRead
   }
   msg
 }
-pub impl @lib.AsyncWrite for Hello with write(self: Hello, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.name)
   writer |> @lib.async_write_varint(16UL);

--- a/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
@@ -1,12 +1,12 @@
 pub(all) struct Test {
   mut created_at : @test2.Hello 
 } derive(Eq, Debug)
-pub impl @lib.Sized for Test with size_of(self) {
+pub impl @lib.Sized for Test with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.created_at); @lib.size_of(size) + size }
   size
 }
-pub impl Default for Test with default() -> Test {
+pub impl Default for Test with fn default() -> Test {
   Test::{
     created_at : @test2.Hello::default(),
   }
@@ -16,7 +16,7 @@ pub fn Test::new(created_at : @test2.Hello) -> Test {
     created_at,
   }
 }
-pub impl @lib.Read for Test with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
+pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
   try {
     for ;; {
@@ -31,18 +31,18 @@ pub impl @lib.Read for Test with read_with_limit(reader : @lib.LimitedReader[&@l
   }
   msg
 }
-pub impl @lib.Write for Test with write(self: Test, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_uint32(@lib.size_of(self.created_at)); @lib.Write::write(self.created_at, writer)
 }
-pub impl ToJson for Test with to_json(self) {
+pub impl ToJson for Test with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.created_at != Default::default() {
   json["createdAt"] = self.created_at.to_json()
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Test with from_json(json: Json, path: @json.JsonPath) -> Test raise {
+pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonPath) -> Test raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Test"))
   }
@@ -50,12 +50,12 @@ pub impl @json.FromJson for Test with from_json(json: Json, path: @json.JsonPath
   for key, value in obj {
     match (key, value) {
       ("createdAt", value) => message.created_at = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Test with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
+pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
   try {
     for ;; {
@@ -70,7 +70,7 @@ pub impl @lib.AsyncRead for Test with read_with_limit(reader : @lib.LimitedReade
   }
   msg
 }
-pub impl @lib.AsyncWrite for Test with write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_uint32(@lib.size_of(self.created_at)); @lib.AsyncWrite::write(self.created_at, writer)
 }

--- a/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
+++ b/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
@@ -4,7 +4,7 @@ pub(all) struct Version {
   mut patch : Int?
   mut suffix : String?
 } derive(Eq, Debug)
-pub impl @lib.Sized for Version with size_of(self) {
+pub impl @lib.Sized for Version with fn size_of(self) {
   let mut size = 0U
   if self.major is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -20,7 +20,7 @@ pub impl @lib.Sized for Version with size_of(self) {
   }
   size
 }
-pub impl Default for Version with default() -> Version {
+pub impl Default for Version with fn default() -> Version {
   Version::{
     major : None,
     minor : None,
@@ -36,7 +36,7 @@ pub fn Version::new(major? : Int, minor? : Int, patch? : Int, suffix? : String) 
     suffix,
   }
 }
-pub impl @lib.Read for Version with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Version raise {
+pub impl @lib.Read for Version with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Version raise {
   let msg = Version::default()
   try {
     for ;; {
@@ -54,7 +54,7 @@ pub impl @lib.Read for Version with read_with_limit(reader : @lib.LimitedReader[
   }
   msg
 }
-pub impl @lib.Write for Version with write(self: Version, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Version with fn write(self: Version, writer : &@lib.Writer) -> Unit raise {
   if self.major is Some(v) {
     writer |> @lib.write_varint(8UL);
     writer |> @lib.write_int32(v)
@@ -76,7 +76,7 @@ pub impl @lib.Write for Version with write(self: Version, writer : &@lib.Writer)
 
   }
 }
-pub impl ToJson for Version with to_json(self) {
+pub impl ToJson for Version with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.major {
       Some(v) => json["major"] = v.to_json()
@@ -96,7 +96,7 @@ pub impl ToJson for Version with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for Version with from_json(json: Json, path: @json.JsonPath) -> Version raise {
+pub impl @json.FromJson for Version with fn from_json(json: Json, path: @json.JsonPath) -> Version raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Version"))
   }
@@ -107,12 +107,12 @@ pub impl @json.FromJson for Version with from_json(json: Json, path: @json.JsonP
       ("minor", value) => message.minor = Some(@json.from_json(value, path~))
       ("patch", value) => message.patch = Some(@json.from_json(value, path~))
       ("suffix", value) => message.suffix = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Version with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Version raise {
+pub impl @lib.AsyncRead for Version with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Version raise {
   let msg = Version::default()
   try {
     for ;; {
@@ -130,7 +130,7 @@ pub impl @lib.AsyncRead for Version with read_with_limit(reader : @lib.LimitedRe
   }
   msg
 }
-pub impl @lib.AsyncWrite for Version with write(self: Version, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Version with fn write(self: Version, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.major is Some(v) {
     writer |> @lib.async_write_varint(8UL);
     writer |> @lib.async_write_int32(v)
@@ -159,7 +159,7 @@ pub(all) struct CodeGeneratorRequest {
   mut source_file_descriptors : Array[@protobuf.FileDescriptorProto]
   mut compiler_version : Version?
 } derive(Eq, Debug)
-pub impl @lib.Sized for CodeGeneratorRequest with size_of(self) {
+pub impl @lib.Sized for CodeGeneratorRequest with fn size_of(self) {
   let mut size = 0U
   for s in self.file_to_generate {
     let s = @lib.size_of(s)
@@ -181,7 +181,7 @@ pub impl @lib.Sized for CodeGeneratorRequest with size_of(self) {
   }
   size
 }
-pub impl Default for CodeGeneratorRequest with default() -> CodeGeneratorRequest {
+pub impl Default for CodeGeneratorRequest with fn default() -> CodeGeneratorRequest {
   CodeGeneratorRequest::{
     file_to_generate : [],
     parameter : None,
@@ -199,7 +199,7 @@ pub fn CodeGeneratorRequest::new(file_to_generate : Array[String], parameter? : 
     compiler_version,
   }
 }
-pub impl @lib.Read for CodeGeneratorRequest with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorRequest raise {
+pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
   try {
     for ;; {
@@ -218,7 +218,7 @@ pub impl @lib.Read for CodeGeneratorRequest with read_with_limit(reader : @lib.L
   }
   msg
 }
-pub impl @lib.Write for CodeGeneratorRequest with write(self: CodeGeneratorRequest, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for CodeGeneratorRequest with fn write(self: CodeGeneratorRequest, writer : &@lib.Writer) -> Unit raise {
   for item in self.file_to_generate {
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(item)
@@ -245,7 +245,7 @@ pub impl @lib.Write for CodeGeneratorRequest with write(self: CodeGeneratorReque
 
   }
 }
-pub impl ToJson for CodeGeneratorRequest with to_json(self) {
+pub impl ToJson for CodeGeneratorRequest with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.file_to_generate != Default::default() {
   json["fileToGenerate"] = self.file_to_generate.to_json()
@@ -266,7 +266,7 @@ pub impl ToJson for CodeGeneratorRequest with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for CodeGeneratorRequest with from_json(json: Json, path: @json.JsonPath) -> CodeGeneratorRequest raise {
+pub impl @json.FromJson for CodeGeneratorRequest with fn from_json(json: Json, path: @json.JsonPath) -> CodeGeneratorRequest raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for CodeGeneratorRequest"))
   }
@@ -281,12 +281,12 @@ pub impl @json.FromJson for CodeGeneratorRequest with from_json(json: Json, path
       ("sourceFileDescriptors", Array(value)) => message.source_file_descriptors = value.map(v => 
 @json.from_json(v, path~))
       ("compilerVersion", value) => message.compiler_version = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for CodeGeneratorRequest with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorRequest raise {
+pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
   try {
     for ;; {
@@ -305,7 +305,7 @@ pub impl @lib.AsyncRead for CodeGeneratorRequest with read_with_limit(reader : @
   }
   msg
 }
-pub impl @lib.AsyncWrite for CodeGeneratorRequest with write(self: CodeGeneratorRequest, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for CodeGeneratorRequest with fn write(self: CodeGeneratorRequest, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.file_to_generate {
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(item)
@@ -352,13 +352,13 @@ pub fn CodeGeneratorResponse_Feature::from_enum(i : @lib.Enum) -> CodeGeneratorR
     _ => Default::default()
   }
 }
-pub impl Default for CodeGeneratorResponse_Feature with default() -> CodeGeneratorResponse_Feature {
+pub impl Default for CodeGeneratorResponse_Feature with fn default() -> CodeGeneratorResponse_Feature {
   CodeGeneratorResponse_Feature::FEATURE_NONE
 }
-pub impl @lib.Sized for CodeGeneratorResponse_Feature with size_of(self : CodeGeneratorResponse_Feature) {
+pub impl @lib.Sized for CodeGeneratorResponse_Feature with fn size_of(self : CodeGeneratorResponse_Feature) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for CodeGeneratorResponse_Feature with from_json(json: Json, path: @json.JsonPath) -> CodeGeneratorResponse_Feature raise {
+pub impl @json.FromJson for CodeGeneratorResponse_Feature with fn from_json(json: Json, path: @json.JsonPath) -> CodeGeneratorResponse_Feature raise {
   match json {
     String("FEATURE_NONE") => CodeGeneratorResponse_Feature::FEATURE_NONE
     String("FEATURE_PROTO3_OPTIONAL") => CodeGeneratorResponse_Feature::FEATURE_PROTO3_OPTIONAL
@@ -369,7 +369,7 @@ pub impl @json.FromJson for CodeGeneratorResponse_Feature with from_json(json: J
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for CodeGeneratorResponse_Feature with to_json(self : CodeGeneratorResponse_Feature) -> Json {
+pub impl ToJson for CodeGeneratorResponse_Feature with fn to_json(self : CodeGeneratorResponse_Feature) -> Json {
   match self {
     CodeGeneratorResponse_Feature::FEATURE_NONE => "FEATURE_NONE"
     CodeGeneratorResponse_Feature::FEATURE_PROTO3_OPTIONAL => "FEATURE_PROTO3_OPTIONAL"
@@ -382,7 +382,7 @@ pub(all) struct CodeGeneratorResponse_File {
   mut content : String?
   mut generated_code_info : @protobuf.GeneratedCodeInfo?
 } derive(Eq, Debug)
-pub impl @lib.Sized for CodeGeneratorResponse_File with size_of(self) {
+pub impl @lib.Sized for CodeGeneratorResponse_File with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -398,7 +398,7 @@ pub impl @lib.Sized for CodeGeneratorResponse_File with size_of(self) {
   }
   size
 }
-pub impl Default for CodeGeneratorResponse_File with default() -> CodeGeneratorResponse_File {
+pub impl Default for CodeGeneratorResponse_File with fn default() -> CodeGeneratorResponse_File {
   CodeGeneratorResponse_File::{
     name : None,
     insertion_point : None,
@@ -414,7 +414,7 @@ pub fn CodeGeneratorResponse_File::new(name? : String, insertion_point? : String
     generated_code_info,
   }
 }
-pub impl @lib.Read for CodeGeneratorResponse_File with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorResponse_File raise {
+pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
   try {
     for ;; {
@@ -432,7 +432,7 @@ pub impl @lib.Read for CodeGeneratorResponse_File with read_with_limit(reader : 
   }
   msg
 }
-pub impl @lib.Write for CodeGeneratorResponse_File with write(self: CodeGeneratorResponse_File, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for CodeGeneratorResponse_File with fn write(self: CodeGeneratorResponse_File, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -454,7 +454,7 @@ pub impl @lib.Write for CodeGeneratorResponse_File with write(self: CodeGenerato
 
   }
 }
-pub impl ToJson for CodeGeneratorResponse_File with to_json(self) {
+pub impl ToJson for CodeGeneratorResponse_File with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.name {
       Some(v) => json["name"] = v.to_json()
@@ -474,7 +474,7 @@ pub impl ToJson for CodeGeneratorResponse_File with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for CodeGeneratorResponse_File with from_json(json: Json, path: @json.JsonPath) -> CodeGeneratorResponse_File raise {
+pub impl @json.FromJson for CodeGeneratorResponse_File with fn from_json(json: Json, path: @json.JsonPath) -> CodeGeneratorResponse_File raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for CodeGeneratorResponse_File"))
   }
@@ -485,12 +485,12 @@ pub impl @json.FromJson for CodeGeneratorResponse_File with from_json(json: Json
       ("insertionPoint", value) => message.insertion_point = Some(@json.from_json(value, path~))
       ("content", value) => message.content = Some(@json.from_json(value, path~))
       ("generatedCodeInfo", value) => message.generated_code_info = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for CodeGeneratorResponse_File with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorResponse_File raise {
+pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
   try {
     for ;; {
@@ -508,7 +508,7 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse_File with read_with_limit(read
   }
   msg
 }
-pub impl @lib.AsyncWrite for CodeGeneratorResponse_File with write(self: CodeGeneratorResponse_File, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for CodeGeneratorResponse_File with fn write(self: CodeGeneratorResponse_File, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)
@@ -537,7 +537,7 @@ pub(all) struct CodeGeneratorResponse {
   mut maximum_edition : Int?
   mut file : Array[CodeGeneratorResponse_File]
 } derive(Eq, Debug)
-pub impl @lib.Sized for CodeGeneratorResponse with size_of(self) {
+pub impl @lib.Sized for CodeGeneratorResponse with fn size_of(self) {
   let mut size = 0U
   if self.error is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -557,7 +557,7 @@ pub impl @lib.Sized for CodeGeneratorResponse with size_of(self) {
   }
   size
 }
-pub impl Default for CodeGeneratorResponse with default() -> CodeGeneratorResponse {
+pub impl Default for CodeGeneratorResponse with fn default() -> CodeGeneratorResponse {
   CodeGeneratorResponse::{
     error : None,
     supported_features : None,
@@ -575,7 +575,7 @@ pub fn CodeGeneratorResponse::new(error? : String, supported_features? : UInt64,
     file,
   }
 }
-pub impl @lib.Read for CodeGeneratorResponse with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorResponse raise {
+pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
   try {
     for ;; {
@@ -594,7 +594,7 @@ pub impl @lib.Read for CodeGeneratorResponse with read_with_limit(reader : @lib.
   }
   msg
 }
-pub impl @lib.Write for CodeGeneratorResponse with write(self: CodeGeneratorResponse, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for CodeGeneratorResponse with fn write(self: CodeGeneratorResponse, writer : &@lib.Writer) -> Unit raise {
   if self.error is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -621,7 +621,7 @@ pub impl @lib.Write for CodeGeneratorResponse with write(self: CodeGeneratorResp
 
   }
 }
-pub impl ToJson for CodeGeneratorResponse with to_json(self) {
+pub impl ToJson for CodeGeneratorResponse with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.error {
       Some(v) => json["error"] = v.to_json()
@@ -644,7 +644,7 @@ pub impl ToJson for CodeGeneratorResponse with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for CodeGeneratorResponse with from_json(json: Json, path: @json.JsonPath) -> CodeGeneratorResponse raise {
+pub impl @json.FromJson for CodeGeneratorResponse with fn from_json(json: Json, path: @json.JsonPath) -> CodeGeneratorResponse raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for CodeGeneratorResponse"))
   }
@@ -657,12 +657,12 @@ pub impl @json.FromJson for CodeGeneratorResponse with from_json(json: Json, pat
       ("maximumEdition", value) => message.maximum_edition = Some(@json.from_json(value, path~))
       ("file", Array(value)) => message.file = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for CodeGeneratorResponse with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorResponse raise {
+pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
   try {
     for ;; {
@@ -681,7 +681,7 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse with read_with_limit(reader : 
   }
   msg
 }
-pub impl @lib.AsyncWrite for CodeGeneratorResponse with write(self: CodeGeneratorResponse, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for CodeGeneratorResponse with fn write(self: CodeGeneratorResponse, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.error is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)

--- a/test/snapshots/test_case5/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case5/__snapshot/src/top.mbt
@@ -1,9 +1,9 @@
 pub(all) struct EmptyMessage {
 } derive(Eq, Debug)
-pub impl @lib.Sized for EmptyMessage with size_of(_) {
+pub impl @lib.Sized for EmptyMessage with fn size_of(_) {
   0
 }
-pub impl Default for EmptyMessage with default() -> EmptyMessage {
+pub impl Default for EmptyMessage with fn default() -> EmptyMessage {
   EmptyMessage::{
   }
 }
@@ -11,19 +11,19 @@ pub fn EmptyMessage::new() -> EmptyMessage {
   EmptyMessage::{
   }
 }
-pub impl @lib.Read for EmptyMessage with read_with_limit(_) -> EmptyMessage noraise {
+pub impl @lib.Read for EmptyMessage with fn read_with_limit(_) -> EmptyMessage noraise {
   EmptyMessage::default()
 }
-pub impl @lib.Write for EmptyMessage with write(_, _) -> Unit noraise {
+pub impl @lib.Write for EmptyMessage with fn write(_, _) -> Unit noraise {
 }
-pub impl ToJson for EmptyMessage with to_json(_) {
+pub impl ToJson for EmptyMessage with fn to_json(_) {
   {}
 }
-pub impl @json.FromJson for EmptyMessage with from_json(_, _) -> EmptyMessage noraise {
+pub impl @json.FromJson for EmptyMessage with fn from_json(_, _) -> EmptyMessage noraise {
   EmptyMessage::default()
 }
-pub impl @lib.AsyncRead for EmptyMessage with read_with_limit(_) -> EmptyMessage noraise {
+pub impl @lib.AsyncRead for EmptyMessage with fn read_with_limit(_) -> EmptyMessage noraise {
   EmptyMessage::default()
 }
-pub impl @lib.AsyncWrite for EmptyMessage with write(_, _) -> Unit noraise {
+pub impl @lib.AsyncWrite for EmptyMessage with fn write(_, _) -> Unit noraise {
 }

--- a/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
@@ -2,13 +2,13 @@ pub(all) struct Timestamp {
   mut seconds : Int64
   mut nanos : Int
 } derive(Eq, Debug)
-pub impl @lib.Sized for Timestamp with size_of(self) {
+pub impl @lib.Sized for Timestamp with fn size_of(self) {
   let mut size = 0U
   size += 1U + @lib.size_of(self.seconds)
   size += 1U + @lib.size_of(self.nanos)
   size
 }
-pub impl Default for Timestamp with default() -> Timestamp {
+pub impl Default for Timestamp with fn default() -> Timestamp {
   Timestamp::{
     seconds : Int64::default(),
     nanos : Int::default(),
@@ -20,7 +20,7 @@ pub fn Timestamp::new(seconds : Int64, nanos : Int) -> Timestamp {
     nanos,
   }
 }
-pub impl @lib.Read for Timestamp with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Timestamp raise {
+pub impl @lib.Read for Timestamp with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Timestamp raise {
   let msg = Timestamp::default()
   try {
     for ;; {
@@ -36,13 +36,13 @@ pub impl @lib.Read for Timestamp with read_with_limit(reader : @lib.LimitedReade
   }
   msg
 }
-pub impl @lib.Write for Timestamp with write(self: Timestamp, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Timestamp with fn write(self: Timestamp, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(8UL);
   writer |> @lib.write_int64(self.seconds)
   writer |> @lib.write_varint(16UL);
   writer |> @lib.write_int32(self.nanos)
 }
-pub impl ToJson for Timestamp with to_json(self) {
+pub impl ToJson for Timestamp with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.seconds != Default::default() {
   json["seconds"] = self.seconds.to_json()
@@ -52,7 +52,7 @@ pub impl ToJson for Timestamp with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Timestamp with from_json(json: Json, path: @json.JsonPath) -> Timestamp raise {
+pub impl @json.FromJson for Timestamp with fn from_json(json: Json, path: @json.JsonPath) -> Timestamp raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Timestamp"))
   }
@@ -61,12 +61,12 @@ pub impl @json.FromJson for Timestamp with from_json(json: Json, path: @json.Jso
     match (key, value) {
       ("seconds", value) => message.seconds = @json.from_json(value, path~)
       ("nanos", value) => message.nanos = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Timestamp with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Timestamp raise {
+pub impl @lib.AsyncRead for Timestamp with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Timestamp raise {
   let msg = Timestamp::default()
   try {
     for ;; {
@@ -82,7 +82,7 @@ pub impl @lib.AsyncRead for Timestamp with read_with_limit(reader : @lib.Limited
   }
   msg
 }
-pub impl @lib.AsyncWrite for Timestamp with write(self: Timestamp, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Timestamp with fn write(self: Timestamp, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(8UL);
   writer |> @lib.async_write_int64(self.seconds)
   writer |> @lib.async_write_varint(16UL);

--- a/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
+++ b/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
@@ -5,7 +5,7 @@ pub(all) struct TreeNode {
   mut children : Array[TreeNode]
   mut sibling : TreeNode?
 } derive(Eq, Debug)
-pub impl @lib.Sized for TreeNode with size_of(self) {
+pub impl @lib.Sized for TreeNode with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
   if self.value is Some(v) {
@@ -23,7 +23,7 @@ pub impl @lib.Sized for TreeNode with size_of(self) {
   }
   size
 }
-pub impl Default for TreeNode with default() -> TreeNode {
+pub impl Default for TreeNode with fn default() -> TreeNode {
   TreeNode::{
     name : String::default(),
     value : None,
@@ -41,7 +41,7 @@ pub fn TreeNode::new(name : String, value? : Int, parent? : TreeNode, children :
     sibling,
   }
 }
-pub impl @lib.Read for TreeNode with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> TreeNode raise {
+pub impl @lib.Read for TreeNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> TreeNode raise {
   let msg = TreeNode::default()
   try {
     for ;; {
@@ -60,7 +60,7 @@ pub impl @lib.Read for TreeNode with read_with_limit(reader : @lib.LimitedReader
   }
   msg
 }
-pub impl @lib.Write for TreeNode with write(self: TreeNode, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for TreeNode with fn write(self: TreeNode, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.name)
   if self.value is Some(v) {
@@ -84,7 +84,7 @@ pub impl @lib.Write for TreeNode with write(self: TreeNode, writer : &@lib.Write
 
   }
 }
-pub impl ToJson for TreeNode with to_json(self) {
+pub impl ToJson for TreeNode with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.name != Default::default() {
   json["name"] = self.name.to_json()
@@ -106,7 +106,7 @@ pub impl ToJson for TreeNode with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for TreeNode with from_json(json: Json, path: @json.JsonPath) -> TreeNode raise {
+pub impl @json.FromJson for TreeNode with fn from_json(json: Json, path: @json.JsonPath) -> TreeNode raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for TreeNode"))
   }
@@ -119,12 +119,12 @@ pub impl @json.FromJson for TreeNode with from_json(json: Json, path: @json.Json
       ("children", Array(value)) => message.children = value.map(v => 
 @json.from_json(v, path~))
       ("sibling", value) => message.sibling = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for TreeNode with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> TreeNode raise {
+pub impl @lib.AsyncRead for TreeNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> TreeNode raise {
   let msg = TreeNode::default()
   try {
     for ;; {
@@ -143,7 +143,7 @@ pub impl @lib.AsyncRead for TreeNode with read_with_limit(reader : @lib.LimitedR
   }
   msg
 }
-pub impl @lib.AsyncWrite for TreeNode with write(self: TreeNode, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for TreeNode with fn write(self: TreeNode, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.name)
   if self.value is Some(v) {
@@ -172,7 +172,7 @@ pub(all) struct ListNode {
   mut next : ListNode?
   mut prev : ListNode?
 } derive(Eq, Debug)
-pub impl @lib.Sized for ListNode with size_of(self) {
+pub impl @lib.Sized for ListNode with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.data); @lib.size_of(size) + size }
   if self.next is Some(v) {
@@ -183,7 +183,7 @@ pub impl @lib.Sized for ListNode with size_of(self) {
   }
   size
 }
-pub impl Default for ListNode with default() -> ListNode {
+pub impl Default for ListNode with fn default() -> ListNode {
   ListNode::{
     data : String::default(),
     next : None,
@@ -197,7 +197,7 @@ pub fn ListNode::new(data : String, next? : ListNode, prev? : ListNode) -> ListN
     prev,
   }
 }
-pub impl @lib.Read for ListNode with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ListNode raise {
+pub impl @lib.Read for ListNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ListNode raise {
   let msg = ListNode::default()
   try {
     for ;; {
@@ -214,7 +214,7 @@ pub impl @lib.Read for ListNode with read_with_limit(reader : @lib.LimitedReader
   }
   msg
 }
-pub impl @lib.Write for ListNode with write(self: ListNode, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for ListNode with fn write(self: ListNode, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.data)
   if self.next is Some(v) {
@@ -228,7 +228,7 @@ pub impl @lib.Write for ListNode with write(self: ListNode, writer : &@lib.Write
 
   }
 }
-pub impl ToJson for ListNode with to_json(self) {
+pub impl ToJson for ListNode with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.data != Default::default() {
   json["data"] = self.data.to_json()
@@ -243,7 +243,7 @@ pub impl ToJson for ListNode with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for ListNode with from_json(json: Json, path: @json.JsonPath) -> ListNode raise {
+pub impl @json.FromJson for ListNode with fn from_json(json: Json, path: @json.JsonPath) -> ListNode raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for ListNode"))
   }
@@ -253,12 +253,12 @@ pub impl @json.FromJson for ListNode with from_json(json: Json, path: @json.Json
       ("data", value) => message.data = @json.from_json(value, path~)
       ("next", value) => message.next = Some(@json.from_json(value, path~))
       ("prev", value) => message.prev = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for ListNode with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ListNode raise {
+pub impl @lib.AsyncRead for ListNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ListNode raise {
   let msg = ListNode::default()
   try {
     for ;; {
@@ -275,7 +275,7 @@ pub impl @lib.AsyncRead for ListNode with read_with_limit(reader : @lib.LimitedR
   }
   msg
 }
-pub impl @lib.AsyncWrite for ListNode with write(self: ListNode, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for ListNode with fn write(self: ListNode, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.data)
   if self.next is Some(v) {
@@ -295,7 +295,7 @@ pub(all) struct GraphNode {
   mut neighbors : Array[GraphNode]
   mut visited : Bool?
 } derive(Eq, Debug)
-pub impl @lib.Sized for GraphNode with size_of(self) {
+pub impl @lib.Sized for GraphNode with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.id); @lib.size_of(size) + size }
   if self.label is Some(v) {
@@ -310,7 +310,7 @@ pub impl @lib.Sized for GraphNode with size_of(self) {
   }
   size
 }
-pub impl Default for GraphNode with default() -> GraphNode {
+pub impl Default for GraphNode with fn default() -> GraphNode {
   GraphNode::{
     id : String::default(),
     label : None,
@@ -326,7 +326,7 @@ pub fn GraphNode::new(id : String, label? : String, neighbors : Array[GraphNode]
     visited,
   }
 }
-pub impl @lib.Read for GraphNode with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GraphNode raise {
+pub impl @lib.Read for GraphNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GraphNode raise {
   let msg = GraphNode::default()
   try {
     for ;; {
@@ -344,7 +344,7 @@ pub impl @lib.Read for GraphNode with read_with_limit(reader : @lib.LimitedReade
   }
   msg
 }
-pub impl @lib.Write for GraphNode with write(self: GraphNode, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for GraphNode with fn write(self: GraphNode, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.id)
   if self.label is Some(v) {
@@ -363,7 +363,7 @@ pub impl @lib.Write for GraphNode with write(self: GraphNode, writer : &@lib.Wri
 
   }
 }
-pub impl ToJson for GraphNode with to_json(self) {
+pub impl ToJson for GraphNode with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.id != Default::default() {
   json["id"] = self.id.to_json()
@@ -381,7 +381,7 @@ pub impl ToJson for GraphNode with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for GraphNode with from_json(json: Json, path: @json.JsonPath) -> GraphNode raise {
+pub impl @json.FromJson for GraphNode with fn from_json(json: Json, path: @json.JsonPath) -> GraphNode raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for GraphNode"))
   }
@@ -393,12 +393,12 @@ pub impl @json.FromJson for GraphNode with from_json(json: Json, path: @json.Jso
       ("neighbors", Array(value)) => message.neighbors = value.map(v => 
 @json.from_json(v, path~))
       ("visited", value) => message.visited = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for GraphNode with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GraphNode raise {
+pub impl @lib.AsyncRead for GraphNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GraphNode raise {
   let msg = GraphNode::default()
   try {
     for ;; {
@@ -416,7 +416,7 @@ pub impl @lib.AsyncRead for GraphNode with read_with_limit(reader : @lib.Limited
   }
   msg
 }
-pub impl @lib.AsyncWrite for GraphNode with write(self: GraphNode, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for GraphNode with fn write(self: GraphNode, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.id)
   if self.label is Some(v) {
@@ -440,7 +440,7 @@ pub(all) struct NestedSelfRef_Inner {
   mut outer_ref : NestedSelfRef?
   mut inner_ref : NestedSelfRef_Inner?
 } derive(Eq, Debug)
-pub impl @lib.Sized for NestedSelfRef_Inner with size_of(self) {
+pub impl @lib.Sized for NestedSelfRef_Inner with fn size_of(self) {
   let mut size = 0U
   if self.inner_name is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -453,7 +453,7 @@ pub impl @lib.Sized for NestedSelfRef_Inner with size_of(self) {
   }
   size
 }
-pub impl Default for NestedSelfRef_Inner with default() -> NestedSelfRef_Inner {
+pub impl Default for NestedSelfRef_Inner with fn default() -> NestedSelfRef_Inner {
   NestedSelfRef_Inner::{
     inner_name : None,
     outer_ref : None,
@@ -467,7 +467,7 @@ pub fn NestedSelfRef_Inner::new(inner_name? : String, outer_ref? : NestedSelfRef
     inner_ref,
   }
 }
-pub impl @lib.Read for NestedSelfRef_Inner with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> NestedSelfRef_Inner raise {
+pub impl @lib.Read for NestedSelfRef_Inner with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> NestedSelfRef_Inner raise {
   let msg = NestedSelfRef_Inner::default()
   try {
     for ;; {
@@ -484,7 +484,7 @@ pub impl @lib.Read for NestedSelfRef_Inner with read_with_limit(reader : @lib.Li
   }
   msg
 }
-pub impl @lib.Write for NestedSelfRef_Inner with write(self: NestedSelfRef_Inner, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for NestedSelfRef_Inner with fn write(self: NestedSelfRef_Inner, writer : &@lib.Writer) -> Unit raise {
   if self.inner_name is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -501,7 +501,7 @@ pub impl @lib.Write for NestedSelfRef_Inner with write(self: NestedSelfRef_Inner
 
   }
 }
-pub impl ToJson for NestedSelfRef_Inner with to_json(self) {
+pub impl ToJson for NestedSelfRef_Inner with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.inner_name {
       Some(v) => json["innerName"] = v.to_json()
@@ -517,7 +517,7 @@ pub impl ToJson for NestedSelfRef_Inner with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for NestedSelfRef_Inner with from_json(json: Json, path: @json.JsonPath) -> NestedSelfRef_Inner raise {
+pub impl @json.FromJson for NestedSelfRef_Inner with fn from_json(json: Json, path: @json.JsonPath) -> NestedSelfRef_Inner raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for NestedSelfRef_Inner"))
   }
@@ -527,12 +527,12 @@ pub impl @json.FromJson for NestedSelfRef_Inner with from_json(json: Json, path:
       ("innerName", value) => message.inner_name = Some(@json.from_json(value, path~))
       ("outerRef", value) => message.outer_ref = Some(@json.from_json(value, path~))
       ("innerRef", value) => message.inner_ref = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for NestedSelfRef_Inner with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> NestedSelfRef_Inner raise {
+pub impl @lib.AsyncRead for NestedSelfRef_Inner with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> NestedSelfRef_Inner raise {
   let msg = NestedSelfRef_Inner::default()
   try {
     for ;; {
@@ -549,7 +549,7 @@ pub impl @lib.AsyncRead for NestedSelfRef_Inner with read_with_limit(reader : @l
   }
   msg
 }
-pub impl @lib.AsyncWrite for NestedSelfRef_Inner with write(self: NestedSelfRef_Inner, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for NestedSelfRef_Inner with fn write(self: NestedSelfRef_Inner, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.inner_name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)
@@ -571,7 +571,7 @@ pub(all) struct NestedSelfRef {
   mut inner : NestedSelfRef_Inner?
   mut self_ref : NestedSelfRef?
 } derive(Eq, Debug)
-pub impl @lib.Sized for NestedSelfRef with size_of(self) {
+pub impl @lib.Sized for NestedSelfRef with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
   if self.inner is Some(v) {
@@ -582,7 +582,7 @@ pub impl @lib.Sized for NestedSelfRef with size_of(self) {
   }
   size
 }
-pub impl Default for NestedSelfRef with default() -> NestedSelfRef {
+pub impl Default for NestedSelfRef with fn default() -> NestedSelfRef {
   NestedSelfRef::{
     name : String::default(),
     inner : None,
@@ -596,7 +596,7 @@ pub fn NestedSelfRef::new(name : String, inner? : NestedSelfRef_Inner, self_ref?
     self_ref,
   }
 }
-pub impl @lib.Read for NestedSelfRef with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> NestedSelfRef raise {
+pub impl @lib.Read for NestedSelfRef with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> NestedSelfRef raise {
   let msg = NestedSelfRef::default()
   try {
     for ;; {
@@ -613,7 +613,7 @@ pub impl @lib.Read for NestedSelfRef with read_with_limit(reader : @lib.LimitedR
   }
   msg
 }
-pub impl @lib.Write for NestedSelfRef with write(self: NestedSelfRef, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for NestedSelfRef with fn write(self: NestedSelfRef, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.name)
   if self.inner is Some(v) {
@@ -627,7 +627,7 @@ pub impl @lib.Write for NestedSelfRef with write(self: NestedSelfRef, writer : &
 
   }
 }
-pub impl ToJson for NestedSelfRef with to_json(self) {
+pub impl ToJson for NestedSelfRef with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.name != Default::default() {
   json["name"] = self.name.to_json()
@@ -642,7 +642,7 @@ pub impl ToJson for NestedSelfRef with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for NestedSelfRef with from_json(json: Json, path: @json.JsonPath) -> NestedSelfRef raise {
+pub impl @json.FromJson for NestedSelfRef with fn from_json(json: Json, path: @json.JsonPath) -> NestedSelfRef raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for NestedSelfRef"))
   }
@@ -652,12 +652,12 @@ pub impl @json.FromJson for NestedSelfRef with from_json(json: Json, path: @json
       ("name", value) => message.name = @json.from_json(value, path~)
       ("inner", value) => message.inner = Some(@json.from_json(value, path~))
       ("selfRef", value) => message.self_ref = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for NestedSelfRef with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> NestedSelfRef raise {
+pub impl @lib.AsyncRead for NestedSelfRef with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> NestedSelfRef raise {
   let msg = NestedSelfRef::default()
   try {
     for ;; {
@@ -674,7 +674,7 @@ pub impl @lib.AsyncRead for NestedSelfRef with read_with_limit(reader : @lib.Lim
   }
   msg
 }
-pub impl @lib.AsyncWrite for NestedSelfRef with write(self: NestedSelfRef, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for NestedSelfRef with fn write(self: NestedSelfRef, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.name)
   if self.inner is Some(v) {
@@ -695,7 +695,7 @@ pub(all) struct Organization {
   mut sub_orgs : Array[Organization]
   mut employees : Array[Employee]
 } derive(Eq, Debug)
-pub impl @lib.Sized for Organization with size_of(self) {
+pub impl @lib.Sized for Organization with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
   if self.description is Some(v) {
@@ -714,7 +714,7 @@ pub impl @lib.Sized for Organization with size_of(self) {
   }
   size
 }
-pub impl Default for Organization with default() -> Organization {
+pub impl Default for Organization with fn default() -> Organization {
   Organization::{
     name : String::default(),
     description : None,
@@ -732,7 +732,7 @@ pub fn Organization::new(name : String, description? : String, parent_org? : Org
     employees,
   }
 }
-pub impl @lib.Read for Organization with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Organization raise {
+pub impl @lib.Read for Organization with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Organization raise {
   let msg = Organization::default()
   try {
     for ;; {
@@ -751,7 +751,7 @@ pub impl @lib.Read for Organization with read_with_limit(reader : @lib.LimitedRe
   }
   msg
 }
-pub impl @lib.Write for Organization with write(self: Organization, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Organization with fn write(self: Organization, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.name)
   if self.description is Some(v) {
@@ -775,7 +775,7 @@ pub impl @lib.Write for Organization with write(self: Organization, writer : &@l
 
   }
 }
-pub impl ToJson for Organization with to_json(self) {
+pub impl ToJson for Organization with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.name != Default::default() {
   json["name"] = self.name.to_json()
@@ -796,7 +796,7 @@ pub impl ToJson for Organization with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Organization with from_json(json: Json, path: @json.JsonPath) -> Organization raise {
+pub impl @json.FromJson for Organization with fn from_json(json: Json, path: @json.JsonPath) -> Organization raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Organization"))
   }
@@ -810,12 +810,12 @@ pub impl @json.FromJson for Organization with from_json(json: Json, path: @json.
 @json.from_json(v, path~))
       ("employees", Array(value)) => message.employees = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Organization with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Organization raise {
+pub impl @lib.AsyncRead for Organization with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Organization raise {
   let msg = Organization::default()
   try {
     for ;; {
@@ -834,7 +834,7 @@ pub impl @lib.AsyncRead for Organization with read_with_limit(reader : @lib.Limi
   }
   msg
 }
-pub impl @lib.AsyncWrite for Organization with write(self: Organization, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Organization with fn write(self: Organization, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.name)
   if self.description is Some(v) {
@@ -865,7 +865,7 @@ pub(all) struct Employee {
   mut manager : Employee?
   mut subordinates : Array[Employee]
 } derive(Eq, Debug)
-pub impl @lib.Sized for Employee with size_of(self) {
+pub impl @lib.Sized for Employee with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
   size += 1U + { let size = @lib.size_of(self.id); @lib.size_of(size) + size }
@@ -881,7 +881,7 @@ pub impl @lib.Sized for Employee with size_of(self) {
   }
   size
 }
-pub impl Default for Employee with default() -> Employee {
+pub impl Default for Employee with fn default() -> Employee {
   Employee::{
     name : String::default(),
     id : String::default(),
@@ -899,7 +899,7 @@ pub fn Employee::new(name : String, id : String, organization? : Organization, m
     subordinates,
   }
 }
-pub impl @lib.Read for Employee with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Employee raise {
+pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Employee raise {
   let msg = Employee::default()
   try {
     for ;; {
@@ -918,7 +918,7 @@ pub impl @lib.Read for Employee with read_with_limit(reader : @lib.LimitedReader
   }
   msg
 }
-pub impl @lib.Write for Employee with write(self: Employee, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.name)
   writer |> @lib.write_varint(18UL);
@@ -939,7 +939,7 @@ pub impl @lib.Write for Employee with write(self: Employee, writer : &@lib.Write
 
   }
 }
-pub impl ToJson for Employee with to_json(self) {
+pub impl ToJson for Employee with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.name != Default::default() {
   json["name"] = self.name.to_json()
@@ -960,7 +960,7 @@ pub impl ToJson for Employee with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Employee with from_json(json: Json, path: @json.JsonPath) -> Employee raise {
+pub impl @json.FromJson for Employee with fn from_json(json: Json, path: @json.JsonPath) -> Employee raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Employee"))
   }
@@ -973,12 +973,12 @@ pub impl @json.FromJson for Employee with from_json(json: Json, path: @json.Json
       ("manager", value) => message.manager = Some(@json.from_json(value, path~))
       ("subordinates", Array(value)) => message.subordinates = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Employee with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Employee raise {
+pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Employee raise {
   let msg = Employee::default()
   try {
     for ;; {
@@ -997,7 +997,7 @@ pub impl @lib.AsyncRead for Employee with read_with_limit(reader : @lib.LimitedR
   }
   msg
 }
-pub impl @lib.AsyncWrite for Employee with write(self: Employee, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.name)
   writer |> @lib.async_write_varint(18UL);

--- a/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
+++ b/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
@@ -5,7 +5,7 @@ pub(all) struct User {
   mut orders : Array[Order]
   mut friends : Array[User]
 } derive(Eq, Debug)
-pub impl @lib.Sized for User with size_of(self) {
+pub impl @lib.Sized for User with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.user_id); @lib.size_of(size) + size }
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
@@ -22,7 +22,7 @@ pub impl @lib.Sized for User with size_of(self) {
   }
   size
 }
-pub impl Default for User with default() -> User {
+pub impl Default for User with fn default() -> User {
   User::{
     user_id : String::default(),
     name : String::default(),
@@ -40,7 +40,7 @@ pub fn User::new(user_id : String, name : String, email? : String, orders : Arra
     friends,
   }
 }
-pub impl @lib.Read for User with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> User raise {
+pub impl @lib.Read for User with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> User raise {
   let msg = User::default()
   try {
     for ;; {
@@ -59,7 +59,7 @@ pub impl @lib.Read for User with read_with_limit(reader : @lib.LimitedReader[&@l
   }
   msg
 }
-pub impl @lib.Write for User with write(self: User, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for User with fn write(self: User, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.user_id)
   writer |> @lib.write_varint(18UL);
@@ -80,7 +80,7 @@ pub impl @lib.Write for User with write(self: User, writer : &@lib.Writer) -> Un
 
   }
 }
-pub impl ToJson for User with to_json(self) {
+pub impl ToJson for User with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.user_id != Default::default() {
   json["userId"] = self.user_id.to_json()
@@ -100,7 +100,7 @@ pub impl ToJson for User with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for User with from_json(json: Json, path: @json.JsonPath) -> User raise {
+pub impl @json.FromJson for User with fn from_json(json: Json, path: @json.JsonPath) -> User raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for User"))
   }
@@ -114,12 +114,12 @@ pub impl @json.FromJson for User with from_json(json: Json, path: @json.JsonPath
 @json.from_json(v, path~))
       ("friends", Array(value)) => message.friends = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for User with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> User raise {
+pub impl @lib.AsyncRead for User with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> User raise {
   let msg = User::default()
   try {
     for ;; {
@@ -138,7 +138,7 @@ pub impl @lib.AsyncRead for User with read_with_limit(reader : @lib.LimitedReade
   }
   msg
 }
-pub impl @lib.AsyncWrite for User with write(self: User, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for User with fn write(self: User, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.user_id)
   writer |> @lib.async_write_varint(18UL);
@@ -166,7 +166,7 @@ pub(all) struct Order {
   mut customer : User?
   mut related_orders : Array[Order]
 } derive(Eq, Debug)
-pub impl @lib.Sized for Order with size_of(self) {
+pub impl @lib.Sized for Order with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.order_id); @lib.size_of(size) + size }
   size += 1U + { let size = @lib.size_of(self.product_name); @lib.size_of(size) + size }
@@ -182,7 +182,7 @@ pub impl @lib.Sized for Order with size_of(self) {
   }
   size
 }
-pub impl Default for Order with default() -> Order {
+pub impl Default for Order with fn default() -> Order {
   Order::{
     order_id : String::default(),
     product_name : String::default(),
@@ -200,7 +200,7 @@ pub fn Order::new(order_id : String, product_name : String, amount? : Double, cu
     related_orders,
   }
 }
-pub impl @lib.Read for Order with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Order raise {
+pub impl @lib.Read for Order with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Order raise {
   let msg = Order::default()
   try {
     for ;; {
@@ -219,7 +219,7 @@ pub impl @lib.Read for Order with read_with_limit(reader : @lib.LimitedReader[&@
   }
   msg
 }
-pub impl @lib.Write for Order with write(self: Order, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Order with fn write(self: Order, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.order_id)
   writer |> @lib.write_varint(18UL);
@@ -240,7 +240,7 @@ pub impl @lib.Write for Order with write(self: Order, writer : &@lib.Writer) -> 
 
   }
 }
-pub impl ToJson for Order with to_json(self) {
+pub impl ToJson for Order with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.order_id != Default::default() {
   json["orderId"] = self.order_id.to_json()
@@ -261,7 +261,7 @@ pub impl ToJson for Order with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Order with from_json(json: Json, path: @json.JsonPath) -> Order raise {
+pub impl @json.FromJson for Order with fn from_json(json: Json, path: @json.JsonPath) -> Order raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Order"))
   }
@@ -274,12 +274,12 @@ pub impl @json.FromJson for Order with from_json(json: Json, path: @json.JsonPat
       ("customer", value) => message.customer = Some(@json.from_json(value, path~))
       ("relatedOrders", Array(value)) => message.related_orders = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Order with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Order raise {
+pub impl @lib.AsyncRead for Order with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Order raise {
   let msg = Order::default()
   try {
     for ;; {
@@ -298,7 +298,7 @@ pub impl @lib.AsyncRead for Order with read_with_limit(reader : @lib.LimitedRead
   }
   msg
 }
-pub impl @lib.AsyncWrite for Order with write(self: Order, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Order with fn write(self: Order, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.order_id)
   writer |> @lib.async_write_varint(18UL);
@@ -326,7 +326,7 @@ pub(all) struct Department {
   mut projects : Array[Project]
   mut parent_dept : Department?
 } derive(Eq, Debug)
-pub impl @lib.Sized for Department with size_of(self) {
+pub impl @lib.Sized for Department with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.dept_id); @lib.size_of(size) + size }
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
@@ -343,7 +343,7 @@ pub impl @lib.Sized for Department with size_of(self) {
   }
   size
 }
-pub impl Default for Department with default() -> Department {
+pub impl Default for Department with fn default() -> Department {
   Department::{
     dept_id : String::default(),
     name : String::default(),
@@ -361,7 +361,7 @@ pub fn Department::new(dept_id : String, name : String, employees : Array[Employ
     parent_dept,
   }
 }
-pub impl @lib.Read for Department with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Department raise {
+pub impl @lib.Read for Department with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Department raise {
   let msg = Department::default()
   try {
     for ;; {
@@ -380,7 +380,7 @@ pub impl @lib.Read for Department with read_with_limit(reader : @lib.LimitedRead
   }
   msg
 }
-pub impl @lib.Write for Department with write(self: Department, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Department with fn write(self: Department, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.dept_id)
   writer |> @lib.write_varint(18UL);
@@ -401,7 +401,7 @@ pub impl @lib.Write for Department with write(self: Department, writer : &@lib.W
 
   }
 }
-pub impl ToJson for Department with to_json(self) {
+pub impl ToJson for Department with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.dept_id != Default::default() {
   json["deptId"] = self.dept_id.to_json()
@@ -421,7 +421,7 @@ pub impl ToJson for Department with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for Department with from_json(json: Json, path: @json.JsonPath) -> Department raise {
+pub impl @json.FromJson for Department with fn from_json(json: Json, path: @json.JsonPath) -> Department raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Department"))
   }
@@ -435,12 +435,12 @@ pub impl @json.FromJson for Department with from_json(json: Json, path: @json.Js
       ("projects", Array(value)) => message.projects = value.map(v => 
 @json.from_json(v, path~))
       ("parentDept", value) => message.parent_dept = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Department with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Department raise {
+pub impl @lib.AsyncRead for Department with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Department raise {
   let msg = Department::default()
   try {
     for ;; {
@@ -459,7 +459,7 @@ pub impl @lib.AsyncRead for Department with read_with_limit(reader : @lib.Limite
   }
   msg
 }
-pub impl @lib.AsyncWrite for Department with write(self: Department, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Department with fn write(self: Department, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.dept_id)
   writer |> @lib.async_write_varint(18UL);
@@ -488,7 +488,7 @@ pub(all) struct Employee {
   mut supervisor : Employee?
   mut subordinates : Array[Employee]
 } derive(Eq, Debug)
-pub impl @lib.Sized for Employee with size_of(self) {
+pub impl @lib.Sized for Employee with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.emp_id); @lib.size_of(size) + size }
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
@@ -508,7 +508,7 @@ pub impl @lib.Sized for Employee with size_of(self) {
   }
   size
 }
-pub impl Default for Employee with default() -> Employee {
+pub impl Default for Employee with fn default() -> Employee {
   Employee::{
     emp_id : String::default(),
     name : String::default(),
@@ -528,7 +528,7 @@ pub fn Employee::new(emp_id : String, name : String, department? : Department, p
     subordinates,
   }
 }
-pub impl @lib.Read for Employee with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Employee raise {
+pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Employee raise {
   let msg = Employee::default()
   try {
     for ;; {
@@ -548,7 +548,7 @@ pub impl @lib.Read for Employee with read_with_limit(reader : @lib.LimitedReader
   }
   msg
 }
-pub impl @lib.Write for Employee with write(self: Employee, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.emp_id)
   writer |> @lib.write_varint(18UL);
@@ -574,7 +574,7 @@ pub impl @lib.Write for Employee with write(self: Employee, writer : &@lib.Write
 
   }
 }
-pub impl ToJson for Employee with to_json(self) {
+pub impl ToJson for Employee with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.emp_id != Default::default() {
   json["empId"] = self.emp_id.to_json()
@@ -598,7 +598,7 @@ pub impl ToJson for Employee with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Employee with from_json(json: Json, path: @json.JsonPath) -> Employee raise {
+pub impl @json.FromJson for Employee with fn from_json(json: Json, path: @json.JsonPath) -> Employee raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Employee"))
   }
@@ -613,12 +613,12 @@ pub impl @json.FromJson for Employee with from_json(json: Json, path: @json.Json
       ("supervisor", value) => message.supervisor = Some(@json.from_json(value, path~))
       ("subordinates", Array(value)) => message.subordinates = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Employee with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Employee raise {
+pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Employee raise {
   let msg = Employee::default()
   try {
     for ;; {
@@ -638,7 +638,7 @@ pub impl @lib.AsyncRead for Employee with read_with_limit(reader : @lib.LimitedR
   }
   msg
 }
-pub impl @lib.AsyncWrite for Employee with write(self: Employee, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.emp_id)
   writer |> @lib.async_write_varint(18UL);
@@ -673,7 +673,7 @@ pub(all) struct Project {
   mut dependencies : Array[Project]
   mut dependents : Array[Project]
 } derive(Eq, Debug)
-pub impl @lib.Sized for Project with size_of(self) {
+pub impl @lib.Sized for Project with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.project_id); @lib.size_of(size) + size }
   size += 1U + { let size = @lib.size_of(self.title); @lib.size_of(size) + size }
@@ -697,7 +697,7 @@ pub impl @lib.Sized for Project with size_of(self) {
   }
   size
 }
-pub impl Default for Project with default() -> Project {
+pub impl Default for Project with fn default() -> Project {
   Project::{
     project_id : String::default(),
     title : String::default(),
@@ -719,7 +719,7 @@ pub fn Project::new(project_id : String, title : String, description? : String, 
     dependents,
   }
 }
-pub impl @lib.Read for Project with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Project raise {
+pub impl @lib.Read for Project with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Project raise {
   let msg = Project::default()
   try {
     for ;; {
@@ -740,7 +740,7 @@ pub impl @lib.Read for Project with read_with_limit(reader : @lib.LimitedReader[
   }
   msg
 }
-pub impl @lib.Write for Project with write(self: Project, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Project with fn write(self: Project, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.project_id)
   writer |> @lib.write_varint(18UL);
@@ -771,7 +771,7 @@ pub impl @lib.Write for Project with write(self: Project, writer : &@lib.Writer)
 
   }
 }
-pub impl ToJson for Project with to_json(self) {
+pub impl ToJson for Project with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.project_id != Default::default() {
   json["projectId"] = self.project_id.to_json()
@@ -798,7 +798,7 @@ pub impl ToJson for Project with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Project with from_json(json: Json, path: @json.JsonPath) -> Project raise {
+pub impl @json.FromJson for Project with fn from_json(json: Json, path: @json.JsonPath) -> Project raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Project"))
   }
@@ -815,12 +815,12 @@ pub impl @json.FromJson for Project with from_json(json: Json, path: @json.JsonP
 @json.from_json(v, path~))
       ("dependents", Array(value)) => message.dependents = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Project with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Project raise {
+pub impl @lib.AsyncRead for Project with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Project raise {
   let msg = Project::default()
   try {
     for ;; {
@@ -841,7 +841,7 @@ pub impl @lib.AsyncRead for Project with read_with_limit(reader : @lib.LimitedRe
   }
   msg
 }
-pub impl @lib.AsyncWrite for Project with write(self: Project, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Project with fn write(self: Project, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.project_id)
   writer |> @lib.async_write_varint(18UL);
@@ -879,7 +879,7 @@ pub(all) struct Node_Connection {
   mut target : Node?
   mut weight : Weight?
 } derive(Eq, Debug)
-pub impl @lib.Sized for Node_Connection with size_of(self) {
+pub impl @lib.Sized for Node_Connection with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.connection_id); @lib.size_of(size) + size }
   if self.type_ is Some(v) {
@@ -896,7 +896,7 @@ pub impl @lib.Sized for Node_Connection with size_of(self) {
   }
   size
 }
-pub impl Default for Node_Connection with default() -> Node_Connection {
+pub impl Default for Node_Connection with fn default() -> Node_Connection {
   Node_Connection::{
     connection_id : String::default(),
     type_ : None,
@@ -914,7 +914,7 @@ pub fn Node_Connection::new(connection_id : String, type_? : String, source? : N
     weight,
   }
 }
-pub impl @lib.Read for Node_Connection with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Node_Connection raise {
+pub impl @lib.Read for Node_Connection with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Node_Connection raise {
   let msg = Node_Connection::default()
   try {
     for ;; {
@@ -933,7 +933,7 @@ pub impl @lib.Read for Node_Connection with read_with_limit(reader : @lib.Limite
   }
   msg
 }
-pub impl @lib.Write for Node_Connection with write(self: Node_Connection, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Node_Connection with fn write(self: Node_Connection, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.connection_id)
   if self.type_ is Some(v) {
@@ -957,7 +957,7 @@ pub impl @lib.Write for Node_Connection with write(self: Node_Connection, writer
 
   }
 }
-pub impl ToJson for Node_Connection with to_json(self) {
+pub impl ToJson for Node_Connection with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.connection_id != Default::default() {
   json["connectionId"] = self.connection_id.to_json()
@@ -980,7 +980,7 @@ pub impl ToJson for Node_Connection with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for Node_Connection with from_json(json: Json, path: @json.JsonPath) -> Node_Connection raise {
+pub impl @json.FromJson for Node_Connection with fn from_json(json: Json, path: @json.JsonPath) -> Node_Connection raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Node_Connection"))
   }
@@ -992,12 +992,12 @@ pub impl @json.FromJson for Node_Connection with from_json(json: Json, path: @js
       ("source", value) => message.source = Some(@json.from_json(value, path~))
       ("target", value) => message.target = Some(@json.from_json(value, path~))
       ("weight", value) => message.weight = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Node_Connection with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Node_Connection raise {
+pub impl @lib.AsyncRead for Node_Connection with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Node_Connection raise {
   let msg = Node_Connection::default()
   try {
     for ;; {
@@ -1016,7 +1016,7 @@ pub impl @lib.AsyncRead for Node_Connection with read_with_limit(reader : @lib.L
   }
   msg
 }
-pub impl @lib.AsyncWrite for Node_Connection with write(self: Node_Connection, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Node_Connection with fn write(self: Node_Connection, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.connection_id)
   if self.type_ is Some(v) {
@@ -1046,7 +1046,7 @@ pub(all) struct Node {
   mut connections : Array[Node_Connection]
   mut neighbors : Array[Node]
 } derive(Eq, Debug)
-pub impl @lib.Sized for Node with size_of(self) {
+pub impl @lib.Sized for Node with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.id); @lib.size_of(size) + size }
   if self.data is Some(v) {
@@ -1062,7 +1062,7 @@ pub impl @lib.Sized for Node with size_of(self) {
   }
   size
 }
-pub impl Default for Node with default() -> Node {
+pub impl Default for Node with fn default() -> Node {
   Node::{
     id : String::default(),
     data : None,
@@ -1078,7 +1078,7 @@ pub fn Node::new(id : String, data? : String, connections : Array[Node_Connectio
     neighbors,
   }
 }
-pub impl @lib.Read for Node with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Node raise {
+pub impl @lib.Read for Node with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Node raise {
   let msg = Node::default()
   try {
     for ;; {
@@ -1096,7 +1096,7 @@ pub impl @lib.Read for Node with read_with_limit(reader : @lib.LimitedReader[&@l
   }
   msg
 }
-pub impl @lib.Write for Node with write(self: Node, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Node with fn write(self: Node, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.id)
   if self.data is Some(v) {
@@ -1115,7 +1115,7 @@ pub impl @lib.Write for Node with write(self: Node, writer : &@lib.Writer) -> Un
 
   }
 }
-pub impl ToJson for Node with to_json(self) {
+pub impl ToJson for Node with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.id != Default::default() {
   json["id"] = self.id.to_json()
@@ -1132,7 +1132,7 @@ pub impl ToJson for Node with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Node with from_json(json: Json, path: @json.JsonPath) -> Node raise {
+pub impl @json.FromJson for Node with fn from_json(json: Json, path: @json.JsonPath) -> Node raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Node"))
   }
@@ -1145,12 +1145,12 @@ pub impl @json.FromJson for Node with from_json(json: Json, path: @json.JsonPath
 @json.from_json(v, path~))
       ("neighbors", Array(value)) => message.neighbors = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Node with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Node raise {
+pub impl @lib.AsyncRead for Node with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Node raise {
   let msg = Node::default()
   try {
     for ;; {
@@ -1168,7 +1168,7 @@ pub impl @lib.AsyncRead for Node with read_with_limit(reader : @lib.LimitedReade
   }
   msg
 }
-pub impl @lib.AsyncWrite for Node with write(self: Node, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Node with fn write(self: Node, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.id)
   if self.data is Some(v) {
@@ -1193,7 +1193,7 @@ pub(all) struct Weight {
   mut connection : Node_Connection?
   mut related_nodes : Array[Node]
 } derive(Eq, Debug)
-pub impl @lib.Sized for Weight with size_of(self) {
+pub impl @lib.Sized for Weight with fn size_of(self) {
   let mut size = 0U
   size += 1U + 8U
   if self.unit is Some(v) {
@@ -1208,7 +1208,7 @@ pub impl @lib.Sized for Weight with size_of(self) {
   }
   size
 }
-pub impl Default for Weight with default() -> Weight {
+pub impl Default for Weight with fn default() -> Weight {
   Weight::{
     value : Double::default(),
     unit : None,
@@ -1224,7 +1224,7 @@ pub fn Weight::new(value : Double, unit? : String, connection? : Node_Connection
     related_nodes,
   }
 }
-pub impl @lib.Read for Weight with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Weight raise {
+pub impl @lib.Read for Weight with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Weight raise {
   let msg = Weight::default()
   try {
     for ;; {
@@ -1242,7 +1242,7 @@ pub impl @lib.Read for Weight with read_with_limit(reader : @lib.LimitedReader[&
   }
   msg
 }
-pub impl @lib.Write for Weight with write(self: Weight, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Weight with fn write(self: Weight, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(9UL);
   writer |> @lib.write_double(self.value)
   if self.unit is Some(v) {
@@ -1261,7 +1261,7 @@ pub impl @lib.Write for Weight with write(self: Weight, writer : &@lib.Writer) -
 
   }
 }
-pub impl ToJson for Weight with to_json(self) {
+pub impl ToJson for Weight with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.value != Default::default() {
   json["value"] = self.value.to_json()
@@ -1279,7 +1279,7 @@ pub impl ToJson for Weight with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Weight with from_json(json: Json, path: @json.JsonPath) -> Weight raise {
+pub impl @json.FromJson for Weight with fn from_json(json: Json, path: @json.JsonPath) -> Weight raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Weight"))
   }
@@ -1291,12 +1291,12 @@ pub impl @json.FromJson for Weight with from_json(json: Json, path: @json.JsonPa
       ("connection", value) => message.connection = Some(@json.from_json(value, path~))
       ("relatedNodes", Array(value)) => message.related_nodes = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Weight with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Weight raise {
+pub impl @lib.AsyncRead for Weight with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Weight raise {
   let msg = Weight::default()
   try {
     for ;; {
@@ -1314,7 +1314,7 @@ pub impl @lib.AsyncRead for Weight with read_with_limit(reader : @lib.LimitedRea
   }
   msg
 }
-pub impl @lib.AsyncWrite for Weight with write(self: Weight, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Weight with fn write(self: Weight, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(9UL);
   writer |> @lib.async_write_double(self.value)
   if self.unit is Some(v) {
@@ -1339,7 +1339,7 @@ pub(all) struct Graph {
   mut vertices : Array[Vertex]
   mut edges : Array[Edge]
 } derive(Eq, Debug)
-pub impl @lib.Sized for Graph with size_of(self) {
+pub impl @lib.Sized for Graph with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.graph_id); @lib.size_of(size) + size }
   if self.name is Some(v) {
@@ -1355,7 +1355,7 @@ pub impl @lib.Sized for Graph with size_of(self) {
   }
   size
 }
-pub impl Default for Graph with default() -> Graph {
+pub impl Default for Graph with fn default() -> Graph {
   Graph::{
     graph_id : String::default(),
     name : None,
@@ -1371,7 +1371,7 @@ pub fn Graph::new(graph_id : String, name? : String, vertices : Array[Vertex], e
     edges,
   }
 }
-pub impl @lib.Read for Graph with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Graph raise {
+pub impl @lib.Read for Graph with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Graph raise {
   let msg = Graph::default()
   try {
     for ;; {
@@ -1389,7 +1389,7 @@ pub impl @lib.Read for Graph with read_with_limit(reader : @lib.LimitedReader[&@
   }
   msg
 }
-pub impl @lib.Write for Graph with write(self: Graph, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Graph with fn write(self: Graph, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.graph_id)
   if self.name is Some(v) {
@@ -1408,7 +1408,7 @@ pub impl @lib.Write for Graph with write(self: Graph, writer : &@lib.Writer) -> 
 
   }
 }
-pub impl ToJson for Graph with to_json(self) {
+pub impl ToJson for Graph with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.graph_id != Default::default() {
   json["graphId"] = self.graph_id.to_json()
@@ -1425,7 +1425,7 @@ pub impl ToJson for Graph with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Graph with from_json(json: Json, path: @json.JsonPath) -> Graph raise {
+pub impl @json.FromJson for Graph with fn from_json(json: Json, path: @json.JsonPath) -> Graph raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Graph"))
   }
@@ -1438,12 +1438,12 @@ pub impl @json.FromJson for Graph with from_json(json: Json, path: @json.JsonPat
 @json.from_json(v, path~))
       ("edges", Array(value)) => message.edges = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Graph with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Graph raise {
+pub impl @lib.AsyncRead for Graph with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Graph raise {
   let msg = Graph::default()
   try {
     for ;; {
@@ -1461,7 +1461,7 @@ pub impl @lib.AsyncRead for Graph with read_with_limit(reader : @lib.LimitedRead
   }
   msg
 }
-pub impl @lib.AsyncWrite for Graph with write(self: Graph, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Graph with fn write(self: Graph, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.graph_id)
   if self.name is Some(v) {
@@ -1488,7 +1488,7 @@ pub(all) struct Vertex {
   mut outgoing_edges : Array[Edge]
   mut adjacent_vertices : Array[Vertex]
 } derive(Eq, Debug)
-pub impl @lib.Sized for Vertex with size_of(self) {
+pub impl @lib.Sized for Vertex with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.vertex_id); @lib.size_of(size) + size }
   if self.label is Some(v) {
@@ -1511,7 +1511,7 @@ pub impl @lib.Sized for Vertex with size_of(self) {
   }
   size
 }
-pub impl Default for Vertex with default() -> Vertex {
+pub impl Default for Vertex with fn default() -> Vertex {
   Vertex::{
     vertex_id : String::default(),
     label : None,
@@ -1531,7 +1531,7 @@ pub fn Vertex::new(vertex_id : String, label? : String, graph? : Graph, incoming
     adjacent_vertices,
   }
 }
-pub impl @lib.Read for Vertex with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Vertex raise {
+pub impl @lib.Read for Vertex with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Vertex raise {
   let msg = Vertex::default()
   try {
     for ;; {
@@ -1551,7 +1551,7 @@ pub impl @lib.Read for Vertex with read_with_limit(reader : @lib.LimitedReader[&
   }
   msg
 }
-pub impl @lib.Write for Vertex with write(self: Vertex, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Vertex with fn write(self: Vertex, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.vertex_id)
   if self.label is Some(v) {
@@ -1580,7 +1580,7 @@ pub impl @lib.Write for Vertex with write(self: Vertex, writer : &@lib.Writer) -
 
   }
 }
-pub impl ToJson for Vertex with to_json(self) {
+pub impl ToJson for Vertex with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.vertex_id != Default::default() {
   json["vertexId"] = self.vertex_id.to_json()
@@ -1604,7 +1604,7 @@ pub impl ToJson for Vertex with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Vertex with from_json(json: Json, path: @json.JsonPath) -> Vertex raise {
+pub impl @json.FromJson for Vertex with fn from_json(json: Json, path: @json.JsonPath) -> Vertex raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Vertex"))
   }
@@ -1620,12 +1620,12 @@ pub impl @json.FromJson for Vertex with from_json(json: Json, path: @json.JsonPa
 @json.from_json(v, path~))
       ("adjacentVertices", Array(value)) => message.adjacent_vertices = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Vertex with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Vertex raise {
+pub impl @lib.AsyncRead for Vertex with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Vertex raise {
   let msg = Vertex::default()
   try {
     for ;; {
@@ -1645,7 +1645,7 @@ pub impl @lib.AsyncRead for Vertex with read_with_limit(reader : @lib.LimitedRea
   }
   msg
 }
-pub impl @lib.AsyncWrite for Vertex with write(self: Vertex, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Vertex with fn write(self: Vertex, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.vertex_id)
   if self.label is Some(v) {
@@ -1682,7 +1682,7 @@ pub(all) struct Edge {
   mut target_vertex : Vertex?
   mut parallel_edges : Array[Edge]
 } derive(Eq, Debug)
-pub impl @lib.Sized for Edge with size_of(self) {
+pub impl @lib.Sized for Edge with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.edge_id); @lib.size_of(size) + size }
   if self.weight is Some(_) {
@@ -1703,7 +1703,7 @@ pub impl @lib.Sized for Edge with size_of(self) {
   }
   size
 }
-pub impl Default for Edge with default() -> Edge {
+pub impl Default for Edge with fn default() -> Edge {
   Edge::{
     edge_id : String::default(),
     weight : None,
@@ -1723,7 +1723,7 @@ pub fn Edge::new(edge_id : String, weight? : Double, graph? : Graph, source_vert
     parallel_edges,
   }
 }
-pub impl @lib.Read for Edge with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Edge raise {
+pub impl @lib.Read for Edge with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Edge raise {
   let msg = Edge::default()
   try {
     for ;; {
@@ -1743,7 +1743,7 @@ pub impl @lib.Read for Edge with read_with_limit(reader : @lib.LimitedReader[&@l
   }
   msg
 }
-pub impl @lib.Write for Edge with write(self: Edge, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for Edge with fn write(self: Edge, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.edge_id)
   if self.weight is Some(v) {
@@ -1772,7 +1772,7 @@ pub impl @lib.Write for Edge with write(self: Edge, writer : &@lib.Writer) -> Un
 
   }
 }
-pub impl ToJson for Edge with to_json(self) {
+pub impl ToJson for Edge with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.edge_id != Default::default() {
   json["edgeId"] = self.edge_id.to_json()
@@ -1798,7 +1798,7 @@ pub impl ToJson for Edge with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for Edge with from_json(json: Json, path: @json.JsonPath) -> Edge raise {
+pub impl @json.FromJson for Edge with fn from_json(json: Json, path: @json.JsonPath) -> Edge raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for Edge"))
   }
@@ -1812,12 +1812,12 @@ pub impl @json.FromJson for Edge with from_json(json: Json, path: @json.JsonPath
       ("targetVertex", value) => message.target_vertex = Some(@json.from_json(value, path~))
       ("parallelEdges", Array(value)) => message.parallel_edges = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for Edge with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Edge raise {
+pub impl @lib.AsyncRead for Edge with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Edge raise {
   let msg = Edge::default()
   try {
     for ;; {
@@ -1837,7 +1837,7 @@ pub impl @lib.AsyncRead for Edge with read_with_limit(reader : @lib.LimitedReade
   }
   msg
 }
-pub impl @lib.AsyncWrite for Edge with write(self: Edge, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for Edge with fn write(self: Edge, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.edge_id)
   if self.weight is Some(v) {

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -45,13 +45,13 @@ pub fn Edition::from_enum(i : @lib.Enum) -> Edition {
     _ => Default::default()
   }
 }
-pub impl Default for Edition with default() -> Edition {
+pub impl Default for Edition with fn default() -> Edition {
   Edition::EDITION_UNKNOWN
 }
-pub impl @lib.Sized for Edition with size_of(self : Edition) {
+pub impl @lib.Sized for Edition with fn size_of(self : Edition) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for Edition with from_json(json: Json, path: @json.JsonPath) -> Edition raise {
+pub impl @json.FromJson for Edition with fn from_json(json: Json, path: @json.JsonPath) -> Edition raise {
   match json {
     String("EDITION_UNKNOWN") => Edition::EDITION_UNKNOWN
     String("EDITION_LEGACY") => Edition::EDITION_LEGACY
@@ -80,7 +80,7 @@ pub impl @json.FromJson for Edition with from_json(json: Json, path: @json.JsonP
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for Edition with to_json(self : Edition) -> Json {
+pub impl ToJson for Edition with fn to_json(self : Edition) -> Json {
   match self {
     Edition::EDITION_UNKNOWN => "EDITION_UNKNOWN"
     Edition::EDITION_LEGACY => "EDITION_LEGACY"
@@ -116,13 +116,13 @@ pub fn SymbolVisibility::from_enum(i : @lib.Enum) -> SymbolVisibility {
     _ => Default::default()
   }
 }
-pub impl Default for SymbolVisibility with default() -> SymbolVisibility {
+pub impl Default for SymbolVisibility with fn default() -> SymbolVisibility {
   SymbolVisibility::VISIBILITY_UNSET
 }
-pub impl @lib.Sized for SymbolVisibility with size_of(self : SymbolVisibility) {
+pub impl @lib.Sized for SymbolVisibility with fn size_of(self : SymbolVisibility) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for SymbolVisibility with from_json(json: Json, path: @json.JsonPath) -> SymbolVisibility raise {
+pub impl @json.FromJson for SymbolVisibility with fn from_json(json: Json, path: @json.JsonPath) -> SymbolVisibility raise {
   match json {
     String("VISIBILITY_UNSET") => SymbolVisibility::VISIBILITY_UNSET
     String("VISIBILITY_LOCAL") => SymbolVisibility::VISIBILITY_LOCAL
@@ -133,7 +133,7 @@ pub impl @json.FromJson for SymbolVisibility with from_json(json: Json, path: @j
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for SymbolVisibility with to_json(self : SymbolVisibility) -> Json {
+pub impl ToJson for SymbolVisibility with fn to_json(self : SymbolVisibility) -> Json {
   match self {
     SymbolVisibility::VISIBILITY_UNSET => "VISIBILITY_UNSET"
     SymbolVisibility::VISIBILITY_LOCAL => "VISIBILITY_LOCAL"
@@ -143,7 +143,7 @@ pub impl ToJson for SymbolVisibility with to_json(self : SymbolVisibility) -> Js
 pub(all) struct FileDescriptorSet {
   mut file : Array[FileDescriptorProto]
 } derive(Eq, Debug)
-pub impl @lib.Sized for FileDescriptorSet with size_of(self) {
+pub impl @lib.Sized for FileDescriptorSet with fn size_of(self) {
   let mut size = 0U
   for s in self.file {
     let s = @lib.size_of(s)
@@ -151,7 +151,7 @@ pub impl @lib.Sized for FileDescriptorSet with size_of(self) {
   }
   size
 }
-pub impl Default for FileDescriptorSet with default() -> FileDescriptorSet {
+pub impl Default for FileDescriptorSet with fn default() -> FileDescriptorSet {
   FileDescriptorSet::{
     file : [],
   }
@@ -161,7 +161,7 @@ pub fn FileDescriptorSet::new(file : Array[FileDescriptorProto]) -> FileDescript
     file,
   }
 }
-pub impl @lib.Read for FileDescriptorSet with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileDescriptorSet raise {
+pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
   try {
     for ;; {
@@ -176,21 +176,21 @@ pub impl @lib.Read for FileDescriptorSet with read_with_limit(reader : @lib.Limi
   }
   msg
 }
-pub impl @lib.Write for FileDescriptorSet with write(self: FileDescriptorSet, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FileDescriptorSet with fn write(self: FileDescriptorSet, writer : &@lib.Writer) -> Unit raise {
   for item in self.file {
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
 
   }
 }
-pub impl ToJson for FileDescriptorSet with to_json(self) {
+pub impl ToJson for FileDescriptorSet with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.file != Default::default() {
   json["file"] = self.file.to_json()
   }
   Json::object(json)
 }
-pub impl @json.FromJson for FileDescriptorSet with from_json(json: Json, path: @json.JsonPath) -> FileDescriptorSet raise {
+pub impl @json.FromJson for FileDescriptorSet with fn from_json(json: Json, path: @json.JsonPath) -> FileDescriptorSet raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FileDescriptorSet"))
   }
@@ -199,12 +199,12 @@ pub impl @json.FromJson for FileDescriptorSet with from_json(json: Json, path: @
     match (key, value) {
       ("file", Array(value)) => message.file = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FileDescriptorSet with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileDescriptorSet raise {
+pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
   try {
     for ;; {
@@ -219,7 +219,7 @@ pub impl @lib.AsyncRead for FileDescriptorSet with read_with_limit(reader : @lib
   }
   msg
 }
-pub impl @lib.AsyncWrite for FileDescriptorSet with write(self: FileDescriptorSet, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FileDescriptorSet with fn write(self: FileDescriptorSet, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.file {
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
@@ -242,7 +242,7 @@ pub(all) struct FileDescriptorProto {
   mut syntax : String?
   mut edition : Edition?
 } derive(Eq, Debug)
-pub impl @lib.Sized for FileDescriptorProto with size_of(self) {
+pub impl @lib.Sized for FileDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -296,7 +296,7 @@ pub impl @lib.Sized for FileDescriptorProto with size_of(self) {
   }
   size
 }
-pub impl Default for FileDescriptorProto with default() -> FileDescriptorProto {
+pub impl Default for FileDescriptorProto with fn default() -> FileDescriptorProto {
   FileDescriptorProto::{
     name : None,
     package_ : None,
@@ -332,7 +332,7 @@ pub fn FileDescriptorProto::new(name? : String, package_? : String, dependency :
     edition,
   }
 }
-pub impl @lib.Read for FileDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileDescriptorProto raise {
+pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
   try {
     for ;; {
@@ -362,7 +362,7 @@ pub impl @lib.Read for FileDescriptorProto with read_with_limit(reader : @lib.Li
   }
   msg
 }
-pub impl @lib.Write for FileDescriptorProto with write(self: FileDescriptorProto, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FileDescriptorProto with fn write(self: FileDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -434,7 +434,7 @@ pub impl @lib.Write for FileDescriptorProto with write(self: FileDescriptorProto
 
   }
 }
-pub impl ToJson for FileDescriptorProto with to_json(self) {
+pub impl ToJson for FileDescriptorProto with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.name {
       Some(v) => json["name"] = v.to_json()
@@ -486,7 +486,7 @@ pub impl ToJson for FileDescriptorProto with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for FileDescriptorProto with from_json(json: Json, path: @json.JsonPath) -> FileDescriptorProto raise {
+pub impl @json.FromJson for FileDescriptorProto with fn from_json(json: Json, path: @json.JsonPath) -> FileDescriptorProto raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FileDescriptorProto"))
   }
@@ -515,12 +515,12 @@ pub impl @json.FromJson for FileDescriptorProto with from_json(json: Json, path:
       ("sourceCodeInfo", value) => message.source_code_info = Some(@json.from_json(value, path~))
       ("syntax", value) => message.syntax = Some(@json.from_json(value, path~))
       ("edition", value) => message.edition = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FileDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileDescriptorProto raise {
+pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
   try {
     for ;; {
@@ -550,7 +550,7 @@ pub impl @lib.AsyncRead for FileDescriptorProto with read_with_limit(reader : @l
   }
   msg
 }
-pub impl @lib.AsyncWrite for FileDescriptorProto with write(self: FileDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FileDescriptorProto with fn write(self: FileDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)
@@ -627,7 +627,7 @@ pub(all) struct DescriptorProto_ExtensionRange {
   mut end : Int?
   mut options : ExtensionRangeOptions?
 } derive(Eq, Debug)
-pub impl @lib.Sized for DescriptorProto_ExtensionRange with size_of(self) {
+pub impl @lib.Sized for DescriptorProto_ExtensionRange with fn size_of(self) {
   let mut size = 0U
   if self.start is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -640,7 +640,7 @@ pub impl @lib.Sized for DescriptorProto_ExtensionRange with size_of(self) {
   }
   size
 }
-pub impl Default for DescriptorProto_ExtensionRange with default() -> DescriptorProto_ExtensionRange {
+pub impl Default for DescriptorProto_ExtensionRange with fn default() -> DescriptorProto_ExtensionRange {
   DescriptorProto_ExtensionRange::{
     start : None,
     end : None,
@@ -654,7 +654,7 @@ pub fn DescriptorProto_ExtensionRange::new(start? : Int, end? : Int, options? : 
     options,
   }
 }
-pub impl @lib.Read for DescriptorProto_ExtensionRange with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto_ExtensionRange raise {
+pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
   try {
     for ;; {
@@ -671,7 +671,7 @@ pub impl @lib.Read for DescriptorProto_ExtensionRange with read_with_limit(reade
   }
   msg
 }
-pub impl @lib.Write for DescriptorProto_ExtensionRange with write(self: DescriptorProto_ExtensionRange, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for DescriptorProto_ExtensionRange with fn write(self: DescriptorProto_ExtensionRange, writer : &@lib.Writer) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.write_varint(8UL);
     writer |> @lib.write_int32(v)
@@ -688,7 +688,7 @@ pub impl @lib.Write for DescriptorProto_ExtensionRange with write(self: Descript
 
   }
 }
-pub impl ToJson for DescriptorProto_ExtensionRange with to_json(self) {
+pub impl ToJson for DescriptorProto_ExtensionRange with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.start {
       Some(v) => json["start"] = v.to_json()
@@ -704,7 +704,7 @@ pub impl ToJson for DescriptorProto_ExtensionRange with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for DescriptorProto_ExtensionRange with from_json(json: Json, path: @json.JsonPath) -> DescriptorProto_ExtensionRange raise {
+pub impl @json.FromJson for DescriptorProto_ExtensionRange with fn from_json(json: Json, path: @json.JsonPath) -> DescriptorProto_ExtensionRange raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for DescriptorProto_ExtensionRange"))
   }
@@ -714,12 +714,12 @@ pub impl @json.FromJson for DescriptorProto_ExtensionRange with from_json(json: 
       ("start", value) => message.start = Some(@json.from_json(value, path~))
       ("end", value) => message.end = Some(@json.from_json(value, path~))
       ("options", value) => message.options = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto_ExtensionRange raise {
+pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
   try {
     for ;; {
@@ -736,7 +736,7 @@ pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with read_with_limit(
   }
   msg
 }
-pub impl @lib.AsyncWrite for DescriptorProto_ExtensionRange with write(self: DescriptorProto_ExtensionRange, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for DescriptorProto_ExtensionRange with fn write(self: DescriptorProto_ExtensionRange, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.async_write_varint(8UL);
     writer |> @lib.async_write_int32(v)
@@ -757,7 +757,7 @@ pub(all) struct DescriptorProto_ReservedRange {
   mut start : Int?
   mut end : Int?
 } derive(Eq, Debug)
-pub impl @lib.Sized for DescriptorProto_ReservedRange with size_of(self) {
+pub impl @lib.Sized for DescriptorProto_ReservedRange with fn size_of(self) {
   let mut size = 0U
   if self.start is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -767,7 +767,7 @@ pub impl @lib.Sized for DescriptorProto_ReservedRange with size_of(self) {
   }
   size
 }
-pub impl Default for DescriptorProto_ReservedRange with default() -> DescriptorProto_ReservedRange {
+pub impl Default for DescriptorProto_ReservedRange with fn default() -> DescriptorProto_ReservedRange {
   DescriptorProto_ReservedRange::{
     start : None,
     end : None,
@@ -779,7 +779,7 @@ pub fn DescriptorProto_ReservedRange::new(start? : Int, end? : Int) -> Descripto
     end,
   }
 }
-pub impl @lib.Read for DescriptorProto_ReservedRange with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto_ReservedRange raise {
+pub impl @lib.Read for DescriptorProto_ReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
   try {
     for ;; {
@@ -795,7 +795,7 @@ pub impl @lib.Read for DescriptorProto_ReservedRange with read_with_limit(reader
   }
   msg
 }
-pub impl @lib.Write for DescriptorProto_ReservedRange with write(self: DescriptorProto_ReservedRange, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for DescriptorProto_ReservedRange with fn write(self: DescriptorProto_ReservedRange, writer : &@lib.Writer) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.write_varint(8UL);
     writer |> @lib.write_int32(v)
@@ -807,7 +807,7 @@ pub impl @lib.Write for DescriptorProto_ReservedRange with write(self: Descripto
 
   }
 }
-pub impl ToJson for DescriptorProto_ReservedRange with to_json(self) {
+pub impl ToJson for DescriptorProto_ReservedRange with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.start {
       Some(v) => json["start"] = v.to_json()
@@ -819,7 +819,7 @@ pub impl ToJson for DescriptorProto_ReservedRange with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for DescriptorProto_ReservedRange with from_json(json: Json, path: @json.JsonPath) -> DescriptorProto_ReservedRange raise {
+pub impl @json.FromJson for DescriptorProto_ReservedRange with fn from_json(json: Json, path: @json.JsonPath) -> DescriptorProto_ReservedRange raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for DescriptorProto_ReservedRange"))
   }
@@ -828,12 +828,12 @@ pub impl @json.FromJson for DescriptorProto_ReservedRange with from_json(json: J
     match (key, value) {
       ("start", value) => message.start = Some(@json.from_json(value, path~))
       ("end", value) => message.end = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto_ReservedRange raise {
+pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
   try {
     for ;; {
@@ -849,7 +849,7 @@ pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with read_with_limit(r
   }
   msg
 }
-pub impl @lib.AsyncWrite for DescriptorProto_ReservedRange with write(self: DescriptorProto_ReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for DescriptorProto_ReservedRange with fn write(self: DescriptorProto_ReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.async_write_varint(8UL);
     writer |> @lib.async_write_int32(v)
@@ -874,7 +874,7 @@ pub(all) struct DescriptorProto {
   mut reserved_name : Array[String]
   mut visibility : SymbolVisibility?
 } derive(Eq, Debug)
-pub impl @lib.Sized for DescriptorProto with size_of(self) {
+pub impl @lib.Sized for DescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -919,7 +919,7 @@ pub impl @lib.Sized for DescriptorProto with size_of(self) {
   }
   size
 }
-pub impl Default for DescriptorProto with default() -> DescriptorProto {
+pub impl Default for DescriptorProto with fn default() -> DescriptorProto {
   DescriptorProto::{
     name : None,
     field : [],
@@ -949,7 +949,7 @@ pub fn DescriptorProto::new(name? : String, field : Array[FieldDescriptorProto],
     visibility,
   }
 }
-pub impl @lib.Read for DescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto raise {
+pub impl @lib.Read for DescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
   try {
     for ;; {
@@ -974,7 +974,7 @@ pub impl @lib.Read for DescriptorProto with read_with_limit(reader : @lib.Limite
   }
   msg
 }
-pub impl @lib.Write for DescriptorProto with write(self: DescriptorProto, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for DescriptorProto with fn write(self: DescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -1031,7 +1031,7 @@ pub impl @lib.Write for DescriptorProto with write(self: DescriptorProto, writer
 
   }
 }
-pub impl ToJson for DescriptorProto with to_json(self) {
+pub impl ToJson for DescriptorProto with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.name {
       Some(v) => json["name"] = v.to_json()
@@ -1071,7 +1071,7 @@ pub impl ToJson for DescriptorProto with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for DescriptorProto with from_json(json: Json, path: @json.JsonPath) -> DescriptorProto raise {
+pub impl @json.FromJson for DescriptorProto with fn from_json(json: Json, path: @json.JsonPath) -> DescriptorProto raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for DescriptorProto"))
   }
@@ -1097,12 +1097,12 @@ pub impl @json.FromJson for DescriptorProto with from_json(json: Json, path: @js
       ("reservedName", Array(value)) => message.reserved_name = value.map(v => 
 @json.from_json(v, path~))
       ("visibility", value) => message.visibility = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for DescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto raise {
+pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
   try {
     for ;; {
@@ -1127,7 +1127,7 @@ pub impl @lib.AsyncRead for DescriptorProto with read_with_limit(reader : @lib.L
   }
   msg
 }
-pub impl @lib.AsyncWrite for DescriptorProto with write(self: DescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for DescriptorProto with fn write(self: DescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)
@@ -1201,13 +1201,13 @@ pub fn ExtensionRangeOptions_VerificationState::from_enum(i : @lib.Enum) -> Exte
     _ => Default::default()
   }
 }
-pub impl Default for ExtensionRangeOptions_VerificationState with default() -> ExtensionRangeOptions_VerificationState {
+pub impl Default for ExtensionRangeOptions_VerificationState with fn default() -> ExtensionRangeOptions_VerificationState {
   ExtensionRangeOptions_VerificationState::DECLARATION
 }
-pub impl @lib.Sized for ExtensionRangeOptions_VerificationState with size_of(self : ExtensionRangeOptions_VerificationState) {
+pub impl @lib.Sized for ExtensionRangeOptions_VerificationState with fn size_of(self : ExtensionRangeOptions_VerificationState) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for ExtensionRangeOptions_VerificationState with from_json(json: Json, path: @json.JsonPath) -> ExtensionRangeOptions_VerificationState raise {
+pub impl @json.FromJson for ExtensionRangeOptions_VerificationState with fn from_json(json: Json, path: @json.JsonPath) -> ExtensionRangeOptions_VerificationState raise {
   match json {
     String("DECLARATION") => ExtensionRangeOptions_VerificationState::DECLARATION
     String("UNVERIFIED") => ExtensionRangeOptions_VerificationState::UNVERIFIED
@@ -1216,7 +1216,7 @@ pub impl @json.FromJson for ExtensionRangeOptions_VerificationState with from_js
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for ExtensionRangeOptions_VerificationState with to_json(self : ExtensionRangeOptions_VerificationState) -> Json {
+pub impl ToJson for ExtensionRangeOptions_VerificationState with fn to_json(self : ExtensionRangeOptions_VerificationState) -> Json {
   match self {
     ExtensionRangeOptions_VerificationState::DECLARATION => "DECLARATION"
     ExtensionRangeOptions_VerificationState::UNVERIFIED => "UNVERIFIED"
@@ -1229,7 +1229,7 @@ pub(all) struct ExtensionRangeOptions_Declaration {
   mut reserved : Bool?
   mut repeated : Bool?
 } derive(Eq, Debug)
-pub impl @lib.Sized for ExtensionRangeOptions_Declaration with size_of(self) {
+pub impl @lib.Sized for ExtensionRangeOptions_Declaration with fn size_of(self) {
   let mut size = 0U
   if self.number is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -1248,7 +1248,7 @@ pub impl @lib.Sized for ExtensionRangeOptions_Declaration with size_of(self) {
   }
   size
 }
-pub impl Default for ExtensionRangeOptions_Declaration with default() -> ExtensionRangeOptions_Declaration {
+pub impl Default for ExtensionRangeOptions_Declaration with fn default() -> ExtensionRangeOptions_Declaration {
   ExtensionRangeOptions_Declaration::{
     number : None,
     full_name : None,
@@ -1266,7 +1266,7 @@ pub fn ExtensionRangeOptions_Declaration::new(number? : Int, full_name? : String
     repeated,
   }
 }
-pub impl @lib.Read for ExtensionRangeOptions_Declaration with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ExtensionRangeOptions_Declaration raise {
+pub impl @lib.Read for ExtensionRangeOptions_Declaration with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
   try {
     for ;; {
@@ -1285,7 +1285,7 @@ pub impl @lib.Read for ExtensionRangeOptions_Declaration with read_with_limit(re
   }
   msg
 }
-pub impl @lib.Write for ExtensionRangeOptions_Declaration with write(self: ExtensionRangeOptions_Declaration, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for ExtensionRangeOptions_Declaration with fn write(self: ExtensionRangeOptions_Declaration, writer : &@lib.Writer) -> Unit raise {
   if self.number is Some(v) {
     writer |> @lib.write_varint(8UL);
     writer |> @lib.write_int32(v)
@@ -1312,7 +1312,7 @@ pub impl @lib.Write for ExtensionRangeOptions_Declaration with write(self: Exten
 
   }
 }
-pub impl ToJson for ExtensionRangeOptions_Declaration with to_json(self) {
+pub impl ToJson for ExtensionRangeOptions_Declaration with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.number {
       Some(v) => json["number"] = v.to_json()
@@ -1336,7 +1336,7 @@ pub impl ToJson for ExtensionRangeOptions_Declaration with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for ExtensionRangeOptions_Declaration with from_json(json: Json, path: @json.JsonPath) -> ExtensionRangeOptions_Declaration raise {
+pub impl @json.FromJson for ExtensionRangeOptions_Declaration with fn from_json(json: Json, path: @json.JsonPath) -> ExtensionRangeOptions_Declaration raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for ExtensionRangeOptions_Declaration"))
   }
@@ -1348,12 +1348,12 @@ pub impl @json.FromJson for ExtensionRangeOptions_Declaration with from_json(jso
       ("type", value) => message.type_ = Some(@json.from_json(value, path~))
       ("reserved", value) => message.reserved = Some(@json.from_json(value, path~))
       ("repeated", value) => message.repeated = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ExtensionRangeOptions_Declaration raise {
+pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
   try {
     for ;; {
@@ -1372,7 +1372,7 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with read_with_lim
   }
   msg
 }
-pub impl @lib.AsyncWrite for ExtensionRangeOptions_Declaration with write(self: ExtensionRangeOptions_Declaration, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for ExtensionRangeOptions_Declaration with fn write(self: ExtensionRangeOptions_Declaration, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.number is Some(v) {
     writer |> @lib.async_write_varint(8UL);
     writer |> @lib.async_write_int32(v)
@@ -1405,7 +1405,7 @@ pub(all) struct ExtensionRangeOptions {
   mut features : FeatureSet?
   mut verification : ExtensionRangeOptions_VerificationState?
 } derive(Eq, Debug)
-pub impl @lib.Sized for ExtensionRangeOptions with size_of(self) {
+pub impl @lib.Sized for ExtensionRangeOptions with fn size_of(self) {
   let mut size = 0U
   for s in self.uninterpreted_option {
     let s = @lib.size_of(s)
@@ -1423,7 +1423,7 @@ pub impl @lib.Sized for ExtensionRangeOptions with size_of(self) {
   }
   size
 }
-pub impl Default for ExtensionRangeOptions with default() -> ExtensionRangeOptions {
+pub impl Default for ExtensionRangeOptions with fn default() -> ExtensionRangeOptions {
   ExtensionRangeOptions::{
     uninterpreted_option : [],
     declaration : [],
@@ -1439,7 +1439,7 @@ pub fn ExtensionRangeOptions::new(uninterpreted_option : Array[UninterpretedOpti
     verification,
   }
 }
-pub impl @lib.Read for ExtensionRangeOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ExtensionRangeOptions raise {
+pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
   try {
     for ;; {
@@ -1457,7 +1457,7 @@ pub impl @lib.Read for ExtensionRangeOptions with read_with_limit(reader : @lib.
   }
   msg
 }
-pub impl @lib.Write for ExtensionRangeOptions with write(self: ExtensionRangeOptions, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for ExtensionRangeOptions with fn write(self: ExtensionRangeOptions, writer : &@lib.Writer) -> Unit raise {
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
     writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
@@ -1479,7 +1479,7 @@ pub impl @lib.Write for ExtensionRangeOptions with write(self: ExtensionRangeOpt
 
   }
 }
-pub impl ToJson for ExtensionRangeOptions with to_json(self) {
+pub impl ToJson for ExtensionRangeOptions with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.uninterpreted_option != Default::default() {
   json["uninterpretedOption"] = self.uninterpreted_option.to_json()
@@ -1497,7 +1497,7 @@ pub impl ToJson for ExtensionRangeOptions with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for ExtensionRangeOptions with from_json(json: Json, path: @json.JsonPath) -> ExtensionRangeOptions raise {
+pub impl @json.FromJson for ExtensionRangeOptions with fn from_json(json: Json, path: @json.JsonPath) -> ExtensionRangeOptions raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for ExtensionRangeOptions"))
   }
@@ -1510,12 +1510,12 @@ pub impl @json.FromJson for ExtensionRangeOptions with from_json(json: Json, pat
 @json.from_json(v, path~))
       ("features", value) => message.features = Some(@json.from_json(value, path~))
       ("verification", value) => message.verification = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for ExtensionRangeOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ExtensionRangeOptions raise {
+pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
   try {
     for ;; {
@@ -1533,7 +1533,7 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions with read_with_limit(reader : 
   }
   msg
 }
-pub impl @lib.AsyncWrite for ExtensionRangeOptions with write(self: ExtensionRangeOptions, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for ExtensionRangeOptions with fn write(self: ExtensionRangeOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
     writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
@@ -1620,13 +1620,13 @@ pub fn FieldDescriptorProto_Type::from_enum(i : @lib.Enum) -> FieldDescriptorPro
     _ => Default::default()
   }
 }
-pub impl Default for FieldDescriptorProto_Type with default() -> FieldDescriptorProto_Type {
+pub impl Default for FieldDescriptorProto_Type with fn default() -> FieldDescriptorProto_Type {
   FieldDescriptorProto_Type::TYPE_DOUBLE
 }
-pub impl @lib.Sized for FieldDescriptorProto_Type with size_of(self : FieldDescriptorProto_Type) {
+pub impl @lib.Sized for FieldDescriptorProto_Type with fn size_of(self : FieldDescriptorProto_Type) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FieldDescriptorProto_Type with from_json(json: Json, path: @json.JsonPath) -> FieldDescriptorProto_Type raise {
+pub impl @json.FromJson for FieldDescriptorProto_Type with fn from_json(json: Json, path: @json.JsonPath) -> FieldDescriptorProto_Type raise {
   match json {
     String("TYPE_DOUBLE") => FieldDescriptorProto_Type::TYPE_DOUBLE
     String("TYPE_FLOAT") => FieldDescriptorProto_Type::TYPE_FLOAT
@@ -1667,7 +1667,7 @@ pub impl @json.FromJson for FieldDescriptorProto_Type with from_json(json: Json,
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FieldDescriptorProto_Type with to_json(self : FieldDescriptorProto_Type) -> Json {
+pub impl ToJson for FieldDescriptorProto_Type with fn to_json(self : FieldDescriptorProto_Type) -> Json {
   match self {
     FieldDescriptorProto_Type::TYPE_DOUBLE => "TYPE_DOUBLE"
     FieldDescriptorProto_Type::TYPE_FLOAT => "TYPE_FLOAT"
@@ -1709,13 +1709,13 @@ pub fn FieldDescriptorProto_Label::from_enum(i : @lib.Enum) -> FieldDescriptorPr
     _ => Default::default()
   }
 }
-pub impl Default for FieldDescriptorProto_Label with default() -> FieldDescriptorProto_Label {
+pub impl Default for FieldDescriptorProto_Label with fn default() -> FieldDescriptorProto_Label {
   FieldDescriptorProto_Label::LABEL_OPTIONAL
 }
-pub impl @lib.Sized for FieldDescriptorProto_Label with size_of(self : FieldDescriptorProto_Label) {
+pub impl @lib.Sized for FieldDescriptorProto_Label with fn size_of(self : FieldDescriptorProto_Label) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FieldDescriptorProto_Label with from_json(json: Json, path: @json.JsonPath) -> FieldDescriptorProto_Label raise {
+pub impl @json.FromJson for FieldDescriptorProto_Label with fn from_json(json: Json, path: @json.JsonPath) -> FieldDescriptorProto_Label raise {
   match json {
     String("LABEL_OPTIONAL") => FieldDescriptorProto_Label::LABEL_OPTIONAL
     String("LABEL_REPEATED") => FieldDescriptorProto_Label::LABEL_REPEATED
@@ -1726,7 +1726,7 @@ pub impl @json.FromJson for FieldDescriptorProto_Label with from_json(json: Json
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FieldDescriptorProto_Label with to_json(self : FieldDescriptorProto_Label) -> Json {
+pub impl ToJson for FieldDescriptorProto_Label with fn to_json(self : FieldDescriptorProto_Label) -> Json {
   match self {
     FieldDescriptorProto_Label::LABEL_OPTIONAL => "LABEL_OPTIONAL"
     FieldDescriptorProto_Label::LABEL_REPEATED => "LABEL_REPEATED"
@@ -1746,7 +1746,7 @@ pub(all) struct FieldDescriptorProto {
   mut options : FieldOptions?
   mut proto3_optional : Bool?
 } derive(Eq, Debug)
-pub impl @lib.Sized for FieldDescriptorProto with size_of(self) {
+pub impl @lib.Sized for FieldDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -1783,7 +1783,7 @@ pub impl @lib.Sized for FieldDescriptorProto with size_of(self) {
   }
   size
 }
-pub impl Default for FieldDescriptorProto with default() -> FieldDescriptorProto {
+pub impl Default for FieldDescriptorProto with fn default() -> FieldDescriptorProto {
   FieldDescriptorProto::{
     name : None,
     number : None,
@@ -1813,7 +1813,7 @@ pub fn FieldDescriptorProto::new(name? : String, number? : Int, label? : FieldDe
     proto3_optional,
   }
 }
-pub impl @lib.Read for FieldDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldDescriptorProto raise {
+pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
   try {
     for ;; {
@@ -1838,7 +1838,7 @@ pub impl @lib.Read for FieldDescriptorProto with read_with_limit(reader : @lib.L
   }
   msg
 }
-pub impl @lib.Write for FieldDescriptorProto with write(self: FieldDescriptorProto, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FieldDescriptorProto with fn write(self: FieldDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -1895,7 +1895,7 @@ pub impl @lib.Write for FieldDescriptorProto with write(self: FieldDescriptorPro
 
   }
 }
-pub impl ToJson for FieldDescriptorProto with to_json(self) {
+pub impl ToJson for FieldDescriptorProto with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.name {
       Some(v) => json["name"] = v.to_json()
@@ -1943,7 +1943,7 @@ pub impl ToJson for FieldDescriptorProto with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for FieldDescriptorProto with from_json(json: Json, path: @json.JsonPath) -> FieldDescriptorProto raise {
+pub impl @json.FromJson for FieldDescriptorProto with fn from_json(json: Json, path: @json.JsonPath) -> FieldDescriptorProto raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FieldDescriptorProto"))
   }
@@ -1961,12 +1961,12 @@ pub impl @json.FromJson for FieldDescriptorProto with from_json(json: Json, path
       ("jsonName", value) => message.json_name = Some(@json.from_json(value, path~))
       ("options", value) => message.options = Some(@json.from_json(value, path~))
       ("proto3Optional", value) => message.proto3_optional = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FieldDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldDescriptorProto raise {
+pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
   try {
     for ;; {
@@ -1991,7 +1991,7 @@ pub impl @lib.AsyncRead for FieldDescriptorProto with read_with_limit(reader : @
   }
   msg
 }
-pub impl @lib.AsyncWrite for FieldDescriptorProto with write(self: FieldDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FieldDescriptorProto with fn write(self: FieldDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)
@@ -2052,7 +2052,7 @@ pub(all) struct OneofDescriptorProto {
   mut name : String?
   mut options : OneofOptions?
 } derive(Eq, Debug)
-pub impl @lib.Sized for OneofDescriptorProto with size_of(self) {
+pub impl @lib.Sized for OneofDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -2062,7 +2062,7 @@ pub impl @lib.Sized for OneofDescriptorProto with size_of(self) {
   }
   size
 }
-pub impl Default for OneofDescriptorProto with default() -> OneofDescriptorProto {
+pub impl Default for OneofDescriptorProto with fn default() -> OneofDescriptorProto {
   OneofDescriptorProto::{
     name : None,
     options : None,
@@ -2074,7 +2074,7 @@ pub fn OneofDescriptorProto::new(name? : String, options? : OneofOptions) -> One
     options,
   }
 }
-pub impl @lib.Read for OneofDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> OneofDescriptorProto raise {
+pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
   try {
     for ;; {
@@ -2090,7 +2090,7 @@ pub impl @lib.Read for OneofDescriptorProto with read_with_limit(reader : @lib.L
   }
   msg
 }
-pub impl @lib.Write for OneofDescriptorProto with write(self: OneofDescriptorProto, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for OneofDescriptorProto with fn write(self: OneofDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -2102,7 +2102,7 @@ pub impl @lib.Write for OneofDescriptorProto with write(self: OneofDescriptorPro
 
   }
 }
-pub impl ToJson for OneofDescriptorProto with to_json(self) {
+pub impl ToJson for OneofDescriptorProto with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.name {
       Some(v) => json["name"] = v.to_json()
@@ -2114,7 +2114,7 @@ pub impl ToJson for OneofDescriptorProto with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for OneofDescriptorProto with from_json(json: Json, path: @json.JsonPath) -> OneofDescriptorProto raise {
+pub impl @json.FromJson for OneofDescriptorProto with fn from_json(json: Json, path: @json.JsonPath) -> OneofDescriptorProto raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for OneofDescriptorProto"))
   }
@@ -2123,12 +2123,12 @@ pub impl @json.FromJson for OneofDescriptorProto with from_json(json: Json, path
     match (key, value) {
       ("name", value) => message.name = Some(@json.from_json(value, path~))
       ("options", value) => message.options = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for OneofDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> OneofDescriptorProto raise {
+pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
   try {
     for ;; {
@@ -2144,7 +2144,7 @@ pub impl @lib.AsyncRead for OneofDescriptorProto with read_with_limit(reader : @
   }
   msg
 }
-pub impl @lib.AsyncWrite for OneofDescriptorProto with write(self: OneofDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for OneofDescriptorProto with fn write(self: OneofDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)
@@ -2160,7 +2160,7 @@ pub(all) struct EnumDescriptorProto_EnumReservedRange {
   mut start : Int?
   mut end : Int?
 } derive(Eq, Debug)
-pub impl @lib.Sized for EnumDescriptorProto_EnumReservedRange with size_of(self) {
+pub impl @lib.Sized for EnumDescriptorProto_EnumReservedRange with fn size_of(self) {
   let mut size = 0U
   if self.start is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -2170,7 +2170,7 @@ pub impl @lib.Sized for EnumDescriptorProto_EnumReservedRange with size_of(self)
   }
   size
 }
-pub impl Default for EnumDescriptorProto_EnumReservedRange with default() -> EnumDescriptorProto_EnumReservedRange {
+pub impl Default for EnumDescriptorProto_EnumReservedRange with fn default() -> EnumDescriptorProto_EnumReservedRange {
   EnumDescriptorProto_EnumReservedRange::{
     start : None,
     end : None,
@@ -2182,7 +2182,7 @@ pub fn EnumDescriptorProto_EnumReservedRange::new(start? : Int, end? : Int) -> E
     end,
   }
 }
-pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumDescriptorProto_EnumReservedRange raise {
+pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
   try {
     for ;; {
@@ -2198,7 +2198,7 @@ pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with read_with_limi
   }
   msg
 }
-pub impl @lib.Write for EnumDescriptorProto_EnumReservedRange with write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for EnumDescriptorProto_EnumReservedRange with fn write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.Writer) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.write_varint(8UL);
     writer |> @lib.write_int32(v)
@@ -2210,7 +2210,7 @@ pub impl @lib.Write for EnumDescriptorProto_EnumReservedRange with write(self: E
 
   }
 }
-pub impl ToJson for EnumDescriptorProto_EnumReservedRange with to_json(self) {
+pub impl ToJson for EnumDescriptorProto_EnumReservedRange with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.start {
       Some(v) => json["start"] = v.to_json()
@@ -2222,7 +2222,7 @@ pub impl ToJson for EnumDescriptorProto_EnumReservedRange with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for EnumDescriptorProto_EnumReservedRange with from_json(json: Json, path: @json.JsonPath) -> EnumDescriptorProto_EnumReservedRange raise {
+pub impl @json.FromJson for EnumDescriptorProto_EnumReservedRange with fn from_json(json: Json, path: @json.JsonPath) -> EnumDescriptorProto_EnumReservedRange raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for EnumDescriptorProto_EnumReservedRange"))
   }
@@ -2231,12 +2231,12 @@ pub impl @json.FromJson for EnumDescriptorProto_EnumReservedRange with from_json
     match (key, value) {
       ("start", value) => message.start = Some(@json.from_json(value, path~))
       ("end", value) => message.end = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumDescriptorProto_EnumReservedRange raise {
+pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
   try {
     for ;; {
@@ -2252,7 +2252,7 @@ pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with read_with
   }
   msg
 }
-pub impl @lib.AsyncWrite for EnumDescriptorProto_EnumReservedRange with write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for EnumDescriptorProto_EnumReservedRange with fn write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.async_write_varint(8UL);
     writer |> @lib.async_write_int32(v)
@@ -2272,7 +2272,7 @@ pub(all) struct EnumDescriptorProto {
   mut reserved_name : Array[String]
   mut visibility : SymbolVisibility?
 } derive(Eq, Debug)
-pub impl @lib.Sized for EnumDescriptorProto with size_of(self) {
+pub impl @lib.Sized for EnumDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -2297,7 +2297,7 @@ pub impl @lib.Sized for EnumDescriptorProto with size_of(self) {
   }
   size
 }
-pub impl Default for EnumDescriptorProto with default() -> EnumDescriptorProto {
+pub impl Default for EnumDescriptorProto with fn default() -> EnumDescriptorProto {
   EnumDescriptorProto::{
     name : None,
     value : [],
@@ -2317,7 +2317,7 @@ pub fn EnumDescriptorProto::new(name? : String, value : Array[EnumValueDescripto
     visibility,
   }
 }
-pub impl @lib.Read for EnumDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumDescriptorProto raise {
+pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
   try {
     for ;; {
@@ -2337,7 +2337,7 @@ pub impl @lib.Read for EnumDescriptorProto with read_with_limit(reader : @lib.Li
   }
   msg
 }
-pub impl @lib.Write for EnumDescriptorProto with write(self: EnumDescriptorProto, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for EnumDescriptorProto with fn write(self: EnumDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -2369,7 +2369,7 @@ pub impl @lib.Write for EnumDescriptorProto with write(self: EnumDescriptorProto
 
   }
 }
-pub impl ToJson for EnumDescriptorProto with to_json(self) {
+pub impl ToJson for EnumDescriptorProto with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.name {
       Some(v) => json["name"] = v.to_json()
@@ -2394,7 +2394,7 @@ pub impl ToJson for EnumDescriptorProto with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for EnumDescriptorProto with from_json(json: Json, path: @json.JsonPath) -> EnumDescriptorProto raise {
+pub impl @json.FromJson for EnumDescriptorProto with fn from_json(json: Json, path: @json.JsonPath) -> EnumDescriptorProto raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for EnumDescriptorProto"))
   }
@@ -2410,12 +2410,12 @@ pub impl @json.FromJson for EnumDescriptorProto with from_json(json: Json, path:
       ("reservedName", Array(value)) => message.reserved_name = value.map(v => 
 @json.from_json(v, path~))
       ("visibility", value) => message.visibility = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for EnumDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumDescriptorProto raise {
+pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
   try {
     for ;; {
@@ -2435,7 +2435,7 @@ pub impl @lib.AsyncRead for EnumDescriptorProto with read_with_limit(reader : @l
   }
   msg
 }
-pub impl @lib.AsyncWrite for EnumDescriptorProto with write(self: EnumDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for EnumDescriptorProto with fn write(self: EnumDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)
@@ -2472,7 +2472,7 @@ pub(all) struct EnumValueDescriptorProto {
   mut number : Int?
   mut options : EnumValueOptions?
 } derive(Eq, Debug)
-pub impl @lib.Sized for EnumValueDescriptorProto with size_of(self) {
+pub impl @lib.Sized for EnumValueDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -2485,7 +2485,7 @@ pub impl @lib.Sized for EnumValueDescriptorProto with size_of(self) {
   }
   size
 }
-pub impl Default for EnumValueDescriptorProto with default() -> EnumValueDescriptorProto {
+pub impl Default for EnumValueDescriptorProto with fn default() -> EnumValueDescriptorProto {
   EnumValueDescriptorProto::{
     name : None,
     number : None,
@@ -2499,7 +2499,7 @@ pub fn EnumValueDescriptorProto::new(name? : String, number? : Int, options? : E
     options,
   }
 }
-pub impl @lib.Read for EnumValueDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumValueDescriptorProto raise {
+pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
   try {
     for ;; {
@@ -2516,7 +2516,7 @@ pub impl @lib.Read for EnumValueDescriptorProto with read_with_limit(reader : @l
   }
   msg
 }
-pub impl @lib.Write for EnumValueDescriptorProto with write(self: EnumValueDescriptorProto, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for EnumValueDescriptorProto with fn write(self: EnumValueDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -2533,7 +2533,7 @@ pub impl @lib.Write for EnumValueDescriptorProto with write(self: EnumValueDescr
 
   }
 }
-pub impl ToJson for EnumValueDescriptorProto with to_json(self) {
+pub impl ToJson for EnumValueDescriptorProto with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.name {
       Some(v) => json["name"] = v.to_json()
@@ -2549,7 +2549,7 @@ pub impl ToJson for EnumValueDescriptorProto with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for EnumValueDescriptorProto with from_json(json: Json, path: @json.JsonPath) -> EnumValueDescriptorProto raise {
+pub impl @json.FromJson for EnumValueDescriptorProto with fn from_json(json: Json, path: @json.JsonPath) -> EnumValueDescriptorProto raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for EnumValueDescriptorProto"))
   }
@@ -2559,12 +2559,12 @@ pub impl @json.FromJson for EnumValueDescriptorProto with from_json(json: Json, 
       ("name", value) => message.name = Some(@json.from_json(value, path~))
       ("number", value) => message.number = Some(@json.from_json(value, path~))
       ("options", value) => message.options = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for EnumValueDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumValueDescriptorProto raise {
+pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
   try {
     for ;; {
@@ -2581,7 +2581,7 @@ pub impl @lib.AsyncRead for EnumValueDescriptorProto with read_with_limit(reader
   }
   msg
 }
-pub impl @lib.AsyncWrite for EnumValueDescriptorProto with write(self: EnumValueDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for EnumValueDescriptorProto with fn write(self: EnumValueDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)
@@ -2603,7 +2603,7 @@ pub(all) struct ServiceDescriptorProto {
   mut method_ : Array[MethodDescriptorProto]
   mut options : ServiceOptions?
 } derive(Eq, Debug)
-pub impl @lib.Sized for ServiceDescriptorProto with size_of(self) {
+pub impl @lib.Sized for ServiceDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -2617,7 +2617,7 @@ pub impl @lib.Sized for ServiceDescriptorProto with size_of(self) {
   }
   size
 }
-pub impl Default for ServiceDescriptorProto with default() -> ServiceDescriptorProto {
+pub impl Default for ServiceDescriptorProto with fn default() -> ServiceDescriptorProto {
   ServiceDescriptorProto::{
     name : None,
     method_ : [],
@@ -2631,7 +2631,7 @@ pub fn ServiceDescriptorProto::new(name? : String, method_ : Array[MethodDescrip
     options,
   }
 }
-pub impl @lib.Read for ServiceDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ServiceDescriptorProto raise {
+pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
   try {
     for ;; {
@@ -2648,7 +2648,7 @@ pub impl @lib.Read for ServiceDescriptorProto with read_with_limit(reader : @lib
   }
   msg
 }
-pub impl @lib.Write for ServiceDescriptorProto with write(self: ServiceDescriptorProto, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for ServiceDescriptorProto with fn write(self: ServiceDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -2665,7 +2665,7 @@ pub impl @lib.Write for ServiceDescriptorProto with write(self: ServiceDescripto
 
   }
 }
-pub impl ToJson for ServiceDescriptorProto with to_json(self) {
+pub impl ToJson for ServiceDescriptorProto with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.name {
       Some(v) => json["name"] = v.to_json()
@@ -2680,7 +2680,7 @@ pub impl ToJson for ServiceDescriptorProto with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for ServiceDescriptorProto with from_json(json: Json, path: @json.JsonPath) -> ServiceDescriptorProto raise {
+pub impl @json.FromJson for ServiceDescriptorProto with fn from_json(json: Json, path: @json.JsonPath) -> ServiceDescriptorProto raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for ServiceDescriptorProto"))
   }
@@ -2691,12 +2691,12 @@ pub impl @json.FromJson for ServiceDescriptorProto with from_json(json: Json, pa
       ("method", Array(value)) => message.method_ = value.map(v => 
 @json.from_json(v, path~))
       ("options", value) => message.options = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for ServiceDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ServiceDescriptorProto raise {
+pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
   try {
     for ;; {
@@ -2713,7 +2713,7 @@ pub impl @lib.AsyncRead for ServiceDescriptorProto with read_with_limit(reader :
   }
   msg
 }
-pub impl @lib.AsyncWrite for ServiceDescriptorProto with write(self: ServiceDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for ServiceDescriptorProto with fn write(self: ServiceDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)
@@ -2738,7 +2738,7 @@ pub(all) struct MethodDescriptorProto {
   mut client_streaming : Bool?
   mut server_streaming : Bool?
 } derive(Eq, Debug)
-pub impl @lib.Sized for MethodDescriptorProto with size_of(self) {
+pub impl @lib.Sized for MethodDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -2760,7 +2760,7 @@ pub impl @lib.Sized for MethodDescriptorProto with size_of(self) {
   }
   size
 }
-pub impl Default for MethodDescriptorProto with default() -> MethodDescriptorProto {
+pub impl Default for MethodDescriptorProto with fn default() -> MethodDescriptorProto {
   MethodDescriptorProto::{
     name : None,
     input_type : None,
@@ -2780,7 +2780,7 @@ pub fn MethodDescriptorProto::new(name? : String, input_type? : String, output_t
     server_streaming,
   }
 }
-pub impl @lib.Read for MethodDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MethodDescriptorProto raise {
+pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
   try {
     for ;; {
@@ -2800,7 +2800,7 @@ pub impl @lib.Read for MethodDescriptorProto with read_with_limit(reader : @lib.
   }
   msg
 }
-pub impl @lib.Write for MethodDescriptorProto with write(self: MethodDescriptorProto, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for MethodDescriptorProto with fn write(self: MethodDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -2832,7 +2832,7 @@ pub impl @lib.Write for MethodDescriptorProto with write(self: MethodDescriptorP
 
   }
 }
-pub impl ToJson for MethodDescriptorProto with to_json(self) {
+pub impl ToJson for MethodDescriptorProto with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.name {
       Some(v) => json["name"] = v.to_json()
@@ -2860,7 +2860,7 @@ pub impl ToJson for MethodDescriptorProto with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for MethodDescriptorProto with from_json(json: Json, path: @json.JsonPath) -> MethodDescriptorProto raise {
+pub impl @json.FromJson for MethodDescriptorProto with fn from_json(json: Json, path: @json.JsonPath) -> MethodDescriptorProto raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for MethodDescriptorProto"))
   }
@@ -2873,12 +2873,12 @@ pub impl @json.FromJson for MethodDescriptorProto with from_json(json: Json, pat
       ("options", value) => message.options = Some(@json.from_json(value, path~))
       ("clientStreaming", value) => message.client_streaming = Some(@json.from_json(value, path~))
       ("serverStreaming", value) => message.server_streaming = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for MethodDescriptorProto with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MethodDescriptorProto raise {
+pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
   try {
     for ;; {
@@ -2898,7 +2898,7 @@ pub impl @lib.AsyncRead for MethodDescriptorProto with read_with_limit(reader : 
   }
   msg
 }
-pub impl @lib.AsyncWrite for MethodDescriptorProto with write(self: MethodDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for MethodDescriptorProto with fn write(self: MethodDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)
@@ -2950,13 +2950,13 @@ pub fn FileOptions_OptimizeMode::from_enum(i : @lib.Enum) -> FileOptions_Optimiz
     _ => Default::default()
   }
 }
-pub impl Default for FileOptions_OptimizeMode with default() -> FileOptions_OptimizeMode {
+pub impl Default for FileOptions_OptimizeMode with fn default() -> FileOptions_OptimizeMode {
   FileOptions_OptimizeMode::SPEED
 }
-pub impl @lib.Sized for FileOptions_OptimizeMode with size_of(self : FileOptions_OptimizeMode) {
+pub impl @lib.Sized for FileOptions_OptimizeMode with fn size_of(self : FileOptions_OptimizeMode) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FileOptions_OptimizeMode with from_json(json: Json, path: @json.JsonPath) -> FileOptions_OptimizeMode raise {
+pub impl @json.FromJson for FileOptions_OptimizeMode with fn from_json(json: Json, path: @json.JsonPath) -> FileOptions_OptimizeMode raise {
   match json {
     String("SPEED") => FileOptions_OptimizeMode::SPEED
     String("CODE_SIZE") => FileOptions_OptimizeMode::CODE_SIZE
@@ -2967,7 +2967,7 @@ pub impl @json.FromJson for FileOptions_OptimizeMode with from_json(json: Json, 
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FileOptions_OptimizeMode with to_json(self : FileOptions_OptimizeMode) -> Json {
+pub impl ToJson for FileOptions_OptimizeMode with fn to_json(self : FileOptions_OptimizeMode) -> Json {
   match self {
     FileOptions_OptimizeMode::SPEED => "SPEED"
     FileOptions_OptimizeMode::CODE_SIZE => "CODE_SIZE"
@@ -2997,7 +2997,7 @@ pub(all) struct FileOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
 } derive(Eq, Debug)
-pub impl @lib.Sized for FileOptions with size_of(self) {
+pub impl @lib.Sized for FileOptions with fn size_of(self) {
   let mut size = 0U
   if self.java_package is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -3065,7 +3065,7 @@ pub impl @lib.Sized for FileOptions with size_of(self) {
   }
   size
 }
-pub impl Default for FileOptions with default() -> FileOptions {
+pub impl Default for FileOptions with fn default() -> FileOptions {
   FileOptions::{
     java_package : None,
     java_outer_classname : None,
@@ -3115,7 +3115,7 @@ pub fn FileOptions::new(java_package? : String, java_outer_classname? : String, 
     uninterpreted_option,
   }
 }
-pub impl @lib.Read for FileOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileOptions raise {
+pub impl @lib.Read for FileOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileOptions raise {
   let msg = FileOptions::default()
   try {
     for ;; {
@@ -3150,7 +3150,7 @@ pub impl @lib.Read for FileOptions with read_with_limit(reader : @lib.LimitedRea
   }
   msg
 }
-pub impl @lib.Write for FileOptions with write(self: FileOptions, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FileOptions with fn write(self: FileOptions, writer : &@lib.Writer) -> Unit raise {
   if self.java_package is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_string(v)
@@ -3257,7 +3257,7 @@ pub impl @lib.Write for FileOptions with write(self: FileOptions, writer : &@lib
 
   }
 }
-pub impl ToJson for FileOptions with to_json(self) {
+pub impl ToJson for FileOptions with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.java_package {
       Some(v) => json["javaPackage"] = v.to_json()
@@ -3344,7 +3344,7 @@ pub impl ToJson for FileOptions with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for FileOptions with from_json(json: Json, path: @json.JsonPath) -> FileOptions raise {
+pub impl @json.FromJson for FileOptions with fn from_json(json: Json, path: @json.JsonPath) -> FileOptions raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FileOptions"))
   }
@@ -3373,12 +3373,12 @@ pub impl @json.FromJson for FileOptions with from_json(json: Json, path: @json.J
       ("features", value) => message.features = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) => message.uninterpreted_option = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FileOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileOptions raise {
+pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileOptions raise {
   let msg = FileOptions::default()
   try {
     for ;; {
@@ -3413,7 +3413,7 @@ pub impl @lib.AsyncRead for FileOptions with read_with_limit(reader : @lib.Limit
   }
   msg
 }
-pub impl @lib.AsyncWrite for FileOptions with write(self: FileOptions, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FileOptions with fn write(self: FileOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.java_package is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_string(v)
@@ -3529,7 +3529,7 @@ pub(all) struct MessageOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
 } derive(Eq, Debug)
-pub impl @lib.Sized for MessageOptions with size_of(self) {
+pub impl @lib.Sized for MessageOptions with fn size_of(self) {
   let mut size = 0U
   if self.message_set_wire_format is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -3555,7 +3555,7 @@ pub impl @lib.Sized for MessageOptions with size_of(self) {
   }
   size
 }
-pub impl Default for MessageOptions with default() -> MessageOptions {
+pub impl Default for MessageOptions with fn default() -> MessageOptions {
   MessageOptions::{
     message_set_wire_format : Some(false),
     no_standard_descriptor_accessor : Some(false),
@@ -3577,7 +3577,7 @@ pub fn MessageOptions::new(message_set_wire_format? : Bool, no_standard_descript
     uninterpreted_option,
   }
 }
-pub impl @lib.Read for MessageOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MessageOptions raise {
+pub impl @lib.Read for MessageOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MessageOptions raise {
   let msg = MessageOptions::default()
   try {
     for ;; {
@@ -3598,7 +3598,7 @@ pub impl @lib.Read for MessageOptions with read_with_limit(reader : @lib.Limited
   }
   msg
 }
-pub impl @lib.Write for MessageOptions with write(self: MessageOptions, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for MessageOptions with fn write(self: MessageOptions, writer : &@lib.Writer) -> Unit raise {
   if self.message_set_wire_format is Some(v) {
     writer |> @lib.write_varint(8UL);
     writer |> @lib.write_bool(v)
@@ -3635,7 +3635,7 @@ pub impl @lib.Write for MessageOptions with write(self: MessageOptions, writer :
 
   }
 }
-pub impl ToJson for MessageOptions with to_json(self) {
+pub impl ToJson for MessageOptions with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.message_set_wire_format {
       Some(v) if v != false => json["messageSetWireFormat"] = v.to_json()
@@ -3666,7 +3666,7 @@ pub impl ToJson for MessageOptions with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for MessageOptions with from_json(json: Json, path: @json.JsonPath) -> MessageOptions raise {
+pub impl @json.FromJson for MessageOptions with fn from_json(json: Json, path: @json.JsonPath) -> MessageOptions raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for MessageOptions"))
   }
@@ -3681,12 +3681,12 @@ pub impl @json.FromJson for MessageOptions with from_json(json: Json, path: @jso
       ("features", value) => message.features = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) => message.uninterpreted_option = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for MessageOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MessageOptions raise {
+pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MessageOptions raise {
   let msg = MessageOptions::default()
   try {
     for ;; {
@@ -3707,7 +3707,7 @@ pub impl @lib.AsyncRead for MessageOptions with read_with_limit(reader : @lib.Li
   }
   msg
 }
-pub impl @lib.AsyncWrite for MessageOptions with write(self: MessageOptions, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for MessageOptions with fn write(self: MessageOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.message_set_wire_format is Some(v) {
     writer |> @lib.async_write_varint(8UL);
     writer |> @lib.async_write_bool(v)
@@ -3764,13 +3764,13 @@ pub fn FieldOptions_CType::from_enum(i : @lib.Enum) -> FieldOptions_CType {
     _ => Default::default()
   }
 }
-pub impl Default for FieldOptions_CType with default() -> FieldOptions_CType {
+pub impl Default for FieldOptions_CType with fn default() -> FieldOptions_CType {
   FieldOptions_CType::STRING
 }
-pub impl @lib.Sized for FieldOptions_CType with size_of(self : FieldOptions_CType) {
+pub impl @lib.Sized for FieldOptions_CType with fn size_of(self : FieldOptions_CType) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FieldOptions_CType with from_json(json: Json, path: @json.JsonPath) -> FieldOptions_CType raise {
+pub impl @json.FromJson for FieldOptions_CType with fn from_json(json: Json, path: @json.JsonPath) -> FieldOptions_CType raise {
   match json {
     String("STRING") => FieldOptions_CType::STRING
     String("CORD") => FieldOptions_CType::CORD
@@ -3781,7 +3781,7 @@ pub impl @json.FromJson for FieldOptions_CType with from_json(json: Json, path: 
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FieldOptions_CType with to_json(self : FieldOptions_CType) -> Json {
+pub impl ToJson for FieldOptions_CType with fn to_json(self : FieldOptions_CType) -> Json {
   match self {
     FieldOptions_CType::STRING => "STRING"
     FieldOptions_CType::CORD => "CORD"
@@ -3808,13 +3808,13 @@ pub fn FieldOptions_JSType::from_enum(i : @lib.Enum) -> FieldOptions_JSType {
     _ => Default::default()
   }
 }
-pub impl Default for FieldOptions_JSType with default() -> FieldOptions_JSType {
+pub impl Default for FieldOptions_JSType with fn default() -> FieldOptions_JSType {
   FieldOptions_JSType::JS_NORMAL
 }
-pub impl @lib.Sized for FieldOptions_JSType with size_of(self : FieldOptions_JSType) {
+pub impl @lib.Sized for FieldOptions_JSType with fn size_of(self : FieldOptions_JSType) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FieldOptions_JSType with from_json(json: Json, path: @json.JsonPath) -> FieldOptions_JSType raise {
+pub impl @json.FromJson for FieldOptions_JSType with fn from_json(json: Json, path: @json.JsonPath) -> FieldOptions_JSType raise {
   match json {
     String("JS_NORMAL") => FieldOptions_JSType::JS_NORMAL
     String("JS_STRING") => FieldOptions_JSType::JS_STRING
@@ -3825,7 +3825,7 @@ pub impl @json.FromJson for FieldOptions_JSType with from_json(json: Json, path:
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FieldOptions_JSType with to_json(self : FieldOptions_JSType) -> Json {
+pub impl ToJson for FieldOptions_JSType with fn to_json(self : FieldOptions_JSType) -> Json {
   match self {
     FieldOptions_JSType::JS_NORMAL => "JS_NORMAL"
     FieldOptions_JSType::JS_STRING => "JS_STRING"
@@ -3852,13 +3852,13 @@ pub fn FieldOptions_OptionRetention::from_enum(i : @lib.Enum) -> FieldOptions_Op
     _ => Default::default()
   }
 }
-pub impl Default for FieldOptions_OptionRetention with default() -> FieldOptions_OptionRetention {
+pub impl Default for FieldOptions_OptionRetention with fn default() -> FieldOptions_OptionRetention {
   FieldOptions_OptionRetention::RETENTION_UNKNOWN
 }
-pub impl @lib.Sized for FieldOptions_OptionRetention with size_of(self : FieldOptions_OptionRetention) {
+pub impl @lib.Sized for FieldOptions_OptionRetention with fn size_of(self : FieldOptions_OptionRetention) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FieldOptions_OptionRetention with from_json(json: Json, path: @json.JsonPath) -> FieldOptions_OptionRetention raise {
+pub impl @json.FromJson for FieldOptions_OptionRetention with fn from_json(json: Json, path: @json.JsonPath) -> FieldOptions_OptionRetention raise {
   match json {
     String("RETENTION_UNKNOWN") => FieldOptions_OptionRetention::RETENTION_UNKNOWN
     String("RETENTION_RUNTIME") => FieldOptions_OptionRetention::RETENTION_RUNTIME
@@ -3869,7 +3869,7 @@ pub impl @json.FromJson for FieldOptions_OptionRetention with from_json(json: Js
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FieldOptions_OptionRetention with to_json(self : FieldOptions_OptionRetention) -> Json {
+pub impl ToJson for FieldOptions_OptionRetention with fn to_json(self : FieldOptions_OptionRetention) -> Json {
   match self {
     FieldOptions_OptionRetention::RETENTION_UNKNOWN => "RETENTION_UNKNOWN"
     FieldOptions_OptionRetention::RETENTION_RUNTIME => "RETENTION_RUNTIME"
@@ -3917,13 +3917,13 @@ pub fn FieldOptions_OptionTargetType::from_enum(i : @lib.Enum) -> FieldOptions_O
     _ => Default::default()
   }
 }
-pub impl Default for FieldOptions_OptionTargetType with default() -> FieldOptions_OptionTargetType {
+pub impl Default for FieldOptions_OptionTargetType with fn default() -> FieldOptions_OptionTargetType {
   FieldOptions_OptionTargetType::TARGET_TYPE_UNKNOWN
 }
-pub impl @lib.Sized for FieldOptions_OptionTargetType with size_of(self : FieldOptions_OptionTargetType) {
+pub impl @lib.Sized for FieldOptions_OptionTargetType with fn size_of(self : FieldOptions_OptionTargetType) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FieldOptions_OptionTargetType with from_json(json: Json, path: @json.JsonPath) -> FieldOptions_OptionTargetType raise {
+pub impl @json.FromJson for FieldOptions_OptionTargetType with fn from_json(json: Json, path: @json.JsonPath) -> FieldOptions_OptionTargetType raise {
   match json {
     String("TARGET_TYPE_UNKNOWN") => FieldOptions_OptionTargetType::TARGET_TYPE_UNKNOWN
     String("TARGET_TYPE_FILE") => FieldOptions_OptionTargetType::TARGET_TYPE_FILE
@@ -3948,7 +3948,7 @@ pub impl @json.FromJson for FieldOptions_OptionTargetType with from_json(json: J
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FieldOptions_OptionTargetType with to_json(self : FieldOptions_OptionTargetType) -> Json {
+pub impl ToJson for FieldOptions_OptionTargetType with fn to_json(self : FieldOptions_OptionTargetType) -> Json {
   match self {
     FieldOptions_OptionTargetType::TARGET_TYPE_UNKNOWN => "TARGET_TYPE_UNKNOWN"
     FieldOptions_OptionTargetType::TARGET_TYPE_FILE => "TARGET_TYPE_FILE"
@@ -3966,7 +3966,7 @@ pub(all) struct FieldOptions_EditionDefault {
   mut edition : Edition?
   mut value : String?
 } derive(Eq, Debug)
-pub impl @lib.Sized for FieldOptions_EditionDefault with size_of(self) {
+pub impl @lib.Sized for FieldOptions_EditionDefault with fn size_of(self) {
   let mut size = 0U
   if self.edition is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -3976,7 +3976,7 @@ pub impl @lib.Sized for FieldOptions_EditionDefault with size_of(self) {
   }
   size
 }
-pub impl Default for FieldOptions_EditionDefault with default() -> FieldOptions_EditionDefault {
+pub impl Default for FieldOptions_EditionDefault with fn default() -> FieldOptions_EditionDefault {
   FieldOptions_EditionDefault::{
     edition : None,
     value : None,
@@ -3988,7 +3988,7 @@ pub fn FieldOptions_EditionDefault::new(edition? : Edition, value? : String) -> 
     value,
   }
 }
-pub impl @lib.Read for FieldOptions_EditionDefault with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions_EditionDefault raise {
+pub impl @lib.Read for FieldOptions_EditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
   try {
     for ;; {
@@ -4004,7 +4004,7 @@ pub impl @lib.Read for FieldOptions_EditionDefault with read_with_limit(reader :
   }
   msg
 }
-pub impl @lib.Write for FieldOptions_EditionDefault with write(self: FieldOptions_EditionDefault, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FieldOptions_EditionDefault with fn write(self: FieldOptions_EditionDefault, writer : &@lib.Writer) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.write_varint(24UL);
     writer |> @lib.write_enum(v.to_enum())
@@ -4016,7 +4016,7 @@ pub impl @lib.Write for FieldOptions_EditionDefault with write(self: FieldOption
 
   }
 }
-pub impl ToJson for FieldOptions_EditionDefault with to_json(self) {
+pub impl ToJson for FieldOptions_EditionDefault with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.edition {
       Some(v) => json["edition"] = v.to_json()
@@ -4028,7 +4028,7 @@ pub impl ToJson for FieldOptions_EditionDefault with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for FieldOptions_EditionDefault with from_json(json: Json, path: @json.JsonPath) -> FieldOptions_EditionDefault raise {
+pub impl @json.FromJson for FieldOptions_EditionDefault with fn from_json(json: Json, path: @json.JsonPath) -> FieldOptions_EditionDefault raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FieldOptions_EditionDefault"))
   }
@@ -4037,12 +4037,12 @@ pub impl @json.FromJson for FieldOptions_EditionDefault with from_json(json: Jso
     match (key, value) {
       ("edition", value) => message.edition = Some(@json.from_json(value, path~))
       ("value", value) => message.value = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FieldOptions_EditionDefault with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions_EditionDefault raise {
+pub impl @lib.AsyncRead for FieldOptions_EditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
   try {
     for ;; {
@@ -4058,7 +4058,7 @@ pub impl @lib.AsyncRead for FieldOptions_EditionDefault with read_with_limit(rea
   }
   msg
 }
-pub impl @lib.AsyncWrite for FieldOptions_EditionDefault with write(self: FieldOptions_EditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FieldOptions_EditionDefault with fn write(self: FieldOptions_EditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.async_write_varint(24UL);
     writer |> @lib.async_write_enum(v.to_enum())
@@ -4076,7 +4076,7 @@ pub(all) struct FieldOptions_FeatureSupport {
   mut deprecation_warning : String?
   mut edition_removed : Edition?
 } derive(Eq, Debug)
-pub impl @lib.Sized for FieldOptions_FeatureSupport with size_of(self) {
+pub impl @lib.Sized for FieldOptions_FeatureSupport with fn size_of(self) {
   let mut size = 0U
   if self.edition_introduced is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -4092,7 +4092,7 @@ pub impl @lib.Sized for FieldOptions_FeatureSupport with size_of(self) {
   }
   size
 }
-pub impl Default for FieldOptions_FeatureSupport with default() -> FieldOptions_FeatureSupport {
+pub impl Default for FieldOptions_FeatureSupport with fn default() -> FieldOptions_FeatureSupport {
   FieldOptions_FeatureSupport::{
     edition_introduced : None,
     edition_deprecated : None,
@@ -4108,7 +4108,7 @@ pub fn FieldOptions_FeatureSupport::new(edition_introduced? : Edition, edition_d
     edition_removed,
   }
 }
-pub impl @lib.Read for FieldOptions_FeatureSupport with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions_FeatureSupport raise {
+pub impl @lib.Read for FieldOptions_FeatureSupport with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
   try {
     for ;; {
@@ -4126,7 +4126,7 @@ pub impl @lib.Read for FieldOptions_FeatureSupport with read_with_limit(reader :
   }
   msg
 }
-pub impl @lib.Write for FieldOptions_FeatureSupport with write(self: FieldOptions_FeatureSupport, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FieldOptions_FeatureSupport with fn write(self: FieldOptions_FeatureSupport, writer : &@lib.Writer) -> Unit raise {
   if self.edition_introduced is Some(v) {
     writer |> @lib.write_varint(8UL);
     writer |> @lib.write_enum(v.to_enum())
@@ -4148,7 +4148,7 @@ pub impl @lib.Write for FieldOptions_FeatureSupport with write(self: FieldOption
 
   }
 }
-pub impl ToJson for FieldOptions_FeatureSupport with to_json(self) {
+pub impl ToJson for FieldOptions_FeatureSupport with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.edition_introduced {
       Some(v) => json["editionIntroduced"] = v.to_json()
@@ -4168,7 +4168,7 @@ pub impl ToJson for FieldOptions_FeatureSupport with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for FieldOptions_FeatureSupport with from_json(json: Json, path: @json.JsonPath) -> FieldOptions_FeatureSupport raise {
+pub impl @json.FromJson for FieldOptions_FeatureSupport with fn from_json(json: Json, path: @json.JsonPath) -> FieldOptions_FeatureSupport raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FieldOptions_FeatureSupport"))
   }
@@ -4179,12 +4179,12 @@ pub impl @json.FromJson for FieldOptions_FeatureSupport with from_json(json: Jso
       ("editionDeprecated", value) => message.edition_deprecated = Some(@json.from_json(value, path~))
       ("deprecationWarning", value) => message.deprecation_warning = Some(@json.from_json(value, path~))
       ("editionRemoved", value) => message.edition_removed = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions_FeatureSupport raise {
+pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
   try {
     for ;; {
@@ -4202,7 +4202,7 @@ pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with read_with_limit(rea
   }
   msg
 }
-pub impl @lib.AsyncWrite for FieldOptions_FeatureSupport with write(self: FieldOptions_FeatureSupport, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FieldOptions_FeatureSupport with fn write(self: FieldOptions_FeatureSupport, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.edition_introduced is Some(v) {
     writer |> @lib.async_write_varint(8UL);
     writer |> @lib.async_write_enum(v.to_enum())
@@ -4240,7 +4240,7 @@ pub(all) struct FieldOptions {
   mut feature_support : FieldOptions_FeatureSupport?
   mut uninterpreted_option : Array[UninterpretedOption]
 } derive(Eq, Debug)
-pub impl @lib.Sized for FieldOptions with size_of(self) {
+pub impl @lib.Sized for FieldOptions with fn size_of(self) {
   let mut size = 0U
   if self.ctype is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -4289,7 +4289,7 @@ pub impl @lib.Sized for FieldOptions with size_of(self) {
   }
   size
 }
-pub impl Default for FieldOptions with default() -> FieldOptions {
+pub impl Default for FieldOptions with fn default() -> FieldOptions {
   FieldOptions::{
     ctype : Some(FieldOptions_CType::STRING),
     packed : None,
@@ -4325,7 +4325,7 @@ pub fn FieldOptions::new(ctype? : FieldOptions_CType, packed? : Bool, jstype? : 
     uninterpreted_option,
   }
 }
-pub impl @lib.Read for FieldOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions raise {
+pub impl @lib.Read for FieldOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions raise {
   let msg = FieldOptions::default()
   try {
     for ;; {
@@ -4354,7 +4354,7 @@ pub impl @lib.Read for FieldOptions with read_with_limit(reader : @lib.LimitedRe
   }
   msg
 }
-pub impl @lib.Write for FieldOptions with write(self: FieldOptions, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FieldOptions with fn write(self: FieldOptions, writer : &@lib.Writer) -> Unit raise {
   if self.ctype is Some(v) {
     writer |> @lib.write_varint(8UL);
     writer |> @lib.write_enum(v.to_enum())
@@ -4426,7 +4426,7 @@ pub impl @lib.Write for FieldOptions with write(self: FieldOptions, writer : &@l
 
   }
 }
-pub impl ToJson for FieldOptions with to_json(self) {
+pub impl ToJson for FieldOptions with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.ctype {
       Some(v) if v != FieldOptions_CType::STRING => json["ctype"] = v.to_json()
@@ -4483,7 +4483,7 @@ pub impl ToJson for FieldOptions with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for FieldOptions with from_json(json: Json, path: @json.JsonPath) -> FieldOptions raise {
+pub impl @json.FromJson for FieldOptions with fn from_json(json: Json, path: @json.JsonPath) -> FieldOptions raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FieldOptions"))
   }
@@ -4507,12 +4507,12 @@ pub impl @json.FromJson for FieldOptions with from_json(json: Json, path: @json.
       ("featureSupport", value) => message.feature_support = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) => message.uninterpreted_option = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FieldOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions raise {
+pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions raise {
   let msg = FieldOptions::default()
   try {
     for ;; {
@@ -4541,7 +4541,7 @@ pub impl @lib.AsyncRead for FieldOptions with read_with_limit(reader : @lib.Limi
   }
   msg
 }
-pub impl @lib.AsyncWrite for FieldOptions with write(self: FieldOptions, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FieldOptions with fn write(self: FieldOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.ctype is Some(v) {
     writer |> @lib.async_write_varint(8UL);
     writer |> @lib.async_write_enum(v.to_enum())
@@ -4617,7 +4617,7 @@ pub(all) struct OneofOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
 } derive(Eq, Debug)
-pub impl @lib.Sized for OneofOptions with size_of(self) {
+pub impl @lib.Sized for OneofOptions with fn size_of(self) {
   let mut size = 0U
   if self.features is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -4628,7 +4628,7 @@ pub impl @lib.Sized for OneofOptions with size_of(self) {
   }
   size
 }
-pub impl Default for OneofOptions with default() -> OneofOptions {
+pub impl Default for OneofOptions with fn default() -> OneofOptions {
   OneofOptions::{
     features : None,
     uninterpreted_option : [],
@@ -4640,7 +4640,7 @@ pub fn OneofOptions::new(features? : FeatureSet, uninterpreted_option : Array[Un
     uninterpreted_option,
   }
 }
-pub impl @lib.Read for OneofOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> OneofOptions raise {
+pub impl @lib.Read for OneofOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> OneofOptions raise {
   let msg = OneofOptions::default()
   try {
     for ;; {
@@ -4656,7 +4656,7 @@ pub impl @lib.Read for OneofOptions with read_with_limit(reader : @lib.LimitedRe
   }
   msg
 }
-pub impl @lib.Write for OneofOptions with write(self: OneofOptions, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for OneofOptions with fn write(self: OneofOptions, writer : &@lib.Writer) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.write_varint(10UL);
     writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
@@ -4668,7 +4668,7 @@ pub impl @lib.Write for OneofOptions with write(self: OneofOptions, writer : &@l
 
   }
 }
-pub impl ToJson for OneofOptions with to_json(self) {
+pub impl ToJson for OneofOptions with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.features {
       Some(v) => json["features"] = v.to_json()
@@ -4679,7 +4679,7 @@ pub impl ToJson for OneofOptions with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for OneofOptions with from_json(json: Json, path: @json.JsonPath) -> OneofOptions raise {
+pub impl @json.FromJson for OneofOptions with fn from_json(json: Json, path: @json.JsonPath) -> OneofOptions raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for OneofOptions"))
   }
@@ -4689,12 +4689,12 @@ pub impl @json.FromJson for OneofOptions with from_json(json: Json, path: @json.
       ("features", value) => message.features = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) => message.uninterpreted_option = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for OneofOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> OneofOptions raise {
+pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> OneofOptions raise {
   let msg = OneofOptions::default()
   try {
     for ;; {
@@ -4710,7 +4710,7 @@ pub impl @lib.AsyncRead for OneofOptions with read_with_limit(reader : @lib.Limi
   }
   msg
 }
-pub impl @lib.AsyncWrite for OneofOptions with write(self: OneofOptions, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for OneofOptions with fn write(self: OneofOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(10UL);
     writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
@@ -4729,7 +4729,7 @@ pub(all) struct EnumOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
 } derive(Eq, Debug)
-pub impl @lib.Sized for EnumOptions with size_of(self) {
+pub impl @lib.Sized for EnumOptions with fn size_of(self) {
   let mut size = 0U
   if self.allow_alias is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -4749,7 +4749,7 @@ pub impl @lib.Sized for EnumOptions with size_of(self) {
   }
   size
 }
-pub impl Default for EnumOptions with default() -> EnumOptions {
+pub impl Default for EnumOptions with fn default() -> EnumOptions {
   EnumOptions::{
     allow_alias : None,
     deprecated : Some(false),
@@ -4767,7 +4767,7 @@ pub fn EnumOptions::new(allow_alias? : Bool, deprecated? : Bool, deprecated_lega
     uninterpreted_option,
   }
 }
-pub impl @lib.Read for EnumOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumOptions raise {
+pub impl @lib.Read for EnumOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumOptions raise {
   let msg = EnumOptions::default()
   try {
     for ;; {
@@ -4786,7 +4786,7 @@ pub impl @lib.Read for EnumOptions with read_with_limit(reader : @lib.LimitedRea
   }
   msg
 }
-pub impl @lib.Write for EnumOptions with write(self: EnumOptions, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for EnumOptions with fn write(self: EnumOptions, writer : &@lib.Writer) -> Unit raise {
   if self.allow_alias is Some(v) {
     writer |> @lib.write_varint(16UL);
     writer |> @lib.write_bool(v)
@@ -4813,7 +4813,7 @@ pub impl @lib.Write for EnumOptions with write(self: EnumOptions, writer : &@lib
 
   }
 }
-pub impl ToJson for EnumOptions with to_json(self) {
+pub impl ToJson for EnumOptions with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.allow_alias {
       Some(v) => json["allowAlias"] = v.to_json()
@@ -4836,7 +4836,7 @@ pub impl ToJson for EnumOptions with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for EnumOptions with from_json(json: Json, path: @json.JsonPath) -> EnumOptions raise {
+pub impl @json.FromJson for EnumOptions with fn from_json(json: Json, path: @json.JsonPath) -> EnumOptions raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for EnumOptions"))
   }
@@ -4849,12 +4849,12 @@ pub impl @json.FromJson for EnumOptions with from_json(json: Json, path: @json.J
       ("features", value) => message.features = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) => message.uninterpreted_option = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for EnumOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumOptions raise {
+pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumOptions raise {
   let msg = EnumOptions::default()
   try {
     for ;; {
@@ -4873,7 +4873,7 @@ pub impl @lib.AsyncRead for EnumOptions with read_with_limit(reader : @lib.Limit
   }
   msg
 }
-pub impl @lib.AsyncWrite for EnumOptions with write(self: EnumOptions, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for EnumOptions with fn write(self: EnumOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.allow_alias is Some(v) {
     writer |> @lib.async_write_varint(16UL);
     writer |> @lib.async_write_bool(v)
@@ -4907,7 +4907,7 @@ pub(all) struct EnumValueOptions {
   mut feature_support : FieldOptions_FeatureSupport?
   mut uninterpreted_option : Array[UninterpretedOption]
 } derive(Eq, Debug)
-pub impl @lib.Sized for EnumValueOptions with size_of(self) {
+pub impl @lib.Sized for EnumValueOptions with fn size_of(self) {
   let mut size = 0U
   if self.deprecated is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -4927,7 +4927,7 @@ pub impl @lib.Sized for EnumValueOptions with size_of(self) {
   }
   size
 }
-pub impl Default for EnumValueOptions with default() -> EnumValueOptions {
+pub impl Default for EnumValueOptions with fn default() -> EnumValueOptions {
   EnumValueOptions::{
     deprecated : Some(false),
     features : None,
@@ -4945,7 +4945,7 @@ pub fn EnumValueOptions::new(deprecated? : Bool, features? : FeatureSet, debug_r
     uninterpreted_option,
   }
 }
-pub impl @lib.Read for EnumValueOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumValueOptions raise {
+pub impl @lib.Read for EnumValueOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
   try {
     for ;; {
@@ -4964,7 +4964,7 @@ pub impl @lib.Read for EnumValueOptions with read_with_limit(reader : @lib.Limit
   }
   msg
 }
-pub impl @lib.Write for EnumValueOptions with write(self: EnumValueOptions, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for EnumValueOptions with fn write(self: EnumValueOptions, writer : &@lib.Writer) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(8UL);
     writer |> @lib.write_bool(v)
@@ -4991,7 +4991,7 @@ pub impl @lib.Write for EnumValueOptions with write(self: EnumValueOptions, writ
 
   }
 }
-pub impl ToJson for EnumValueOptions with to_json(self) {
+pub impl ToJson for EnumValueOptions with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.deprecated {
       Some(v) if v != false => json["deprecated"] = v.to_json()
@@ -5014,7 +5014,7 @@ pub impl ToJson for EnumValueOptions with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for EnumValueOptions with from_json(json: Json, path: @json.JsonPath) -> EnumValueOptions raise {
+pub impl @json.FromJson for EnumValueOptions with fn from_json(json: Json, path: @json.JsonPath) -> EnumValueOptions raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for EnumValueOptions"))
   }
@@ -5027,12 +5027,12 @@ pub impl @json.FromJson for EnumValueOptions with from_json(json: Json, path: @j
       ("featureSupport", value) => message.feature_support = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) => message.uninterpreted_option = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for EnumValueOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumValueOptions raise {
+pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
   try {
     for ;; {
@@ -5051,7 +5051,7 @@ pub impl @lib.AsyncRead for EnumValueOptions with read_with_limit(reader : @lib.
   }
   msg
 }
-pub impl @lib.AsyncWrite for EnumValueOptions with write(self: EnumValueOptions, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for EnumValueOptions with fn write(self: EnumValueOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(8UL);
     writer |> @lib.async_write_bool(v)
@@ -5083,7 +5083,7 @@ pub(all) struct ServiceOptions {
   mut deprecated : Bool?
   mut uninterpreted_option : Array[UninterpretedOption]
 } derive(Eq, Debug)
-pub impl @lib.Sized for ServiceOptions with size_of(self) {
+pub impl @lib.Sized for ServiceOptions with fn size_of(self) {
   let mut size = 0U
   if self.features is Some(v) {
     size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -5097,7 +5097,7 @@ pub impl @lib.Sized for ServiceOptions with size_of(self) {
   }
   size
 }
-pub impl Default for ServiceOptions with default() -> ServiceOptions {
+pub impl Default for ServiceOptions with fn default() -> ServiceOptions {
   ServiceOptions::{
     features : None,
     deprecated : Some(false),
@@ -5111,7 +5111,7 @@ pub fn ServiceOptions::new(features? : FeatureSet, deprecated? : Bool, uninterpr
     uninterpreted_option,
   }
 }
-pub impl @lib.Read for ServiceOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ServiceOptions raise {
+pub impl @lib.Read for ServiceOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
   try {
     for ;; {
@@ -5128,7 +5128,7 @@ pub impl @lib.Read for ServiceOptions with read_with_limit(reader : @lib.Limited
   }
   msg
 }
-pub impl @lib.Write for ServiceOptions with write(self: ServiceOptions, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for ServiceOptions with fn write(self: ServiceOptions, writer : &@lib.Writer) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.write_varint(274UL);
     writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
@@ -5145,7 +5145,7 @@ pub impl @lib.Write for ServiceOptions with write(self: ServiceOptions, writer :
 
   }
 }
-pub impl ToJson for ServiceOptions with to_json(self) {
+pub impl ToJson for ServiceOptions with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.features {
       Some(v) => json["features"] = v.to_json()
@@ -5160,7 +5160,7 @@ pub impl ToJson for ServiceOptions with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for ServiceOptions with from_json(json: Json, path: @json.JsonPath) -> ServiceOptions raise {
+pub impl @json.FromJson for ServiceOptions with fn from_json(json: Json, path: @json.JsonPath) -> ServiceOptions raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for ServiceOptions"))
   }
@@ -5171,12 +5171,12 @@ pub impl @json.FromJson for ServiceOptions with from_json(json: Json, path: @jso
       ("deprecated", value) => message.deprecated = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) => message.uninterpreted_option = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for ServiceOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ServiceOptions raise {
+pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
   try {
     for ;; {
@@ -5193,7 +5193,7 @@ pub impl @lib.AsyncRead for ServiceOptions with read_with_limit(reader : @lib.Li
   }
   msg
 }
-pub impl @lib.AsyncWrite for ServiceOptions with write(self: ServiceOptions, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for ServiceOptions with fn write(self: ServiceOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(274UL);
     writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
@@ -5230,13 +5230,13 @@ pub fn MethodOptions_IdempotencyLevel::from_enum(i : @lib.Enum) -> MethodOptions
     _ => Default::default()
   }
 }
-pub impl Default for MethodOptions_IdempotencyLevel with default() -> MethodOptions_IdempotencyLevel {
+pub impl Default for MethodOptions_IdempotencyLevel with fn default() -> MethodOptions_IdempotencyLevel {
   MethodOptions_IdempotencyLevel::IDEMPOTENCY_UNKNOWN
 }
-pub impl @lib.Sized for MethodOptions_IdempotencyLevel with size_of(self : MethodOptions_IdempotencyLevel) {
+pub impl @lib.Sized for MethodOptions_IdempotencyLevel with fn size_of(self : MethodOptions_IdempotencyLevel) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for MethodOptions_IdempotencyLevel with from_json(json: Json, path: @json.JsonPath) -> MethodOptions_IdempotencyLevel raise {
+pub impl @json.FromJson for MethodOptions_IdempotencyLevel with fn from_json(json: Json, path: @json.JsonPath) -> MethodOptions_IdempotencyLevel raise {
   match json {
     String("IDEMPOTENCY_UNKNOWN") => MethodOptions_IdempotencyLevel::IDEMPOTENCY_UNKNOWN
     String("NO_SIDE_EFFECTS") => MethodOptions_IdempotencyLevel::NO_SIDE_EFFECTS
@@ -5247,7 +5247,7 @@ pub impl @json.FromJson for MethodOptions_IdempotencyLevel with from_json(json: 
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for MethodOptions_IdempotencyLevel with to_json(self : MethodOptions_IdempotencyLevel) -> Json {
+pub impl ToJson for MethodOptions_IdempotencyLevel with fn to_json(self : MethodOptions_IdempotencyLevel) -> Json {
   match self {
     MethodOptions_IdempotencyLevel::IDEMPOTENCY_UNKNOWN => "IDEMPOTENCY_UNKNOWN"
     MethodOptions_IdempotencyLevel::NO_SIDE_EFFECTS => "NO_SIDE_EFFECTS"
@@ -5260,7 +5260,7 @@ pub(all) struct MethodOptions {
   mut features : FeatureSet?
   mut uninterpreted_option : Array[UninterpretedOption]
 } derive(Eq, Debug)
-pub impl @lib.Sized for MethodOptions with size_of(self) {
+pub impl @lib.Sized for MethodOptions with fn size_of(self) {
   let mut size = 0U
   if self.deprecated is Some(v) {
     size += 2U + @lib.size_of(v)
@@ -5277,7 +5277,7 @@ pub impl @lib.Sized for MethodOptions with size_of(self) {
   }
   size
 }
-pub impl Default for MethodOptions with default() -> MethodOptions {
+pub impl Default for MethodOptions with fn default() -> MethodOptions {
   MethodOptions::{
     deprecated : Some(false),
     idempotency_level : Some(MethodOptions_IdempotencyLevel::IDEMPOTENCY_UNKNOWN),
@@ -5293,7 +5293,7 @@ pub fn MethodOptions::new(deprecated? : Bool, idempotency_level? : MethodOptions
     uninterpreted_option,
   }
 }
-pub impl @lib.Read for MethodOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MethodOptions raise {
+pub impl @lib.Read for MethodOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MethodOptions raise {
   let msg = MethodOptions::default()
   try {
     for ;; {
@@ -5311,7 +5311,7 @@ pub impl @lib.Read for MethodOptions with read_with_limit(reader : @lib.LimitedR
   }
   msg
 }
-pub impl @lib.Write for MethodOptions with write(self: MethodOptions, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for MethodOptions with fn write(self: MethodOptions, writer : &@lib.Writer) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(264UL);
     writer |> @lib.write_bool(v)
@@ -5333,7 +5333,7 @@ pub impl @lib.Write for MethodOptions with write(self: MethodOptions, writer : &
 
   }
 }
-pub impl ToJson for MethodOptions with to_json(self) {
+pub impl ToJson for MethodOptions with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.deprecated {
       Some(v) if v != false => json["deprecated"] = v.to_json()
@@ -5352,7 +5352,7 @@ pub impl ToJson for MethodOptions with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for MethodOptions with from_json(json: Json, path: @json.JsonPath) -> MethodOptions raise {
+pub impl @json.FromJson for MethodOptions with fn from_json(json: Json, path: @json.JsonPath) -> MethodOptions raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for MethodOptions"))
   }
@@ -5364,12 +5364,12 @@ pub impl @json.FromJson for MethodOptions with from_json(json: Json, path: @json
       ("features", value) => message.features = Some(@json.from_json(value, path~))
       ("uninterpretedOption", Array(value)) => message.uninterpreted_option = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for MethodOptions with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MethodOptions raise {
+pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MethodOptions raise {
   let msg = MethodOptions::default()
   try {
     for ;; {
@@ -5387,7 +5387,7 @@ pub impl @lib.AsyncRead for MethodOptions with read_with_limit(reader : @lib.Lim
   }
   msg
 }
-pub impl @lib.AsyncWrite for MethodOptions with write(self: MethodOptions, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for MethodOptions with fn write(self: MethodOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(264UL);
     writer |> @lib.async_write_bool(v)
@@ -5413,13 +5413,13 @@ pub(all) struct UninterpretedOption_NamePart {
   mut name_part : String
   mut is_extension : Bool
 } derive(Eq, Debug)
-pub impl @lib.Sized for UninterpretedOption_NamePart with size_of(self) {
+pub impl @lib.Sized for UninterpretedOption_NamePart with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = @lib.size_of(self.name_part); @lib.size_of(size) + size }
   size += 1U + @lib.size_of(self.is_extension)
   size
 }
-pub impl Default for UninterpretedOption_NamePart with default() -> UninterpretedOption_NamePart {
+pub impl Default for UninterpretedOption_NamePart with fn default() -> UninterpretedOption_NamePart {
   UninterpretedOption_NamePart::{
     name_part : String::default(),
     is_extension : Bool::default(),
@@ -5431,7 +5431,7 @@ pub fn UninterpretedOption_NamePart::new(name_part : String, is_extension : Bool
     is_extension,
   }
 }
-pub impl @lib.Read for UninterpretedOption_NamePart with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> UninterpretedOption_NamePart raise {
+pub impl @lib.Read for UninterpretedOption_NamePart with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
   try {
     for ;; {
@@ -5447,13 +5447,13 @@ pub impl @lib.Read for UninterpretedOption_NamePart with read_with_limit(reader 
   }
   msg
 }
-pub impl @lib.Write for UninterpretedOption_NamePart with write(self: UninterpretedOption_NamePart, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for UninterpretedOption_NamePart with fn write(self: UninterpretedOption_NamePart, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.name_part)
   writer |> @lib.write_varint(16UL);
   writer |> @lib.write_bool(self.is_extension)
 }
-pub impl ToJson for UninterpretedOption_NamePart with to_json(self) {
+pub impl ToJson for UninterpretedOption_NamePart with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.name_part != Default::default() {
   json["namePart"] = self.name_part.to_json()
@@ -5463,7 +5463,7 @@ pub impl ToJson for UninterpretedOption_NamePart with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for UninterpretedOption_NamePart with from_json(json: Json, path: @json.JsonPath) -> UninterpretedOption_NamePart raise {
+pub impl @json.FromJson for UninterpretedOption_NamePart with fn from_json(json: Json, path: @json.JsonPath) -> UninterpretedOption_NamePart raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for UninterpretedOption_NamePart"))
   }
@@ -5472,12 +5472,12 @@ pub impl @json.FromJson for UninterpretedOption_NamePart with from_json(json: Js
     match (key, value) {
       ("namePart", value) => message.name_part = @json.from_json(value, path~)
       ("isExtension", value) => message.is_extension = @json.from_json(value, path~)
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for UninterpretedOption_NamePart with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> UninterpretedOption_NamePart raise {
+pub impl @lib.AsyncRead for UninterpretedOption_NamePart with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
   try {
     for ;; {
@@ -5493,7 +5493,7 @@ pub impl @lib.AsyncRead for UninterpretedOption_NamePart with read_with_limit(re
   }
   msg
 }
-pub impl @lib.AsyncWrite for UninterpretedOption_NamePart with write(self: UninterpretedOption_NamePart, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for UninterpretedOption_NamePart with fn write(self: UninterpretedOption_NamePart, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.name_part)
   writer |> @lib.async_write_varint(16UL);
@@ -5508,7 +5508,7 @@ pub(all) struct UninterpretedOption {
   mut string_value : Bytes?
   mut aggregate_value : String?
 } derive(Eq, Debug)
-pub impl @lib.Sized for UninterpretedOption with size_of(self) {
+pub impl @lib.Sized for UninterpretedOption with fn size_of(self) {
   let mut size = 0U
   for s in self.name {
     let s = @lib.size_of(s)
@@ -5534,7 +5534,7 @@ pub impl @lib.Sized for UninterpretedOption with size_of(self) {
   }
   size
 }
-pub impl Default for UninterpretedOption with default() -> UninterpretedOption {
+pub impl Default for UninterpretedOption with fn default() -> UninterpretedOption {
   UninterpretedOption::{
     name : [],
     identifier_value : None,
@@ -5556,7 +5556,7 @@ pub fn UninterpretedOption::new(name : Array[UninterpretedOption_NamePart], iden
     aggregate_value,
   }
 }
-pub impl @lib.Read for UninterpretedOption with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> UninterpretedOption raise {
+pub impl @lib.Read for UninterpretedOption with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
   try {
     for ;; {
@@ -5577,7 +5577,7 @@ pub impl @lib.Read for UninterpretedOption with read_with_limit(reader : @lib.Li
   }
   msg
 }
-pub impl @lib.Write for UninterpretedOption with write(self: UninterpretedOption, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for UninterpretedOption with fn write(self: UninterpretedOption, writer : &@lib.Writer) -> Unit raise {
   for item in self.name {
     writer |> @lib.write_varint(18UL)
     writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
@@ -5614,7 +5614,7 @@ pub impl @lib.Write for UninterpretedOption with write(self: UninterpretedOption
 
   }
 }
-pub impl ToJson for UninterpretedOption with to_json(self) {
+pub impl ToJson for UninterpretedOption with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.name != Default::default() {
   json["name"] = self.name.to_json()
@@ -5645,7 +5645,7 @@ pub impl ToJson for UninterpretedOption with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for UninterpretedOption with from_json(json: Json, path: @json.JsonPath) -> UninterpretedOption raise {
+pub impl @json.FromJson for UninterpretedOption with fn from_json(json: Json, path: @json.JsonPath) -> UninterpretedOption raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for UninterpretedOption"))
   }
@@ -5660,12 +5660,12 @@ pub impl @json.FromJson for UninterpretedOption with from_json(json: Json, path:
       ("doubleValue", value) => message.double_value = Some(@json.from_json(value, path~))
       ("stringValue", String(value)) => message.string_value = Some(@lib.base64_decode(value))
       ("aggregateValue", value) => message.aggregate_value = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for UninterpretedOption with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> UninterpretedOption raise {
+pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
   try {
     for ;; {
@@ -5686,7 +5686,7 @@ pub impl @lib.AsyncRead for UninterpretedOption with read_with_limit(reader : @l
   }
   msg
 }
-pub impl @lib.AsyncWrite for UninterpretedOption with write(self: UninterpretedOption, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for UninterpretedOption with fn write(self: UninterpretedOption, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.name {
     writer |> @lib.async_write_varint(18UL)
     writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
@@ -5746,13 +5746,13 @@ pub fn FeatureSet_FieldPresence::from_enum(i : @lib.Enum) -> FeatureSet_FieldPre
     _ => Default::default()
   }
 }
-pub impl Default for FeatureSet_FieldPresence with default() -> FeatureSet_FieldPresence {
+pub impl Default for FeatureSet_FieldPresence with fn default() -> FeatureSet_FieldPresence {
   FeatureSet_FieldPresence::FIELD_PRESENCE_UNKNOWN
 }
-pub impl @lib.Sized for FeatureSet_FieldPresence with size_of(self : FeatureSet_FieldPresence) {
+pub impl @lib.Sized for FeatureSet_FieldPresence with fn size_of(self : FeatureSet_FieldPresence) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FeatureSet_FieldPresence with from_json(json: Json, path: @json.JsonPath) -> FeatureSet_FieldPresence raise {
+pub impl @json.FromJson for FeatureSet_FieldPresence with fn from_json(json: Json, path: @json.JsonPath) -> FeatureSet_FieldPresence raise {
   match json {
     String("FIELD_PRESENCE_UNKNOWN") => FeatureSet_FieldPresence::FIELD_PRESENCE_UNKNOWN
     String("EXPLICIT") => FeatureSet_FieldPresence::EXPLICIT
@@ -5765,7 +5765,7 @@ pub impl @json.FromJson for FeatureSet_FieldPresence with from_json(json: Json, 
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FeatureSet_FieldPresence with to_json(self : FeatureSet_FieldPresence) -> Json {
+pub impl ToJson for FeatureSet_FieldPresence with fn to_json(self : FeatureSet_FieldPresence) -> Json {
   match self {
     FeatureSet_FieldPresence::FIELD_PRESENCE_UNKNOWN => "FIELD_PRESENCE_UNKNOWN"
     FeatureSet_FieldPresence::EXPLICIT => "EXPLICIT"
@@ -5793,13 +5793,13 @@ pub fn FeatureSet_EnumType::from_enum(i : @lib.Enum) -> FeatureSet_EnumType {
     _ => Default::default()
   }
 }
-pub impl Default for FeatureSet_EnumType with default() -> FeatureSet_EnumType {
+pub impl Default for FeatureSet_EnumType with fn default() -> FeatureSet_EnumType {
   FeatureSet_EnumType::ENUM_TYPE_UNKNOWN
 }
-pub impl @lib.Sized for FeatureSet_EnumType with size_of(self : FeatureSet_EnumType) {
+pub impl @lib.Sized for FeatureSet_EnumType with fn size_of(self : FeatureSet_EnumType) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FeatureSet_EnumType with from_json(json: Json, path: @json.JsonPath) -> FeatureSet_EnumType raise {
+pub impl @json.FromJson for FeatureSet_EnumType with fn from_json(json: Json, path: @json.JsonPath) -> FeatureSet_EnumType raise {
   match json {
     String("ENUM_TYPE_UNKNOWN") => FeatureSet_EnumType::ENUM_TYPE_UNKNOWN
     String("OPEN") => FeatureSet_EnumType::OPEN
@@ -5810,7 +5810,7 @@ pub impl @json.FromJson for FeatureSet_EnumType with from_json(json: Json, path:
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FeatureSet_EnumType with to_json(self : FeatureSet_EnumType) -> Json {
+pub impl ToJson for FeatureSet_EnumType with fn to_json(self : FeatureSet_EnumType) -> Json {
   match self {
     FeatureSet_EnumType::ENUM_TYPE_UNKNOWN => "ENUM_TYPE_UNKNOWN"
     FeatureSet_EnumType::OPEN => "OPEN"
@@ -5837,13 +5837,13 @@ pub fn FeatureSet_RepeatedFieldEncoding::from_enum(i : @lib.Enum) -> FeatureSet_
     _ => Default::default()
   }
 }
-pub impl Default for FeatureSet_RepeatedFieldEncoding with default() -> FeatureSet_RepeatedFieldEncoding {
+pub impl Default for FeatureSet_RepeatedFieldEncoding with fn default() -> FeatureSet_RepeatedFieldEncoding {
   FeatureSet_RepeatedFieldEncoding::REPEATED_FIELD_ENCODING_UNKNOWN
 }
-pub impl @lib.Sized for FeatureSet_RepeatedFieldEncoding with size_of(self : FeatureSet_RepeatedFieldEncoding) {
+pub impl @lib.Sized for FeatureSet_RepeatedFieldEncoding with fn size_of(self : FeatureSet_RepeatedFieldEncoding) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FeatureSet_RepeatedFieldEncoding with from_json(json: Json, path: @json.JsonPath) -> FeatureSet_RepeatedFieldEncoding raise {
+pub impl @json.FromJson for FeatureSet_RepeatedFieldEncoding with fn from_json(json: Json, path: @json.JsonPath) -> FeatureSet_RepeatedFieldEncoding raise {
   match json {
     String("REPEATED_FIELD_ENCODING_UNKNOWN") => FeatureSet_RepeatedFieldEncoding::REPEATED_FIELD_ENCODING_UNKNOWN
     String("PACKED") => FeatureSet_RepeatedFieldEncoding::PACKED
@@ -5854,7 +5854,7 @@ pub impl @json.FromJson for FeatureSet_RepeatedFieldEncoding with from_json(json
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FeatureSet_RepeatedFieldEncoding with to_json(self : FeatureSet_RepeatedFieldEncoding) -> Json {
+pub impl ToJson for FeatureSet_RepeatedFieldEncoding with fn to_json(self : FeatureSet_RepeatedFieldEncoding) -> Json {
   match self {
     FeatureSet_RepeatedFieldEncoding::REPEATED_FIELD_ENCODING_UNKNOWN => "REPEATED_FIELD_ENCODING_UNKNOWN"
     FeatureSet_RepeatedFieldEncoding::PACKED => "PACKED"
@@ -5881,13 +5881,13 @@ pub fn FeatureSet_Utf8Validation::from_enum(i : @lib.Enum) -> FeatureSet_Utf8Val
     _ => Default::default()
   }
 }
-pub impl Default for FeatureSet_Utf8Validation with default() -> FeatureSet_Utf8Validation {
+pub impl Default for FeatureSet_Utf8Validation with fn default() -> FeatureSet_Utf8Validation {
   FeatureSet_Utf8Validation::UTF8_VALIDATION_UNKNOWN
 }
-pub impl @lib.Sized for FeatureSet_Utf8Validation with size_of(self : FeatureSet_Utf8Validation) {
+pub impl @lib.Sized for FeatureSet_Utf8Validation with fn size_of(self : FeatureSet_Utf8Validation) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FeatureSet_Utf8Validation with from_json(json: Json, path: @json.JsonPath) -> FeatureSet_Utf8Validation raise {
+pub impl @json.FromJson for FeatureSet_Utf8Validation with fn from_json(json: Json, path: @json.JsonPath) -> FeatureSet_Utf8Validation raise {
   match json {
     String("UTF8_VALIDATION_UNKNOWN") => FeatureSet_Utf8Validation::UTF8_VALIDATION_UNKNOWN
     String("VERIFY") => FeatureSet_Utf8Validation::VERIFY
@@ -5898,7 +5898,7 @@ pub impl @json.FromJson for FeatureSet_Utf8Validation with from_json(json: Json,
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FeatureSet_Utf8Validation with to_json(self : FeatureSet_Utf8Validation) -> Json {
+pub impl ToJson for FeatureSet_Utf8Validation with fn to_json(self : FeatureSet_Utf8Validation) -> Json {
   match self {
     FeatureSet_Utf8Validation::UTF8_VALIDATION_UNKNOWN => "UTF8_VALIDATION_UNKNOWN"
     FeatureSet_Utf8Validation::VERIFY => "VERIFY"
@@ -5925,13 +5925,13 @@ pub fn FeatureSet_MessageEncoding::from_enum(i : @lib.Enum) -> FeatureSet_Messag
     _ => Default::default()
   }
 }
-pub impl Default for FeatureSet_MessageEncoding with default() -> FeatureSet_MessageEncoding {
+pub impl Default for FeatureSet_MessageEncoding with fn default() -> FeatureSet_MessageEncoding {
   FeatureSet_MessageEncoding::MESSAGE_ENCODING_UNKNOWN
 }
-pub impl @lib.Sized for FeatureSet_MessageEncoding with size_of(self : FeatureSet_MessageEncoding) {
+pub impl @lib.Sized for FeatureSet_MessageEncoding with fn size_of(self : FeatureSet_MessageEncoding) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FeatureSet_MessageEncoding with from_json(json: Json, path: @json.JsonPath) -> FeatureSet_MessageEncoding raise {
+pub impl @json.FromJson for FeatureSet_MessageEncoding with fn from_json(json: Json, path: @json.JsonPath) -> FeatureSet_MessageEncoding raise {
   match json {
     String("MESSAGE_ENCODING_UNKNOWN") => FeatureSet_MessageEncoding::MESSAGE_ENCODING_UNKNOWN
     String("LENGTH_PREFIXED") => FeatureSet_MessageEncoding::LENGTH_PREFIXED
@@ -5942,7 +5942,7 @@ pub impl @json.FromJson for FeatureSet_MessageEncoding with from_json(json: Json
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FeatureSet_MessageEncoding with to_json(self : FeatureSet_MessageEncoding) -> Json {
+pub impl ToJson for FeatureSet_MessageEncoding with fn to_json(self : FeatureSet_MessageEncoding) -> Json {
   match self {
     FeatureSet_MessageEncoding::MESSAGE_ENCODING_UNKNOWN => "MESSAGE_ENCODING_UNKNOWN"
     FeatureSet_MessageEncoding::LENGTH_PREFIXED => "LENGTH_PREFIXED"
@@ -5969,13 +5969,13 @@ pub fn FeatureSet_JsonFormat::from_enum(i : @lib.Enum) -> FeatureSet_JsonFormat 
     _ => Default::default()
   }
 }
-pub impl Default for FeatureSet_JsonFormat with default() -> FeatureSet_JsonFormat {
+pub impl Default for FeatureSet_JsonFormat with fn default() -> FeatureSet_JsonFormat {
   FeatureSet_JsonFormat::JSON_FORMAT_UNKNOWN
 }
-pub impl @lib.Sized for FeatureSet_JsonFormat with size_of(self : FeatureSet_JsonFormat) {
+pub impl @lib.Sized for FeatureSet_JsonFormat with fn size_of(self : FeatureSet_JsonFormat) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FeatureSet_JsonFormat with from_json(json: Json, path: @json.JsonPath) -> FeatureSet_JsonFormat raise {
+pub impl @json.FromJson for FeatureSet_JsonFormat with fn from_json(json: Json, path: @json.JsonPath) -> FeatureSet_JsonFormat raise {
   match json {
     String("JSON_FORMAT_UNKNOWN") => FeatureSet_JsonFormat::JSON_FORMAT_UNKNOWN
     String("ALLOW") => FeatureSet_JsonFormat::ALLOW
@@ -5986,7 +5986,7 @@ pub impl @json.FromJson for FeatureSet_JsonFormat with from_json(json: Json, pat
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FeatureSet_JsonFormat with to_json(self : FeatureSet_JsonFormat) -> Json {
+pub impl ToJson for FeatureSet_JsonFormat with fn to_json(self : FeatureSet_JsonFormat) -> Json {
   match self {
     FeatureSet_JsonFormat::JSON_FORMAT_UNKNOWN => "JSON_FORMAT_UNKNOWN"
     FeatureSet_JsonFormat::ALLOW => "ALLOW"
@@ -6013,13 +6013,13 @@ pub fn FeatureSet_EnforceNamingStyle::from_enum(i : @lib.Enum) -> FeatureSet_Enf
     _ => Default::default()
   }
 }
-pub impl Default for FeatureSet_EnforceNamingStyle with default() -> FeatureSet_EnforceNamingStyle {
+pub impl Default for FeatureSet_EnforceNamingStyle with fn default() -> FeatureSet_EnforceNamingStyle {
   FeatureSet_EnforceNamingStyle::ENFORCE_NAMING_STYLE_UNKNOWN
 }
-pub impl @lib.Sized for FeatureSet_EnforceNamingStyle with size_of(self : FeatureSet_EnforceNamingStyle) {
+pub impl @lib.Sized for FeatureSet_EnforceNamingStyle with fn size_of(self : FeatureSet_EnforceNamingStyle) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FeatureSet_EnforceNamingStyle with from_json(json: Json, path: @json.JsonPath) -> FeatureSet_EnforceNamingStyle raise {
+pub impl @json.FromJson for FeatureSet_EnforceNamingStyle with fn from_json(json: Json, path: @json.JsonPath) -> FeatureSet_EnforceNamingStyle raise {
   match json {
     String("ENFORCE_NAMING_STYLE_UNKNOWN") => FeatureSet_EnforceNamingStyle::ENFORCE_NAMING_STYLE_UNKNOWN
     String("STYLE2024") => FeatureSet_EnforceNamingStyle::STYLE2024
@@ -6030,7 +6030,7 @@ pub impl @json.FromJson for FeatureSet_EnforceNamingStyle with from_json(json: J
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FeatureSet_EnforceNamingStyle with to_json(self : FeatureSet_EnforceNamingStyle) -> Json {
+pub impl ToJson for FeatureSet_EnforceNamingStyle with fn to_json(self : FeatureSet_EnforceNamingStyle) -> Json {
   match self {
     FeatureSet_EnforceNamingStyle::ENFORCE_NAMING_STYLE_UNKNOWN => "ENFORCE_NAMING_STYLE_UNKNOWN"
     FeatureSet_EnforceNamingStyle::STYLE2024 => "STYLE2024"
@@ -6063,13 +6063,13 @@ pub fn FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum(i : @lib.
     _ => Default::default()
   }
 }
-pub impl Default for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with default() -> FeatureSet_VisibilityFeature_DefaultSymbolVisibility {
+pub impl Default for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with fn default() -> FeatureSet_VisibilityFeature_DefaultSymbolVisibility {
   FeatureSet_VisibilityFeature_DefaultSymbolVisibility::DEFAULT_SYMBOL_VISIBILITY_UNKNOWN
 }
-pub impl @lib.Sized for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with size_of(self : FeatureSet_VisibilityFeature_DefaultSymbolVisibility) {
+pub impl @lib.Sized for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with fn size_of(self : FeatureSet_VisibilityFeature_DefaultSymbolVisibility) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with from_json(json: Json, path: @json.JsonPath) -> FeatureSet_VisibilityFeature_DefaultSymbolVisibility raise {
+pub impl @json.FromJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with fn from_json(json: Json, path: @json.JsonPath) -> FeatureSet_VisibilityFeature_DefaultSymbolVisibility raise {
   match json {
     String("DEFAULT_SYMBOL_VISIBILITY_UNKNOWN") => FeatureSet_VisibilityFeature_DefaultSymbolVisibility::DEFAULT_SYMBOL_VISIBILITY_UNKNOWN
     String("EXPORT_ALL") => FeatureSet_VisibilityFeature_DefaultSymbolVisibility::EXPORT_ALL
@@ -6084,7 +6084,7 @@ pub impl @json.FromJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with to_json(self : FeatureSet_VisibilityFeature_DefaultSymbolVisibility) -> Json {
+pub impl ToJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with fn to_json(self : FeatureSet_VisibilityFeature_DefaultSymbolVisibility) -> Json {
   match self {
     FeatureSet_VisibilityFeature_DefaultSymbolVisibility::DEFAULT_SYMBOL_VISIBILITY_UNKNOWN => "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN"
     FeatureSet_VisibilityFeature_DefaultSymbolVisibility::EXPORT_ALL => "EXPORT_ALL"
@@ -6095,10 +6095,10 @@ pub impl ToJson for FeatureSet_VisibilityFeature_DefaultSymbolVisibility with to
 }
 pub(all) struct FeatureSet_VisibilityFeature {
 } derive(Eq, Debug)
-pub impl @lib.Sized for FeatureSet_VisibilityFeature with size_of(_) {
+pub impl @lib.Sized for FeatureSet_VisibilityFeature with fn size_of(_) {
   0
 }
-pub impl Default for FeatureSet_VisibilityFeature with default() -> FeatureSet_VisibilityFeature {
+pub impl Default for FeatureSet_VisibilityFeature with fn default() -> FeatureSet_VisibilityFeature {
   FeatureSet_VisibilityFeature::{
   }
 }
@@ -6106,21 +6106,21 @@ pub fn FeatureSet_VisibilityFeature::new() -> FeatureSet_VisibilityFeature {
   FeatureSet_VisibilityFeature::{
   }
 }
-pub impl @lib.Read for FeatureSet_VisibilityFeature with read_with_limit(_) -> FeatureSet_VisibilityFeature noraise {
+pub impl @lib.Read for FeatureSet_VisibilityFeature with fn read_with_limit(_) -> FeatureSet_VisibilityFeature noraise {
   FeatureSet_VisibilityFeature::default()
 }
-pub impl @lib.Write for FeatureSet_VisibilityFeature with write(_, _) -> Unit noraise {
+pub impl @lib.Write for FeatureSet_VisibilityFeature with fn write(_, _) -> Unit noraise {
 }
-pub impl ToJson for FeatureSet_VisibilityFeature with to_json(_) {
+pub impl ToJson for FeatureSet_VisibilityFeature with fn to_json(_) {
   {}
 }
-pub impl @json.FromJson for FeatureSet_VisibilityFeature with from_json(_, _) -> FeatureSet_VisibilityFeature noraise {
+pub impl @json.FromJson for FeatureSet_VisibilityFeature with fn from_json(_, _) -> FeatureSet_VisibilityFeature noraise {
   FeatureSet_VisibilityFeature::default()
 }
-pub impl @lib.AsyncRead for FeatureSet_VisibilityFeature with read_with_limit(_) -> FeatureSet_VisibilityFeature noraise {
+pub impl @lib.AsyncRead for FeatureSet_VisibilityFeature with fn read_with_limit(_) -> FeatureSet_VisibilityFeature noraise {
   FeatureSet_VisibilityFeature::default()
 }
-pub impl @lib.AsyncWrite for FeatureSet_VisibilityFeature with write(_, _) -> Unit noraise {
+pub impl @lib.AsyncWrite for FeatureSet_VisibilityFeature with fn write(_, _) -> Unit noraise {
 }
 pub(all) struct FeatureSet {
   mut field_presence : FeatureSet_FieldPresence?
@@ -6132,7 +6132,7 @@ pub(all) struct FeatureSet {
   mut enforce_naming_style : FeatureSet_EnforceNamingStyle?
   mut default_symbol_visibility : FeatureSet_VisibilityFeature_DefaultSymbolVisibility?
 } derive(Eq, Debug)
-pub impl @lib.Sized for FeatureSet with size_of(self) {
+pub impl @lib.Sized for FeatureSet with fn size_of(self) {
   let mut size = 0U
   if self.field_presence is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -6160,7 +6160,7 @@ pub impl @lib.Sized for FeatureSet with size_of(self) {
   }
   size
 }
-pub impl Default for FeatureSet with default() -> FeatureSet {
+pub impl Default for FeatureSet with fn default() -> FeatureSet {
   FeatureSet::{
     field_presence : None,
     enum_type : None,
@@ -6184,7 +6184,7 @@ pub fn FeatureSet::new(field_presence? : FeatureSet_FieldPresence, enum_type? : 
     default_symbol_visibility,
   }
 }
-pub impl @lib.Read for FeatureSet with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSet raise {
+pub impl @lib.Read for FeatureSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSet raise {
   let msg = FeatureSet::default()
   try {
     for ;; {
@@ -6206,7 +6206,7 @@ pub impl @lib.Read for FeatureSet with read_with_limit(reader : @lib.LimitedRead
   }
   msg
 }
-pub impl @lib.Write for FeatureSet with write(self: FeatureSet, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FeatureSet with fn write(self: FeatureSet, writer : &@lib.Writer) -> Unit raise {
   if self.field_presence is Some(v) {
     writer |> @lib.write_varint(8UL);
     writer |> @lib.write_enum(v.to_enum())
@@ -6248,7 +6248,7 @@ pub impl @lib.Write for FeatureSet with write(self: FeatureSet, writer : &@lib.W
 
   }
 }
-pub impl ToJson for FeatureSet with to_json(self) {
+pub impl ToJson for FeatureSet with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.field_presence {
       Some(v) => json["fieldPresence"] = v.to_json()
@@ -6284,7 +6284,7 @@ pub impl ToJson for FeatureSet with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for FeatureSet with from_json(json: Json, path: @json.JsonPath) -> FeatureSet raise {
+pub impl @json.FromJson for FeatureSet with fn from_json(json: Json, path: @json.JsonPath) -> FeatureSet raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FeatureSet"))
   }
@@ -6299,12 +6299,12 @@ pub impl @json.FromJson for FeatureSet with from_json(json: Json, path: @json.Js
       ("jsonFormat", value) => message.json_format = Some(@json.from_json(value, path~))
       ("enforceNamingStyle", value) => message.enforce_naming_style = Some(@json.from_json(value, path~))
       ("defaultSymbolVisibility", value) => message.default_symbol_visibility = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FeatureSet with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSet raise {
+pub impl @lib.AsyncRead for FeatureSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSet raise {
   let msg = FeatureSet::default()
   try {
     for ;; {
@@ -6326,7 +6326,7 @@ pub impl @lib.AsyncRead for FeatureSet with read_with_limit(reader : @lib.Limite
   }
   msg
 }
-pub impl @lib.AsyncWrite for FeatureSet with write(self: FeatureSet, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FeatureSet with fn write(self: FeatureSet, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.field_presence is Some(v) {
     writer |> @lib.async_write_varint(8UL);
     writer |> @lib.async_write_enum(v.to_enum())
@@ -6373,7 +6373,7 @@ pub(all) struct FeatureSetDefaults_FeatureSetEditionDefault {
   mut overridable_features : FeatureSet?
   mut fixed_features : FeatureSet?
 } derive(Eq, Debug)
-pub impl @lib.Sized for FeatureSetDefaults_FeatureSetEditionDefault with size_of(self) {
+pub impl @lib.Sized for FeatureSetDefaults_FeatureSetEditionDefault with fn size_of(self) {
   let mut size = 0U
   if self.edition is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -6386,7 +6386,7 @@ pub impl @lib.Sized for FeatureSetDefaults_FeatureSetEditionDefault with size_of
   }
   size
 }
-pub impl Default for FeatureSetDefaults_FeatureSetEditionDefault with default() -> FeatureSetDefaults_FeatureSetEditionDefault {
+pub impl Default for FeatureSetDefaults_FeatureSetEditionDefault with fn default() -> FeatureSetDefaults_FeatureSetEditionDefault {
   FeatureSetDefaults_FeatureSetEditionDefault::{
     edition : None,
     overridable_features : None,
@@ -6400,7 +6400,7 @@ pub fn FeatureSetDefaults_FeatureSetEditionDefault::new(edition? : Edition, over
     fixed_features,
   }
 }
-pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
+pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
   try {
     for ;; {
@@ -6417,7 +6417,7 @@ pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with read_wit
   }
   msg
 }
-pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with fn write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.Writer) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.write_varint(24UL);
     writer |> @lib.write_enum(v.to_enum())
@@ -6434,7 +6434,7 @@ pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with write(s
 
   }
 }
-pub impl ToJson for FeatureSetDefaults_FeatureSetEditionDefault with to_json(self) {
+pub impl ToJson for FeatureSetDefaults_FeatureSetEditionDefault with fn to_json(self) {
   let json: Map[String, Json] = {}
   match self.edition {
       Some(v) => json["edition"] = v.to_json()
@@ -6450,7 +6450,7 @@ pub impl ToJson for FeatureSetDefaults_FeatureSetEditionDefault with to_json(sel
     }
   Json::object(json)
 }
-pub impl @json.FromJson for FeatureSetDefaults_FeatureSetEditionDefault with from_json(json: Json, path: @json.JsonPath) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
+pub impl @json.FromJson for FeatureSetDefaults_FeatureSetEditionDefault with fn from_json(json: Json, path: @json.JsonPath) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FeatureSetDefaults_FeatureSetEditionDefault"))
   }
@@ -6460,12 +6460,12 @@ pub impl @json.FromJson for FeatureSetDefaults_FeatureSetEditionDefault with fro
       ("edition", value) => message.edition = Some(@json.from_json(value, path~))
       ("overridableFeatures", value) => message.overridable_features = Some(@json.from_json(value, path~))
       ("fixedFeatures", value) => message.fixed_features = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
+pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
   try {
     for ;; {
@@ -6482,7 +6482,7 @@ pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with rea
   }
   msg
 }
-pub impl @lib.AsyncWrite for FeatureSetDefaults_FeatureSetEditionDefault with write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FeatureSetDefaults_FeatureSetEditionDefault with fn write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.async_write_varint(24UL);
     writer |> @lib.async_write_enum(v.to_enum())
@@ -6504,7 +6504,7 @@ pub(all) struct FeatureSetDefaults {
   mut minimum_edition : Edition?
   mut maximum_edition : Edition?
 } derive(Eq, Debug)
-pub impl @lib.Sized for FeatureSetDefaults with size_of(self) {
+pub impl @lib.Sized for FeatureSetDefaults with fn size_of(self) {
   let mut size = 0U
   for s in self.defaults {
     let s = @lib.size_of(s)
@@ -6518,7 +6518,7 @@ pub impl @lib.Sized for FeatureSetDefaults with size_of(self) {
   }
   size
 }
-pub impl Default for FeatureSetDefaults with default() -> FeatureSetDefaults {
+pub impl Default for FeatureSetDefaults with fn default() -> FeatureSetDefaults {
   FeatureSetDefaults::{
     defaults : [],
     minimum_edition : None,
@@ -6532,7 +6532,7 @@ pub fn FeatureSetDefaults::new(defaults : Array[FeatureSetDefaults_FeatureSetEdi
     maximum_edition,
   }
 }
-pub impl @lib.Read for FeatureSetDefaults with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSetDefaults raise {
+pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
   try {
     for ;; {
@@ -6549,7 +6549,7 @@ pub impl @lib.Read for FeatureSetDefaults with read_with_limit(reader : @lib.Lim
   }
   msg
 }
-pub impl @lib.Write for FeatureSetDefaults with write(self: FeatureSetDefaults, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for FeatureSetDefaults with fn write(self: FeatureSetDefaults, writer : &@lib.Writer) -> Unit raise {
   for item in self.defaults {
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
@@ -6566,7 +6566,7 @@ pub impl @lib.Write for FeatureSetDefaults with write(self: FeatureSetDefaults, 
 
   }
 }
-pub impl ToJson for FeatureSetDefaults with to_json(self) {
+pub impl ToJson for FeatureSetDefaults with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.defaults != Default::default() {
   json["defaults"] = self.defaults.to_json()
@@ -6581,7 +6581,7 @@ pub impl ToJson for FeatureSetDefaults with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for FeatureSetDefaults with from_json(json: Json, path: @json.JsonPath) -> FeatureSetDefaults raise {
+pub impl @json.FromJson for FeatureSetDefaults with fn from_json(json: Json, path: @json.JsonPath) -> FeatureSetDefaults raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for FeatureSetDefaults"))
   }
@@ -6592,12 +6592,12 @@ pub impl @json.FromJson for FeatureSetDefaults with from_json(json: Json, path: 
 @json.from_json(v, path~))
       ("minimumEdition", value) => message.minimum_edition = Some(@json.from_json(value, path~))
       ("maximumEdition", value) => message.maximum_edition = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for FeatureSetDefaults with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSetDefaults raise {
+pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
   try {
     for ;; {
@@ -6614,7 +6614,7 @@ pub impl @lib.AsyncRead for FeatureSetDefaults with read_with_limit(reader : @li
   }
   msg
 }
-pub impl @lib.AsyncWrite for FeatureSetDefaults with write(self: FeatureSetDefaults, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for FeatureSetDefaults with fn write(self: FeatureSetDefaults, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.defaults {
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
@@ -6638,7 +6638,7 @@ pub(all) struct SourceCodeInfo_Location {
   mut trailing_comments : String?
   mut leading_detached_comments : Array[String]
 } derive(Eq, Debug)
-pub impl @lib.Sized for SourceCodeInfo_Location with size_of(self) {
+pub impl @lib.Sized for SourceCodeInfo_Location with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
   size += 1U + { let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
@@ -6654,7 +6654,7 @@ pub impl @lib.Sized for SourceCodeInfo_Location with size_of(self) {
   }
   size
 }
-pub impl Default for SourceCodeInfo_Location with default() -> SourceCodeInfo_Location {
+pub impl Default for SourceCodeInfo_Location with fn default() -> SourceCodeInfo_Location {
   SourceCodeInfo_Location::{
     path : [],
     span : [],
@@ -6672,7 +6672,7 @@ pub fn SourceCodeInfo_Location::new(path : Array[Int], span : Array[Int], leadin
     leading_detached_comments,
   }
 }
-pub impl @lib.Read for SourceCodeInfo_Location with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> SourceCodeInfo_Location raise {
+pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
   try {
     for ;; {
@@ -6693,7 +6693,7 @@ pub impl @lib.Read for SourceCodeInfo_Location with read_with_limit(reader : @li
   }
   msg
 }
-pub impl @lib.Write for SourceCodeInfo_Location with write(self: SourceCodeInfo_Location, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for SourceCodeInfo_Location with fn write(self: SourceCodeInfo_Location, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL)
   let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
   writer |> @lib.write_uint32(size)
@@ -6724,7 +6724,7 @@ pub impl @lib.Write for SourceCodeInfo_Location with write(self: SourceCodeInfo_
 
   }
 }
-pub impl ToJson for SourceCodeInfo_Location with to_json(self) {
+pub impl ToJson for SourceCodeInfo_Location with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.path != Default::default() {
   json["path"] = self.path.to_json()
@@ -6745,7 +6745,7 @@ pub impl ToJson for SourceCodeInfo_Location with to_json(self) {
   }
   Json::object(json)
 }
-pub impl @json.FromJson for SourceCodeInfo_Location with from_json(json: Json, path: @json.JsonPath) -> SourceCodeInfo_Location raise {
+pub impl @json.FromJson for SourceCodeInfo_Location with fn from_json(json: Json, path: @json.JsonPath) -> SourceCodeInfo_Location raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for SourceCodeInfo_Location"))
   }
@@ -6760,12 +6760,12 @@ pub impl @json.FromJson for SourceCodeInfo_Location with from_json(json: Json, p
       ("trailingComments", value) => message.trailing_comments = Some(@json.from_json(value, path~))
       ("leadingDetachedComments", Array(value)) => message.leading_detached_comments = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for SourceCodeInfo_Location with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> SourceCodeInfo_Location raise {
+pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
   try {
     for ;; {
@@ -6786,7 +6786,7 @@ pub impl @lib.AsyncRead for SourceCodeInfo_Location with read_with_limit(reader 
   }
   msg
 }
-pub impl @lib.AsyncWrite for SourceCodeInfo_Location with write(self: SourceCodeInfo_Location, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for SourceCodeInfo_Location with fn write(self: SourceCodeInfo_Location, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL)
   let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
   writer |> @lib.async_write_uint32(size)
@@ -6820,7 +6820,7 @@ pub impl @lib.AsyncWrite for SourceCodeInfo_Location with write(self: SourceCode
 pub(all) struct SourceCodeInfo {
   mut location : Array[SourceCodeInfo_Location]
 } derive(Eq, Debug)
-pub impl @lib.Sized for SourceCodeInfo with size_of(self) {
+pub impl @lib.Sized for SourceCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.location {
     let s = @lib.size_of(s)
@@ -6828,7 +6828,7 @@ pub impl @lib.Sized for SourceCodeInfo with size_of(self) {
   }
   size
 }
-pub impl Default for SourceCodeInfo with default() -> SourceCodeInfo {
+pub impl Default for SourceCodeInfo with fn default() -> SourceCodeInfo {
   SourceCodeInfo::{
     location : [],
   }
@@ -6838,7 +6838,7 @@ pub fn SourceCodeInfo::new(location : Array[SourceCodeInfo_Location]) -> SourceC
     location,
   }
 }
-pub impl @lib.Read for SourceCodeInfo with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> SourceCodeInfo raise {
+pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
   try {
     for ;; {
@@ -6853,21 +6853,21 @@ pub impl @lib.Read for SourceCodeInfo with read_with_limit(reader : @lib.Limited
   }
   msg
 }
-pub impl @lib.Write for SourceCodeInfo with write(self: SourceCodeInfo, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for SourceCodeInfo with fn write(self: SourceCodeInfo, writer : &@lib.Writer) -> Unit raise {
   for item in self.location {
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
 
   }
 }
-pub impl ToJson for SourceCodeInfo with to_json(self) {
+pub impl ToJson for SourceCodeInfo with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.location != Default::default() {
   json["location"] = self.location.to_json()
   }
   Json::object(json)
 }
-pub impl @json.FromJson for SourceCodeInfo with from_json(json: Json, path: @json.JsonPath) -> SourceCodeInfo raise {
+pub impl @json.FromJson for SourceCodeInfo with fn from_json(json: Json, path: @json.JsonPath) -> SourceCodeInfo raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for SourceCodeInfo"))
   }
@@ -6876,12 +6876,12 @@ pub impl @json.FromJson for SourceCodeInfo with from_json(json: Json, path: @jso
     match (key, value) {
       ("location", Array(value)) => message.location = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for SourceCodeInfo with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> SourceCodeInfo raise {
+pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
   try {
     for ;; {
@@ -6896,7 +6896,7 @@ pub impl @lib.AsyncRead for SourceCodeInfo with read_with_limit(reader : @lib.Li
   }
   msg
 }
-pub impl @lib.AsyncWrite for SourceCodeInfo with write(self: SourceCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for SourceCodeInfo with fn write(self: SourceCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.location {
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
@@ -6923,13 +6923,13 @@ pub fn GeneratedCodeInfo_Annotation_Semantic::from_enum(i : @lib.Enum) -> Genera
     _ => Default::default()
   }
 }
-pub impl Default for GeneratedCodeInfo_Annotation_Semantic with default() -> GeneratedCodeInfo_Annotation_Semantic {
+pub impl Default for GeneratedCodeInfo_Annotation_Semantic with fn default() -> GeneratedCodeInfo_Annotation_Semantic {
   GeneratedCodeInfo_Annotation_Semantic::NONE
 }
-pub impl @lib.Sized for GeneratedCodeInfo_Annotation_Semantic with size_of(self : GeneratedCodeInfo_Annotation_Semantic) {
+pub impl @lib.Sized for GeneratedCodeInfo_Annotation_Semantic with fn size_of(self : GeneratedCodeInfo_Annotation_Semantic) {
   @lib.Sized::size_of(self.to_enum())
 }
-pub impl @json.FromJson for GeneratedCodeInfo_Annotation_Semantic with from_json(json: Json, path: @json.JsonPath) -> GeneratedCodeInfo_Annotation_Semantic raise {
+pub impl @json.FromJson for GeneratedCodeInfo_Annotation_Semantic with fn from_json(json: Json, path: @json.JsonPath) -> GeneratedCodeInfo_Annotation_Semantic raise {
   match json {
     String("NONE") => GeneratedCodeInfo_Annotation_Semantic::NONE
     String("SET") => GeneratedCodeInfo_Annotation_Semantic::SET
@@ -6940,7 +6940,7 @@ pub impl @json.FromJson for GeneratedCodeInfo_Annotation_Semantic with from_json
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
-pub impl ToJson for GeneratedCodeInfo_Annotation_Semantic with to_json(self : GeneratedCodeInfo_Annotation_Semantic) -> Json {
+pub impl ToJson for GeneratedCodeInfo_Annotation_Semantic with fn to_json(self : GeneratedCodeInfo_Annotation_Semantic) -> Json {
   match self {
     GeneratedCodeInfo_Annotation_Semantic::NONE => "NONE"
     GeneratedCodeInfo_Annotation_Semantic::SET => "SET"
@@ -6954,7 +6954,7 @@ pub(all) struct GeneratedCodeInfo_Annotation {
   mut end : Int?
   mut semantic : GeneratedCodeInfo_Annotation_Semantic?
 } derive(Eq, Debug)
-pub impl @lib.Sized for GeneratedCodeInfo_Annotation with size_of(self) {
+pub impl @lib.Sized for GeneratedCodeInfo_Annotation with fn size_of(self) {
   let mut size = 0U
   size += 1U + { let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
   if self.source_file is Some(v) {
@@ -6971,7 +6971,7 @@ pub impl @lib.Sized for GeneratedCodeInfo_Annotation with size_of(self) {
   }
   size
 }
-pub impl Default for GeneratedCodeInfo_Annotation with default() -> GeneratedCodeInfo_Annotation {
+pub impl Default for GeneratedCodeInfo_Annotation with fn default() -> GeneratedCodeInfo_Annotation {
   GeneratedCodeInfo_Annotation::{
     path : [],
     source_file : None,
@@ -6989,7 +6989,7 @@ pub fn GeneratedCodeInfo_Annotation::new(path : Array[Int], source_file? : Strin
     semantic,
   }
 }
-pub impl @lib.Read for GeneratedCodeInfo_Annotation with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GeneratedCodeInfo_Annotation raise {
+pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
   try {
     for ;; {
@@ -7009,7 +7009,7 @@ pub impl @lib.Read for GeneratedCodeInfo_Annotation with read_with_limit(reader 
   }
   msg
 }
-pub impl @lib.Write for GeneratedCodeInfo_Annotation with write(self: GeneratedCodeInfo_Annotation, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for GeneratedCodeInfo_Annotation with fn write(self: GeneratedCodeInfo_Annotation, writer : &@lib.Writer) -> Unit raise {
   writer |> @lib.write_varint(10UL)
   let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
   writer |> @lib.write_uint32(size)
@@ -7038,7 +7038,7 @@ pub impl @lib.Write for GeneratedCodeInfo_Annotation with write(self: GeneratedC
 
   }
 }
-pub impl ToJson for GeneratedCodeInfo_Annotation with to_json(self) {
+pub impl ToJson for GeneratedCodeInfo_Annotation with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.path != Default::default() {
   json["path"] = self.path.to_json()
@@ -7061,7 +7061,7 @@ pub impl ToJson for GeneratedCodeInfo_Annotation with to_json(self) {
     }
   Json::object(json)
 }
-pub impl @json.FromJson for GeneratedCodeInfo_Annotation with from_json(json: Json, path: @json.JsonPath) -> GeneratedCodeInfo_Annotation raise {
+pub impl @json.FromJson for GeneratedCodeInfo_Annotation with fn from_json(json: Json, path: @json.JsonPath) -> GeneratedCodeInfo_Annotation raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for GeneratedCodeInfo_Annotation"))
   }
@@ -7074,12 +7074,12 @@ pub impl @json.FromJson for GeneratedCodeInfo_Annotation with from_json(json: Js
       ("begin", value) => message.begin = Some(@json.from_json(value, path~))
       ("end", value) => message.end = Some(@json.from_json(value, path~))
       ("semantic", value) => message.semantic = Some(@json.from_json(value, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GeneratedCodeInfo_Annotation raise {
+pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
   try {
     for ;; {
@@ -7099,7 +7099,7 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with read_with_limit(re
   }
   msg
 }
-pub impl @lib.AsyncWrite for GeneratedCodeInfo_Annotation with write(self: GeneratedCodeInfo_Annotation, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for GeneratedCodeInfo_Annotation with fn write(self: GeneratedCodeInfo_Annotation, writer : &@lib.AsyncWriter) -> Unit raise {
   writer |> @lib.async_write_varint(10UL)
   let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
   writer |> @lib.async_write_uint32(size)
@@ -7131,7 +7131,7 @@ pub impl @lib.AsyncWrite for GeneratedCodeInfo_Annotation with write(self: Gener
 pub(all) struct GeneratedCodeInfo {
   mut annotation : Array[GeneratedCodeInfo_Annotation]
 } derive(Eq, Debug)
-pub impl @lib.Sized for GeneratedCodeInfo with size_of(self) {
+pub impl @lib.Sized for GeneratedCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.annotation {
     let s = @lib.size_of(s)
@@ -7139,7 +7139,7 @@ pub impl @lib.Sized for GeneratedCodeInfo with size_of(self) {
   }
   size
 }
-pub impl Default for GeneratedCodeInfo with default() -> GeneratedCodeInfo {
+pub impl Default for GeneratedCodeInfo with fn default() -> GeneratedCodeInfo {
   GeneratedCodeInfo::{
     annotation : [],
   }
@@ -7149,7 +7149,7 @@ pub fn GeneratedCodeInfo::new(annotation : Array[GeneratedCodeInfo_Annotation]) 
     annotation,
   }
 }
-pub impl @lib.Read for GeneratedCodeInfo with read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GeneratedCodeInfo raise {
+pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
   try {
     for ;; {
@@ -7164,21 +7164,21 @@ pub impl @lib.Read for GeneratedCodeInfo with read_with_limit(reader : @lib.Limi
   }
   msg
 }
-pub impl @lib.Write for GeneratedCodeInfo with write(self: GeneratedCodeInfo, writer : &@lib.Writer) -> Unit raise {
+pub impl @lib.Write for GeneratedCodeInfo with fn write(self: GeneratedCodeInfo, writer : &@lib.Writer) -> Unit raise {
   for item in self.annotation {
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
 
   }
 }
-pub impl ToJson for GeneratedCodeInfo with to_json(self) {
+pub impl ToJson for GeneratedCodeInfo with fn to_json(self) {
   let json: Map[String, Json] = {}
   if self.annotation != Default::default() {
   json["annotation"] = self.annotation.to_json()
   }
   Json::object(json)
 }
-pub impl @json.FromJson for GeneratedCodeInfo with from_json(json: Json, path: @json.JsonPath) -> GeneratedCodeInfo raise {
+pub impl @json.FromJson for GeneratedCodeInfo with fn from_json(json: Json, path: @json.JsonPath) -> GeneratedCodeInfo raise {
   guard json is Object(obj) else {
     raise @json.JsonDecodeError((path, "Expected an object for GeneratedCodeInfo"))
   }
@@ -7187,12 +7187,12 @@ pub impl @json.FromJson for GeneratedCodeInfo with from_json(json: Json, path: @
     match (key, value) {
       ("annotation", Array(value)) => message.annotation = value.map(v => 
 @json.from_json(v, path~))
-      key => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
+      (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
   message
 }
-pub impl @lib.AsyncRead for GeneratedCodeInfo with read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GeneratedCodeInfo raise {
+pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
   try {
     for ;; {
@@ -7207,7 +7207,7 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo with read_with_limit(reader : @lib
   }
   msg
 }
-pub impl @lib.AsyncWrite for GeneratedCodeInfo with write(self: GeneratedCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {
+pub impl @lib.AsyncWrite for GeneratedCodeInfo with fn write(self: GeneratedCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.annotation {
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)


### PR DESCRIPTION
## Summary
- enforce warning-free MoonBit checks in CI with `--deny-warn` and required `moon fmt` / `moon info` no-diff lint steps
- update hand-authored source/templates/tests to avoid deprecated MoonBit APIs and emit `with fn ...` in generated code
- add `emit_package_files=false` for regenerating plugin code inside the existing plugin module, so `generate-plugin` no longer rewrites tracked package metadata or creates `plugin/moon.mod.json`
- regenerate plugin, reader, codec, interface, and snapshot outputs from the updated sources

## Commit structure
- `9dd9442 chore: enforce warning-free MoonBit checks`: hand-authored CI/source/template/script/manifest changes
- `f658ff0 chore: regenerate MoonBit outputs`: generated outputs only (`pkg.generated.mbti`, codec generated tests, plugin generated code, reader generated code, snapshots)

## Tests
- `moon check lib/ lib/test/ --target all --deny-warn`
- `moon -C plugin check --target native --deny-warn`
- `moon -C cli check --target native --deny-warn`
- `moon test lib/ lib/test/ --target all --deny-warn`
- `moon -C plugin test --target native --deny-warn`
- `moon test cli --target native --deny-warn`
- `python3 scripts/workflow.py generate-plugin`
- `python3 scripts/workflow.py reader-test --include-path /opt/homebrew/include --update`
- `python3 scripts/workflow.py snapshot-test --include-path /opt/homebrew/include`
- `python3 -m py_compile scripts/workflow.py scripts/gen_codec_tests.py`
- `git diff --check`
- module lint clean-tree check: `moon -C lib|plugin|cli fmt/info` followed by `git diff --exit-code`