### PR TITLE
ci: restrict publish checks to library packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,11 @@ jobs:
           moon update
       - name: moon check
         run: |
-          moon -C lib check --target all
+          moon check lib/ lib/test/ --target all --deny-warn
 
       - name: moon test (lib)
         run: |
-          moon -C lib test --target all
+          moon test lib/ lib/test/ --target all --deny-warn
 
       - name: lint (lib)
         run: |


### PR DESCRIPTION
## Summary
- run the publish workflow check/test steps against lib/ and lib/test/ instead of moon -C lib
- keep --deny-warn on those publish checks so publishing uses the same strict library gate as CI

## Why
The recreated v0.1.2 publish run resolved registry dependencies after PR #107, but then moon -C lib check --target all checked the workspace CLI on Wasm and failed on async stdio APIs. The publish workflow only needs to validate and publish the library package.

## Tests
- git diff --check