### PR TITLE
ci: update registry before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
       - name: moon version 
         run: |
           moon version --all
+          moon update
       - name: moon check
         run: |
           moon -C lib check --target all


### PR DESCRIPTION
## Summary
- run `moon update` in the release publish workflow before checking and publishing the library

## Why
The v0.1.2 release triggered publish, but `moon -C lib check --target all` failed before publishing because the workflow had not updated the registry and could not resolve `moonbitlang/async`.

## Tests
- `git diff --check`