### PR TITLE
fix: add generated-code harness and edition semantics

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,8 @@
+# Context
+
+## Domain Terms
+
+- **Generator**: the MoonBit protoc plugin that turns protobuf descriptors into MoonBit packages.
+- **Runtime**: the MoonBit protobuf library used by generated code for read, write, size, and JSON behavior.
+- **Generated-code harness**: a test workflow that builds the Generator, generates MoonBit code from focused proto fixtures, and verifies the generated code through its public Runtime interfaces.
+- **Harness case**: a self-contained Generated-code harness input with proto fixtures, a runner test, and `case.toml` metadata.

--- a/cli/generator.mbt
+++ b/cli/generator.mbt
@@ -138,6 +138,19 @@ fn CodeGenerator::new(
 }
 
 ///|
+fn set_code_generator_capabilities(
+  response : @compiler.CodeGeneratorResponse,
+) -> Unit {
+  response.supported_features = Some(3)
+  response.minimum_edition = Some(
+    @protobuf.Edition::EDITION_2023.to_enum().0.reinterpret_as_int(),
+  )
+  response.maximum_edition = Some(
+    @protobuf.Edition::EDITION_2024.to_enum().0.reinterpret_as_int(),
+  )
+}
+
+///|
 fn CodeGenerator::qualified_name(
   self : CodeGenerator,
   path : ImportPath,
@@ -180,13 +193,7 @@ pub fn CodeGenerator::generate(
     for file in self.generated_files {
       self.response.file.push(file)
     }
-    self.response.supported_features = Some(1)
-    self.response.minimum_edition = Some(
-      @protobuf.Edition::EDITION_UNKNOWN.to_enum().0.reinterpret_as_int(),
-    )
-    self.response.maximum_edition = Some(
-      @protobuf.Edition::EDITION_MAX.to_enum().0.reinterpret_as_int(),
-    )
+    set_code_generator_capabilities(self.response)
   } catch {
     err => self.response.error = Some("Error generating code: \{err}")
   }

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -37,13 +37,7 @@ async fn parse_request() -> @compiler.CodeGeneratorResponse noraise {
   let request = @lib.AsyncRead::read(reader) catch {
     err => {
       let response = @compiler.CodeGeneratorResponse::default()
-      response.supported_features = Some(1)
-      response.minimum_edition = Some(
-        @protobuf.Edition::EDITION_UNKNOWN.to_enum().0.reinterpret_as_int(),
-      )
-      response.maximum_edition = Some(
-        @protobuf.Edition::EDITION_MAX.to_enum().0.reinterpret_as_int(),
-      )
+      set_code_generator_capabilities(response)
       response.error = Some("Error reading CodeGeneratorRequest: \{err}")
       return response
     }

--- a/cli/message_template.mbt
+++ b/cli/message_template.mbt
@@ -33,11 +33,12 @@ fn CodeGenerator::get_moonbit_type(
     FieldDescriptorProto_Type::TYPE_ENUM => {
       let enum_name = field.type_name.unwrap()
       if self.find_enum(enum_name) is Some(enum_) {
-        let path = enum_.import_path
-        if parent_path is Some(path) && path.package_name != path.package_name {
-          return "@\{self.qualified_name(path)}.\{path.path() |> to_camel_case}"
+        let enum_path = enum_.import_path
+        if parent_path is Some(parent_path) &&
+          parent_path.package_name != enum_path.package_name {
+          return "@\{self.qualified_name(enum_path)}.\{enum_path.path() |> to_camel_case}"
         }
-        return path.path() |> to_camel_case
+        return enum_path.path() |> to_camel_case
       }
       raise UnsupportedType("Enum \{enum_name} not found")
     }

--- a/cli/size_template.mbt
+++ b/cli/size_template.mbt
@@ -1,4 +1,34 @@
 ///|
+fn gen_unpacked_value_size_expr(
+  typ : FieldDescriptorProto_Type,
+  value_expr : String,
+  tag_size : Int,
+) -> (String, Bool) {
+  match typ {
+    FieldDescriptorProto_Type::TYPE_STRING
+    | FieldDescriptorProto_Type::TYPE_BYTES
+    | FieldDescriptorProto_Type::TYPE_MESSAGE =>
+      (
+        "\{tag_size}U + { let size = @lib.size_of(\{value_expr}); @lib.size_of(size) + size }",
+        true,
+      )
+    FieldDescriptorProto_Type::TYPE_FIXED32
+    | FieldDescriptorProto_Type::TYPE_SFIXED32
+    | FieldDescriptorProto_Type::TYPE_FLOAT => {
+      let fixed_size = sizeFixed32()
+      ("\{tag_size}U + \{fixed_size}U", false)
+    }
+    FieldDescriptorProto_Type::TYPE_FIXED64
+    | FieldDescriptorProto_Type::TYPE_SFIXED64
+    | FieldDescriptorProto_Type::TYPE_DOUBLE => {
+      let fixed_size = sizeFixed64()
+      ("\{tag_size}U + \{fixed_size}U", false)
+    }
+    _ => ("\{tag_size}U + @lib.size_of(\{value_expr})", true)
+  }
+}
+
+///|
 fn CodeGenerator::gen_message_size(
   _ : CodeGenerator,
   message : Message,
@@ -62,60 +92,16 @@ fn CodeGenerator::gen_message_size(
       let key_field = map_entry.fields[0]
       let value_field = map_entry.fields[1]
       let tag_size = size_tag(field_number)
-      let key_size = match key_field.type_.unwrap() {
-        FieldDescriptorProto_Type::TYPE_STRING
-        | FieldDescriptorProto_Type::TYPE_BYTES
-        | FieldDescriptorProto_Type::TYPE_MESSAGE => {
-          let key_tag_size = size_tag(0)
-          "\{key_tag_size}U + { let size = @lib.size_of(k); @lib.size_of(size) + size }"
-        }
-        FieldDescriptorProto_Type::TYPE_FIXED32
-        | FieldDescriptorProto_Type::TYPE_SFIXED32
-        | FieldDescriptorProto_Type::TYPE_FLOAT => {
-          let key_tag_size = size_tag(0)
-          let fixed_size = sizeFixed32()
-          "\{key_tag_size}U + \{fixed_size}U"
-        }
-        FieldDescriptorProto_Type::TYPE_FIXED64
-        | FieldDescriptorProto_Type::TYPE_SFIXED64
-        | FieldDescriptorProto_Type::TYPE_DOUBLE => {
-          let key_tag_size = size_tag(0)
-          let fixed_size = sizeFixed64()
-          "\{key_tag_size}U + \{fixed_size}U"
-        }
-        _ => {
-          let key_tag_size = size_tag(0)
-          "\{key_tag_size}U + @lib.size_of(k)"
-        }
-      }
-
-      // Calculate value size
-      let value_size = match value_field.type_.unwrap() {
-        FieldDescriptorProto_Type::TYPE_STRING
-        | FieldDescriptorProto_Type::TYPE_BYTES
-        | FieldDescriptorProto_Type::TYPE_MESSAGE => {
-          let value_tag_size = size_tag(1)
-          "\{value_tag_size}U + { let size = @lib.size_of(v); @lib.size_of(size) + size }"
-        }
-        FieldDescriptorProto_Type::TYPE_FIXED32
-        | FieldDescriptorProto_Type::TYPE_SFIXED32
-        | FieldDescriptorProto_Type::TYPE_FLOAT => {
-          let value_tag_size = size_tag(1)
-          let fixed_size = sizeFixed32()
-          "\{value_tag_size}U + \{fixed_size}U"
-        }
-        FieldDescriptorProto_Type::TYPE_FIXED64
-        | FieldDescriptorProto_Type::TYPE_SFIXED64
-        | FieldDescriptorProto_Type::TYPE_DOUBLE => {
-          let value_tag_size = size_tag(1)
-          let fixed_size = sizeFixed64()
-          "\{value_tag_size}U + \{fixed_size}U"
-        }
-        _ => {
-          let value_tag_size = size_tag(1)
-          "\{value_tag_size}U + @lib.size_of(v)"
-        }
-      }
+      let (key_size, _) = gen_unpacked_value_size_expr(
+        key_field.type_.unwrap(),
+        "k",
+        size_tag(key_field.number.unwrap()),
+      )
+      let (value_size, _) = gen_unpacked_value_size_expr(
+        value_field.type_.unwrap(),
+        "v",
+        size_tag(value_field.number.unwrap()),
+      )
       content.write_string(
         (
           $|  for k, v in self.\{field_name} {
@@ -128,46 +114,23 @@ fn CodeGenerator::gen_message_size(
       )
     } else if field.is_list() {
       let tag_size = size_tag(field_number)
+      guard field.type_ is Some(typ)
+      let (delta_size, _) = gen_unpacked_value_size_expr(typ, "s", tag_size)
       content.write_string(
         (
           $|  for s in self.\{field_name} {
-          $|    let s = @lib.size_of(s)
-          $|    size += \{tag_size}U + @lib.size_of(s) + s
+          $|    size += \{delta_size}
           $|  }
           $|
         ),
       )
     } else if field.is_optional() {
       guard field.type_ is Some(typ)
-      let (delta_size, need_v) = match typ {
-        FieldDescriptorProto_Type::TYPE_STRING
-        | FieldDescriptorProto_Type::TYPE_BYTES
-        | FieldDescriptorProto_Type::TYPE_MESSAGE => {
-          let tag_size = size_tag(field_number)
-          (
-            "\{tag_size}U + { let size = @lib.size_of(v); @lib.size_of(size) + size }",
-            true,
-          )
-        }
-        FieldDescriptorProto_Type::TYPE_FIXED32
-        | FieldDescriptorProto_Type::TYPE_SFIXED32
-        | FieldDescriptorProto_Type::TYPE_FLOAT => {
-          let tag_size = size_tag(field_number)
-          let fixed_size = sizeFixed32()
-          ("\{tag_size}U + \{fixed_size}U", false)
-        }
-        FieldDescriptorProto_Type::TYPE_FIXED64
-        | FieldDescriptorProto_Type::TYPE_SFIXED64
-        | FieldDescriptorProto_Type::TYPE_DOUBLE => {
-          let tag_size = size_tag(field_number)
-          let fixed_size = sizeFixed64()
-          ("\{tag_size}U + \{fixed_size}U", false)
-        }
-        _ => {
-          let tag_size = size_tag(field_number)
-          ("\{tag_size}U + @lib.size_of(v)", true)
-        }
-      }
+      let (delta_size, need_v) = gen_unpacked_value_size_expr(
+        typ,
+        "v",
+        size_tag(field_number),
+      )
       if need_v {
         content.write_string(
           (
@@ -188,32 +151,11 @@ fn CodeGenerator::gen_message_size(
         )
       }
     } else if field.type_ is Some(typ) {
-      let delta_size = match typ {
-        FieldDescriptorProto_Type::TYPE_STRING
-        | FieldDescriptorProto_Type::TYPE_BYTES
-        | FieldDescriptorProto_Type::TYPE_MESSAGE => {
-          let tag_size = size_tag(field_number)
-          "\{tag_size}U + { let size = @lib.size_of(self.\{field_name}); @lib.size_of(size) + size }"
-        }
-        FieldDescriptorProto_Type::TYPE_FIXED32
-        | FieldDescriptorProto_Type::TYPE_SFIXED32
-        | FieldDescriptorProto_Type::TYPE_FLOAT => {
-          let tag_size = size_tag(field_number)
-          let fixed_size = sizeFixed32()
-          "\{tag_size}U + \{fixed_size}U"
-        }
-        FieldDescriptorProto_Type::TYPE_FIXED64
-        | FieldDescriptorProto_Type::TYPE_SFIXED64
-        | FieldDescriptorProto_Type::TYPE_DOUBLE => {
-          let tag_size = size_tag(field_number)
-          let fixed_size = sizeFixed64()
-          "\{tag_size}U + \{fixed_size}U"
-        }
-        _ => {
-          let tag_size = size_tag(field_number)
-          "\{tag_size}U + @lib.size_of(self.\{field_name})"
-        }
-      }
+      let (delta_size, _) = gen_unpacked_value_size_expr(
+        typ,
+        "self.\{field_name}",
+        size_tag(field_number),
+      )
       content.write_string("  size += \{delta_size}\n")
     }
   }
@@ -224,32 +166,12 @@ fn CodeGenerator::gen_message_size(
       let field_name = field.import_path.name() |> to_camel_case
       let field_number = field.number.unwrap()
       let delta_size = if field.type_ is Some(typ) {
-        match typ {
-          FieldDescriptorProto_Type::TYPE_STRING
-          | FieldDescriptorProto_Type::TYPE_BYTES
-          | FieldDescriptorProto_Type::TYPE_MESSAGE => {
-            let tag_size = size_tag(field_number)
-            "\{tag_size}U + { let size = @lib.size_of(v); @lib.size_of(size) + size }"
-          }
-          FieldDescriptorProto_Type::TYPE_FIXED32
-          | FieldDescriptorProto_Type::TYPE_SFIXED32
-          | FieldDescriptorProto_Type::TYPE_FLOAT => {
-            let tag_size = size_tag(field_number)
-            let fixed_size = sizeFixed32()
-            "\{tag_size}U + \{fixed_size}U"
-          }
-          FieldDescriptorProto_Type::TYPE_FIXED64
-          | FieldDescriptorProto_Type::TYPE_SFIXED64
-          | FieldDescriptorProto_Type::TYPE_DOUBLE => {
-            let tag_size = size_tag(field_number)
-            let fixed_size = sizeFixed64()
-            "\{tag_size}U + \{fixed_size}U"
-          }
-          _ => {
-            let tag_size = size_tag(field_number)
-            "\{tag_size}U + @lib.size_of(v)"
-          }
-        }
+        let (value_size, _) = gen_unpacked_value_size_expr(
+          typ,
+          "v",
+          size_tag(field_number),
+        )
+        value_size
       } else {
         "0"
       }

--- a/cli/types.mbt
+++ b/cli/types.mbt
@@ -70,7 +70,21 @@ fn ImportPath::path(self : ImportPath) -> String {
 enum Syntax {
   Proto2
   Proto3
+  Editions
 } derive(Eq, Debug)
+
+///|
+priv enum FieldPresence {
+  PresenceImplicit
+  PresenceExplicit
+  PresenceRequired
+} derive(Eq)
+
+///|
+priv enum RepeatedFieldEncoding {
+  RepeatedPacked
+  RepeatedExpanded
+} derive(Eq)
 
 ///|
 struct Field {
@@ -109,16 +123,91 @@ fn Field::from(
 
 ///|
 fn Field::is_pack(self : Field) -> Bool {
-  guard self.parent.file is Some(file) else {
-    self.desc.options is Some(options) && options.packed is Some(true)
+  self.repeated_field_encoding() == RepeatedPacked
+}
+
+///|
+fn Field::feature_field_presence(
+  self : Field,
+) -> @protobuf.FeatureSet_FieldPresence? {
+  match self.options {
+    Some({ features: Some({ field_presence: Some(presence), .. }), .. }) =>
+      Some(presence)
+    _ => None
   }
-  match file.syntax {
-    Proto3 =>
-      match self.desc.options {
-        Some({ packed: Some(packed), .. }) => packed
-        _ => self.is_list() && self.is_packable_scalar()
+}
+
+///|
+fn Field::feature_repeated_field_encoding(
+  self : Field,
+) -> @protobuf.FeatureSet_RepeatedFieldEncoding? {
+  match self.options {
+    Some(
+      { features: Some({ repeated_field_encoding: Some(encoding), .. }), .. }
+    ) => Some(encoding)
+    _ => None
+  }
+}
+
+///|
+fn Field::field_presence(self : Field) -> FieldPresence {
+  if self.is_list() {
+    return PresenceImplicit
+  }
+  match self.feature_field_presence() {
+    Some(@protobuf.FeatureSet_FieldPresence::EXPLICIT) => PresenceExplicit
+    Some(@protobuf.FeatureSet_FieldPresence::IMPLICIT) => PresenceImplicit
+    Some(@protobuf.FeatureSet_FieldPresence::LEGACY_REQUIRED) =>
+      PresenceRequired
+    _ =>
+      if self.parent.file is Some(file) {
+        match file.syntax {
+          Proto3 =>
+            if self.desc.proto3_optional is Some(true) {
+              PresenceExplicit
+            } else {
+              PresenceImplicit
+            }
+          Proto2 =>
+            if self.desc.label is Some(LABEL_REQUIRED) {
+              PresenceRequired
+            } else if self.desc.label is Some(LABEL_OPTIONAL) {
+              PresenceExplicit
+            } else {
+              PresenceImplicit
+            }
+          Editions => PresenceExplicit
+        }
+      } else if self.desc.proto3_optional is Some(true) ||
+        self.desc.label is Some(LABEL_OPTIONAL) {
+        PresenceExplicit
+      } else {
+        PresenceImplicit
       }
-    Proto2 => self.desc.options is Some(options) && options.packed is Some(true)
+  }
+}
+
+///|
+fn Field::repeated_field_encoding(self : Field) -> RepeatedFieldEncoding {
+  if !self.is_list() || !self.is_packable_scalar() {
+    return RepeatedExpanded
+  }
+  match self.feature_repeated_field_encoding() {
+    Some(@protobuf.FeatureSet_RepeatedFieldEncoding::PACKED) =>
+      return RepeatedPacked
+    Some(@protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED) =>
+      return RepeatedExpanded
+    _ => ()
+  }
+  match self.desc.options {
+    Some({ packed: Some(true), .. }) => return RepeatedPacked
+    Some({ packed: Some(false), .. }) => return RepeatedExpanded
+    _ => ()
+  }
+  guard self.parent.file is Some(file) else { return RepeatedExpanded }
+  match file.syntax {
+    Proto3 | Editions => RepeatedPacked
+    Proto2 => RepeatedExpanded
   }
 }
 
@@ -166,14 +255,7 @@ fn Field::is_enum(self : Field) -> Bool {
 
 ///|
 fn Field::is_optional(self : Field) -> Bool {
-  guard self.parent.file is Some(file) else {
-    return self.desc.proto3_optional is Some(true) ||
-      self.desc.label is Some(LABEL_OPTIONAL)
-  }
-  match file.syntax {
-    Proto3 => self.desc.proto3_optional is Some(true)
-    Proto2 => self.desc.label is Some(LABEL_OPTIONAL)
-  }
+  self.field_presence() == PresenceExplicit
 }
 
 ///|
@@ -222,6 +304,7 @@ fn Package::from(
     syntax: match desc.syntax {
       Some("proto3") => Proto3
       Some("proto2") => Proto2
+      Some("editions") => Editions
       Some(_) => panic()
       None => Proto2 // if syntax is not specified, default to proto2
     },

--- a/cli/types.mbt
+++ b/cli/types.mbt
@@ -87,6 +87,54 @@ priv enum RepeatedFieldEncoding {
 } derive(Eq)
 
 ///|
+fn known_feature_field_presence(
+  features : @protobuf.FeatureSet?,
+) -> @protobuf.FeatureSet_FieldPresence? {
+  match features {
+    Some(
+      { field_presence: Some(@protobuf.FeatureSet_FieldPresence::EXPLICIT), .. }
+    ) => Some(@protobuf.FeatureSet_FieldPresence::EXPLICIT)
+    Some(
+      { field_presence: Some(@protobuf.FeatureSet_FieldPresence::IMPLICIT), .. }
+    ) => Some(@protobuf.FeatureSet_FieldPresence::IMPLICIT)
+    Some(
+      {
+        field_presence: Some(
+          @protobuf.FeatureSet_FieldPresence::LEGACY_REQUIRED
+        ),
+        ..,
+      }
+    ) => Some(@protobuf.FeatureSet_FieldPresence::LEGACY_REQUIRED)
+    _ => None
+  }
+}
+
+///|
+fn known_feature_repeated_field_encoding(
+  features : @protobuf.FeatureSet?,
+) -> @protobuf.FeatureSet_RepeatedFieldEncoding? {
+  match features {
+    Some(
+      {
+        repeated_field_encoding: Some(
+          @protobuf.FeatureSet_RepeatedFieldEncoding::PACKED
+        ),
+        ..,
+      }
+    ) => Some(@protobuf.FeatureSet_RepeatedFieldEncoding::PACKED)
+    Some(
+      {
+        repeated_field_encoding: Some(
+          @protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED
+        ),
+        ..,
+      }
+    ) => Some(@protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED)
+    _ => None
+  }
+}
+
+///|
 struct Field {
   desc : @protobuf.FieldDescriptorProto
   import_path : ImportPath
@@ -130,21 +178,26 @@ fn Field::is_pack(self : Field) -> Bool {
 fn Field::feature_field_presence(
   self : Field,
 ) -> @protobuf.FeatureSet_FieldPresence? {
-  match self.options {
-    Some({ features: Some({ field_presence: Some(presence), .. }), .. }) =>
-      Some(presence)
-    _ => None
+  let field_feature = match self.options {
+    Some({ features, .. }) => known_feature_field_presence(features)
+    None => None
+  }
+  match field_feature {
+    Some(presence) => Some(presence)
+    None =>
+      match self.parent.file {
+        Some(file) => file.feature_field_presence()
+        None => None
+      }
   }
 }
 
 ///|
-fn Field::feature_repeated_field_encoding(
+fn Field::own_feature_repeated_field_encoding(
   self : Field,
 ) -> @protobuf.FeatureSet_RepeatedFieldEncoding? {
   match self.options {
-    Some(
-      { features: Some({ repeated_field_encoding: Some(encoding), .. }), .. }
-    ) => Some(encoding)
+    Some({ features, .. }) => known_feature_repeated_field_encoding(features)
     _ => None
   }
 }
@@ -192,7 +245,7 @@ fn Field::repeated_field_encoding(self : Field) -> RepeatedFieldEncoding {
   if !self.is_list() || !self.is_packable_scalar() {
     return RepeatedExpanded
   }
-  match self.feature_repeated_field_encoding() {
+  match self.own_feature_repeated_field_encoding() {
     Some(@protobuf.FeatureSet_RepeatedFieldEncoding::PACKED) =>
       return RepeatedPacked
     Some(@protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED) =>
@@ -205,6 +258,13 @@ fn Field::repeated_field_encoding(self : Field) -> RepeatedFieldEncoding {
     _ => ()
   }
   guard self.parent.file is Some(file) else { return RepeatedExpanded }
+  match file.feature_repeated_field_encoding() {
+    Some(@protobuf.FeatureSet_RepeatedFieldEncoding::PACKED) =>
+      return RepeatedPacked
+    Some(@protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED) =>
+      return RepeatedExpanded
+    _ => ()
+  }
   match file.syntax {
     Proto3 | Editions => RepeatedPacked
     Proto2 => RepeatedExpanded
@@ -321,6 +381,26 @@ fn Package::from(
     }
   }
   package_
+}
+
+///|
+fn Package::feature_field_presence(
+  self : Package,
+) -> @protobuf.FeatureSet_FieldPresence? {
+  match self.options {
+    Some({ features, .. }) => known_feature_field_presence(features)
+    _ => None
+  }
+}
+
+///|
+fn Package::feature_repeated_field_encoding(
+  self : Package,
+) -> @protobuf.FeatureSet_RepeatedFieldEncoding? {
+  match self.options {
+    Some({ features, .. }) => known_feature_repeated_field_encoding(features)
+    _ => None
+  }
 }
 
 ///|

--- a/scripts/workflow.py
+++ b/scripts/workflow.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import shutil
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Sequence
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -15,6 +17,9 @@ CLI_DIR = ROOT / "cli"
 PLUGIN_DIR = ROOT / "plugin"
 READER_DIR = ROOT / "test" / "reader"
 SNAPSHOT_DIR = ROOT / "test" / "snapshots"
+HARNESS_DIR = ROOT / "test" / "harness"
+HARNESS_CASES_DIR = HARNESS_DIR / "cases"
+HARNESS_WORK_DIR = HARNESS_DIR / "__gen"
 PLUGIN_EXE = (
     ROOT
     / "_build"
@@ -118,6 +123,7 @@ def run_protoc(
     include_path: str | None = None,
     options: Sequence[str] = (),
 ) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
     proto_paths = [f"--proto_path={proto_dir}"]
     if include_path:
         proto_paths.append(f"--proto_path={include_path}")
@@ -319,6 +325,69 @@ def reader_test(args: argparse.Namespace) -> None:
         logger.info("Reader test completed successfully.")
 
 
+def generate_harness_case(case_dir: Path) -> None:
+    config = tomllib.loads((case_dir / "case.toml").read_text())
+    generated_project = config["generated_project"]
+
+    logger.info("Generating generated-code harness case %s", case_dir.name)
+    run_protoc(
+        proto_dir=case_dir / "proto",
+        output_dir=HARNESS_WORK_DIR,
+        project_name=generated_project,
+        proto_files=config["proto_files"],
+    )
+
+
+def run_generated_code_case(case_dir: Path) -> bool:
+    config = tomllib.loads((case_dir / "case.toml").read_text())
+    result = moon(
+        config.get(
+            "test_args",
+            ["test", "src", "--target", "native", "--deny-warn"],
+        ),
+        cwd=case_dir / "runner",
+        env=moon_work_env(case_dir / "moon.work"),
+        description=f"Running {case_dir.name} generated-code tests",
+        check=False,
+    )
+    if result.returncode != 0:
+        print_output(result)
+        return False
+    return True
+
+
+def generated_code_test(_: argparse.Namespace) -> None:
+    logger.info("Project root: %s", ROOT)
+    build_plugin()
+
+    if HARNESS_WORK_DIR.exists():
+        shutil.rmtree(HARNESS_WORK_DIR)
+    HARNESS_WORK_DIR.mkdir(parents=True)
+
+    failures: list[str] = []
+    case_dirs = sorted(
+        path for path in HARNESS_CASES_DIR.iterdir()
+        if (path / "case.toml").exists()
+    )
+    if not case_dirs:
+        raise RuntimeError(
+            f"no generated-code harness cases found in {HARNESS_CASES_DIR}",
+        )
+
+    for case_dir in case_dirs:
+        generate_harness_case(case_dir)
+
+    for case_dir in case_dirs:
+        if not run_generated_code_case(case_dir):
+            failures.append(case_dir.name)
+
+    if failures:
+        raise RuntimeError(
+            "generated-code harness failed: " + ", ".join(failures),
+        )
+    logger.info("Generated-code harness passed")
+
+
 def add_test_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--include-path", "-I", metavar="PATH")
     parser.add_argument("--update", "-U", action="store_true")
@@ -350,6 +419,13 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     )
     add_test_options(snapshot)
     snapshot.set_defaults(handler=snapshot_test)
+
+    harness = subcommands.add_parser(
+        "generated-code-test",
+        aliases=["generated_code_test", "harness-test", "harness_test"],
+        help="run behavior tests against freshly generated MoonBit code",
+    )
+    harness.set_defaults(handler=generated_code_test)
 
     return parser.parse_args(argv)
 

--- a/test/harness/cases/edition/case.toml
+++ b/test/harness/cases/edition/case.toml
@@ -1,3 +1,3 @@
 generated_project = "harness_edition"
-proto_files = ["edition.proto"]
+proto_files = ["edition.proto", "inherited_file.proto"]
 test_args = ["test", "src", "--target", "native", "--deny-warn"]

--- a/test/harness/cases/edition/case.toml
+++ b/test/harness/cases/edition/case.toml
@@ -1,0 +1,3 @@
+generated_project = "harness_edition"
+proto_files = ["edition.proto"]
+test_args = ["test", "src", "--target", "native", "--deny-warn"]

--- a/test/harness/cases/edition/moon.work
+++ b/test/harness/cases/edition/moon.work
@@ -1,0 +1,5 @@
+members = [
+  "../../../../lib",
+  "../../__gen/harness_edition",
+  "runner",
+]

--- a/test/harness/cases/edition/proto/edition.proto
+++ b/test/harness/cases/edition/proto/edition.proto
@@ -1,0 +1,9 @@
+edition = "2023";
+
+package harness.edition;
+
+message Payload {
+  repeated int32 values = 1 [features.repeated_field_encoding = EXPANDED];
+  int32 implicit_value = 2 [features.field_presence = IMPLICIT];
+  int32 explicit_value = 3;
+}

--- a/test/harness/cases/edition/proto/inherited_file.proto
+++ b/test/harness/cases/edition/proto/inherited_file.proto
@@ -1,0 +1,15 @@
+edition = "2023";
+
+package harness.inherited.file;
+
+option features.field_presence = IMPLICIT;
+option features.repeated_field_encoding = EXPANDED;
+
+message FilePresence {
+  int32 scalar = 1;
+  int32 explicit_scalar = 2 [features.field_presence = EXPLICIT];
+}
+
+message FileRepeatedEncoding {
+  repeated int32 values = 1;
+}

--- a/test/harness/cases/edition/runner/moon.mod
+++ b/test/harness/cases/edition/runner/moon.mod
@@ -1,0 +1,18 @@
+name = "username/harness_edition_runner"
+
+version = "0.1.0"
+
+import {
+  "moonbitlang/protobuf@0.1.2",
+  "username/harness_edition@0.1.0",
+}
+
+readme = ""
+
+repository = ""
+
+license = ""
+
+keywords = []
+
+description = ""

--- a/test/harness/cases/edition/runner/src/edition_test.mbt
+++ b/test/harness/cases/edition/runner/src/edition_test.mbt
@@ -1,0 +1,24 @@
+///|
+/// Expanded repeated numeric fields should be sized like the writer emits them.
+test "edition expanded repeated scalar size matches writer" {
+  let message = @edition.Payload::default()
+  message.values.push(1)
+  message.values.push(150)
+  message.implicit_value = 7
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(
+    @protobuf.size_of(message),
+    writer.to_bytes().length().reinterpret_as_uint(),
+  )
+}
+
+///|
+/// Edition presence features should decide whether generated fields use `?`.
+test "edition field presence controls generated shape" {
+  let message = @edition.Payload::new([], 7)
+  @debug.assert_eq(message.implicit_value, 7)
+  @debug.assert_eq(message.explicit_value, None)
+  let with_explicit = @edition.Payload::new([], 7, explicit_value=9)
+  @debug.assert_eq(with_explicit.explicit_value, Some(9))
+}

--- a/test/harness/cases/edition/runner/src/edition_test.mbt
+++ b/test/harness/cases/edition/runner/src/edition_test.mbt
@@ -22,3 +22,24 @@ test "edition field presence controls generated shape" {
   let with_explicit = @edition.Payload::new([], 7, explicit_value=9)
   @debug.assert_eq(with_explicit.explicit_value, Some(9))
 }
+
+///|
+/// File-level presence features should be inherited by fields without overrides.
+test "edition file inherited field presence controls generated shape" {
+  let message = @file_inherited.FilePresence::new(7)
+  @debug.assert_eq(message.scalar, 7)
+  @debug.assert_eq(message.explicit_scalar, None)
+  let with_explicit = @file_inherited.FilePresence::new(7, explicit_scalar=9)
+  @debug.assert_eq(with_explicit.explicit_scalar, Some(9))
+}
+
+///|
+/// File-level repeated encoding features should be inherited by repeated scalars.
+test "edition file inherited repeated encoding writes expanded values" {
+  let message = @file_inherited.FileRepeatedEncoding::default()
+  message.values.push(1)
+  message.values.push(150)
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x08\x01\x08\x96\x01")
+}

--- a/test/harness/cases/edition/runner/src/moon.pkg
+++ b/test/harness/cases/edition/runner/src/moon.pkg
@@ -3,6 +3,7 @@ import {
 
 import {
   "username/harness_edition/harness/edition",
+  "username/harness_edition/harness/inherited/file" @file_inherited,
   "moonbitlang/protobuf",
   "moonbitlang/core/buffer",
   "moonbitlang/core/debug",

--- a/test/harness/cases/edition/runner/src/moon.pkg
+++ b/test/harness/cases/edition/runner/src/moon.pkg
@@ -1,0 +1,9 @@
+import {
+}
+
+import {
+  "username/harness_edition/harness/edition",
+  "moonbitlang/protobuf",
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
+} for "test"

--- a/test/harness/cases/imported-enum/case.toml
+++ b/test/harness/cases/imported-enum/case.toml
@@ -1,0 +1,3 @@
+generated_project = "harness_imported_enum"
+proto_files = ["shared.proto", "uses_imported_enum.proto"]
+test_args = ["test", "src", "--target", "native"]

--- a/test/harness/cases/imported-enum/moon.work
+++ b/test/harness/cases/imported-enum/moon.work
@@ -1,0 +1,5 @@
+members = [
+  "../../../../lib",
+  "../../__gen/harness_imported_enum",
+  "runner",
+]

--- a/test/harness/cases/imported-enum/proto/shared.proto
+++ b/test/harness/cases/imported-enum/proto/shared.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package harness.shared;
+
+enum SharedState {
+  SHARED_STATE_UNSPECIFIED = 0;
+  SHARED_STATE_READY = 1;
+}

--- a/test/harness/cases/imported-enum/proto/uses_imported_enum.proto
+++ b/test/harness/cases/imported-enum/proto/uses_imported_enum.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package harness.use;
+
+import "shared.proto";
+
+enum SharedState {
+  LOCAL_SHARED_STATE_UNSPECIFIED = 0;
+  LOCAL_SHARED_STATE_DIFFERENT = 7;
+}
+
+message UsesImportedEnum {
+  harness.shared.SharedState state = 1;
+}

--- a/test/harness/cases/imported-enum/runner/moon.mod
+++ b/test/harness/cases/imported-enum/runner/moon.mod
@@ -1,0 +1,17 @@
+name = "username/harness_imported_enum_runner"
+
+version = "0.1.0"
+
+import {
+  "username/harness_imported_enum@0.1.0",
+}
+
+readme = ""
+
+repository = ""
+
+license = ""
+
+keywords = []
+
+description = ""

--- a/test/harness/cases/imported-enum/runner/src/imported_enum_test.mbt
+++ b/test/harness/cases/imported-enum/runner/src/imported_enum_test.mbt
@@ -1,0 +1,8 @@
+///|
+/// Imported enum fields should stay qualified when a local enum has the same name.
+test "constructor accepts imported enum type when local name collides" {
+  let message = @use.UsesImportedEnum::new(
+    @shared.SharedState::SHARED_STATE_READY,
+  )
+  @debug.assert_eq(message.state, @shared.SharedState::SHARED_STATE_READY)
+}

--- a/test/harness/cases/imported-enum/runner/src/moon.pkg
+++ b/test/harness/cases/imported-enum/runner/src/moon.pkg
@@ -1,0 +1,8 @@
+import {
+}
+
+import {
+  "username/harness_imported_enum/harness/shared",
+  "username/harness_imported_enum/harness/use",
+  "moonbitlang/core/debug",
+} for "test"

--- a/test/harness/cases/size/case.toml
+++ b/test/harness/cases/size/case.toml
@@ -1,0 +1,3 @@
+generated_project = "harness_size"
+proto_files = ["size.proto"]
+test_args = ["test", "src", "--target", "native", "--deny-warn"]

--- a/test/harness/cases/size/moon.work
+++ b/test/harness/cases/size/moon.work
@@ -1,0 +1,5 @@
+members = [
+  "../../../../lib",
+  "../../__gen/harness_size",
+  "runner",
+]

--- a/test/harness/cases/size/proto/size.proto
+++ b/test/harness/cases/size/proto/size.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package harness.size;
+
+message Payload {
+  repeated int32 values = 1 [packed = false];
+  string tail = 2;
+}

--- a/test/harness/cases/size/runner/moon.mod
+++ b/test/harness/cases/size/runner/moon.mod
@@ -1,0 +1,18 @@
+name = "username/harness_size_runner"
+
+version = "0.1.0"
+
+import {
+  "moonbitlang/protobuf@0.1.2",
+  "username/harness_size@0.1.0",
+}
+
+readme = ""
+
+repository = ""
+
+license = ""
+
+keywords = []
+
+description = ""

--- a/test/harness/cases/size/runner/src/moon.pkg
+++ b/test/harness/cases/size/runner/src/moon.pkg
@@ -1,0 +1,9 @@
+import {
+}
+
+import {
+  "username/harness_size/harness/size",
+  "moonbitlang/protobuf",
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
+} for "test"

--- a/test/harness/cases/size/runner/src/size_test.mbt
+++ b/test/harness/cases/size/runner/src/size_test.mbt
@@ -1,0 +1,14 @@
+///|
+/// Unpacked repeated scalar size should match the bytes written by the Runtime.
+test "sized matches writer for unpacked repeated scalar" {
+  let message = @size.Payload::default()
+  message.values.push(1)
+  message.values.push(150)
+  message.tail = "after"
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(
+    @protobuf.size_of(message),
+    writer.to_bytes().length().reinterpret_as_uint(),
+  )
+}

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -298,12 +298,10 @@ pub impl @lib.Sized for FooMessage with fn size_of(self) {
     size += 2U + @lib.size_of(key_size + value_size) + key_size + value_size
   }
   for s in self.f_repeated_string {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.f_repeated_baz_message {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.f_optional_string is Some(v) {
     size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -1141,8 +1139,7 @@ pub(all) struct RepeatedMessage {
 pub impl @lib.Sized for RepeatedMessage with fn size_of(self) {
   let mut size = 0U
   for s in self.bar_message {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -100,8 +100,7 @@ pub impl @lib.Sized for Hello with fn size_of(self) {
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
   size += 1U + @lib.size_of(self.age)
   for s in self.hobbies {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for k, v in self.metadata {
     let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -100,8 +100,7 @@ pub impl @lib.Sized for Hello with fn size_of(self) {
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
   size += 1U + @lib.size_of(self.age)
   for s in self.hobbies {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for k, v in self.metadata {
     let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }

--- a/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
+++ b/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
@@ -162,19 +162,16 @@ pub(all) struct CodeGeneratorRequest {
 pub impl @lib.Sized for CodeGeneratorRequest with fn size_of(self) {
   let mut size = 0U
   for s in self.file_to_generate {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.parameter is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.proto_file {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.source_file_descriptors {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.compiler_version is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -552,8 +549,7 @@ pub impl @lib.Sized for CodeGeneratorResponse with fn size_of(self) {
     size += 1U + @lib.size_of(v)
   }
   for s in self.file {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }

--- a/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
+++ b/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
@@ -15,8 +15,7 @@ pub impl @lib.Sized for TreeNode with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.children {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.sibling is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -302,8 +301,7 @@ pub impl @lib.Sized for GraphNode with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.neighbors {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.visited is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -705,12 +703,10 @@ pub impl @lib.Sized for Organization with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.sub_orgs {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.employees {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -876,8 +872,7 @@ pub impl @lib.Sized for Employee with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.subordinates {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }

--- a/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
+++ b/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
@@ -13,12 +13,10 @@ pub impl @lib.Sized for User with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.orders {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.friends {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -177,8 +175,7 @@ pub impl @lib.Sized for Order with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.related_orders {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -331,12 +328,10 @@ pub impl @lib.Sized for Department with fn size_of(self) {
   size += 1U + { let size = @lib.size_of(self.dept_id); @lib.size_of(size) + size }
   size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
   for s in self.employees {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.projects {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.parent_dept is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -496,15 +491,13 @@ pub impl @lib.Sized for Employee with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.projects {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.supervisor is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.subordinates {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -684,16 +677,13 @@ pub impl @lib.Sized for Project with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.members {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.dependencies {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.dependents {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -1053,12 +1043,10 @@ pub impl @lib.Sized for Node with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.connections {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.neighbors {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -1203,8 +1191,7 @@ pub impl @lib.Sized for Weight with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.related_nodes {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -1346,12 +1333,10 @@ pub impl @lib.Sized for Graph with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.vertices {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.edges {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -1498,16 +1483,13 @@ pub impl @lib.Sized for Vertex with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.incoming_edges {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.outgoing_edges {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.adjacent_vertices {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -1698,8 +1680,7 @@ pub impl @lib.Sized for Edge with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.parallel_edges {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -146,8 +146,7 @@ pub(all) struct FileDescriptorSet {
 pub impl @lib.Sized for FileDescriptorSet with fn size_of(self) {
   let mut size = 0U
   for s in self.file {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -251,36 +250,28 @@ pub impl @lib.Sized for FileDescriptorProto with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.dependency {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.public_dependency {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + @lib.size_of(s)
   }
   for s in self.weak_dependency {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + @lib.size_of(s)
   }
   for s in self.option_dependency {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.message_type {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.enum_type {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.service {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.extension {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.options is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -880,39 +871,31 @@ pub impl @lib.Sized for DescriptorProto with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.field {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.extension {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.nested_type {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.enum_type {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.extension_range {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.oneof_decl {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.options is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.reserved_range {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.reserved_name {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.visibility is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -1408,12 +1391,10 @@ pub(all) struct ExtensionRangeOptions {
 pub impl @lib.Sized for ExtensionRangeOptions with fn size_of(self) {
   let mut size = 0U
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.declaration {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.features is Some(v) {
     size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -2278,19 +2259,16 @@ pub impl @lib.Sized for EnumDescriptorProto with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.value {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.options is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.reserved_range {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   for s in self.reserved_name {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.visibility is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -2609,8 +2587,7 @@ pub impl @lib.Sized for ServiceDescriptorProto with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.method_ {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.options is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -3060,8 +3037,7 @@ pub impl @lib.Sized for FileOptions with fn size_of(self) {
     size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -3550,8 +3526,7 @@ pub impl @lib.Sized for MessageOptions with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -4270,12 +4245,10 @@ pub impl @lib.Sized for FieldOptions with fn size_of(self) {
     size += 2U + @lib.size_of(v)
   }
   for s in self.targets {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + @lib.size_of(s)
   }
   for s in self.edition_defaults {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.features is Some(v) {
     size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -4284,8 +4257,7 @@ pub impl @lib.Sized for FieldOptions with fn size_of(self) {
     size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -4623,8 +4595,7 @@ pub impl @lib.Sized for OneofOptions with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -4744,8 +4715,7 @@ pub impl @lib.Sized for EnumOptions with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -4922,8 +4892,7 @@ pub impl @lib.Sized for EnumValueOptions with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -5092,8 +5061,7 @@ pub impl @lib.Sized for ServiceOptions with fn size_of(self) {
     size += 2U + @lib.size_of(v)
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -5272,8 +5240,7 @@ pub impl @lib.Sized for MethodOptions with fn size_of(self) {
     size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -5511,8 +5478,7 @@ pub(all) struct UninterpretedOption {
 pub impl @lib.Sized for UninterpretedOption with fn size_of(self) {
   let mut size = 0U
   for s in self.name {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.identifier_value is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
@@ -6507,8 +6473,7 @@ pub(all) struct FeatureSetDefaults {
 pub impl @lib.Sized for FeatureSetDefaults with fn size_of(self) {
   let mut size = 0U
   for s in self.defaults {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   if self.minimum_edition is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -6649,8 +6614,7 @@ pub impl @lib.Sized for SourceCodeInfo_Location with fn size_of(self) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
   for s in self.leading_detached_comments {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -6823,8 +6787,7 @@ pub(all) struct SourceCodeInfo {
 pub impl @lib.Sized for SourceCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.location {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }
@@ -7134,8 +7097,7 @@ pub(all) struct GeneratedCodeInfo {
 pub impl @lib.Sized for GeneratedCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.annotation {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
   size
 }


### PR DESCRIPTION
Summary:
- add case-local generated-code harness fixtures and static MoonBit runners
- centralize field presence and repeated-field encoding semantics, including Edition descriptors
- fix generated size accounting for unpacked repeated scalars and imported enum qualification

Validation:
- python3 scripts/workflow.py generated-code-test
- python3 -m py_compile scripts/workflow.py
- moon -C cli check --deny-warn
- moon -C lib check --deny-warn
- moon -C plugin check --deny-warn
- moon -C cli info