### PR TITLE
[codex] Preserve open enum unknown values

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,5 +4,6 @@
 
 - **Generator**: the MoonBit protoc plugin that turns protobuf descriptors into MoonBit packages.
 - **Runtime**: the MoonBit protobuf library used by generated code for read, write, size, and JSON behavior.
+- **Feature resolver**: Generator logic that turns protobuf Editions feature options, inheritance, and syntax defaults into semantic questions used by templates.
 - **Generated-code harness**: a test workflow that builds the Generator, generates MoonBit code from focused proto fixtures, and verifies the generated code through its public Runtime interfaces.
 - **Harness case**: a self-contained Generated-code harness input with proto fixtures, a runner test, and `case.toml` metadata.

--- a/cli/enum_template.mbt
+++ b/cli/enum_template.mbt
@@ -1,4 +1,22 @@
 ///|
+fn Enum::unknown_value_variant_name(self : Enum) -> String {
+  let names : Map[String, Int] = {}
+  for value in self.value {
+    let value_name = to_camel_case(value.name.unwrap())
+    names[value_name] = names.get_or_default(value_name, 0) + 1
+  }
+  let mut suffix = 0
+  while true {
+    let name = if suffix == 0 { "Unknown" } else { "Unknown\{suffix}" }
+    if !names.contains(name) {
+      return name
+    }
+    suffix += 1
+  }
+  panic()
+}
+
+///|
 fn CodeGenerator::gen_enum(
   self : CodeGenerator,
   enum_ : Enum,
@@ -6,10 +24,14 @@ fn CodeGenerator::gen_enum(
 ) -> Unit {
   let derive_list = self.derive_list().join(", ")
   let enum_name = enum_.import_path.path() |> to_camel_case
+  let unknown_variant_name = enum_.unknown_value_variant_name()
   file.write_string("pub(all) enum \{enum_name} {\n")
   for value in enum_.value {
     let value_name = to_camel_case(value.name.unwrap())
     file.write_string("  \{value_name}\n")
+  }
+  if enum_.is_open() {
+    file.write_string("  \{unknown_variant_name}(@lib.Enum)\n")
   }
   file.write_string("} derive(\{derive_list})\n")
 
@@ -25,6 +47,11 @@ fn CodeGenerator::gen_enum(
     let value_name = to_camel_case(value.name.unwrap())
     file.write_string(
       "    \{enum_name}::\{value_name} => \{value.number.unwrap()}\n",
+    )
+  }
+  if enum_.is_open() {
+    file.write_string(
+      "    \{enum_name}::\{unknown_variant_name}(value) => value\n",
     )
   }
   // From enum
@@ -43,14 +70,12 @@ fn CodeGenerator::gen_enum(
       "    \{value.number.unwrap()} => \{enum_name}::\{value_name}\n",
     )
   }
-  file.write_string(
-    (
-      #|    _ => Default::default()
-      #|  }
-      #|}
-      #|
-    ),
-  )
+  if enum_.is_open() {
+    file.write_string("    _ => \{enum_name}::\{unknown_variant_name}(i)\n")
+  } else {
+    file.write_string("    _ => Default::default()\n")
+  }
+  file.write_string("  }\n}\n")
 
   // Default
   if enum_.value.length() > 0 {
@@ -93,6 +118,19 @@ fn CodeGenerator::gen_enum(
         "    Number(\{value.number.unwrap()}, ..) => \{enum_name}::\{value_name}\n",
       )
     }
+    if enum_.is_open() {
+      file.write_string(
+        (
+          $|    Number(value, ..) =>
+          $|      if value.trunc() == value {
+          $|        \{enum_name}::\{unknown_variant_name}(@lib.Enum(value.to_uint()))
+          $|      } else {
+          $|        raise @json.JsonDecodeError((path, "Expected an integer number or string for enum"))
+          $|      }
+          $|
+        ),
+      )
+    }
 
     // To JSON
     file.write_string(
@@ -109,6 +147,11 @@ fn CodeGenerator::gen_enum(
       let value_name = to_camel_case(value.name.unwrap())
       file.write_string(
         "    \{enum_name}::\{value_name} => \"\{value_name}\"\n",
+      )
+    }
+    if enum_.is_open() {
+      file.write_string(
+        "    \{enum_name}::\{unknown_variant_name}(value) => value.0.to_json()\n",
       )
     }
     file.write_string(

--- a/cli/package_template.mbt
+++ b/cli/package_template.mbt
@@ -10,6 +10,9 @@ fn CodeGenerator::gen_package(
   content.write_string("import {\n")
   content.write_string("  \"moonbitlang/protobuf\" @lib,\n")
   content.write_string("   \"moonbitlang/core/json\",")
+  if self.derive_list().contains("Arbitrary") {
+    content.write_string("\n  \"moonbitlang/core/quickcheck\",")
+  }
   for dep in package_.dependency {
     let import_alias = self.qualified_name(dep.import_path)
     let import_path = dep.import_path.package_name.replace_all(old=".", new="/")

--- a/cli/types.mbt
+++ b/cli/types.mbt
@@ -87,6 +87,12 @@ priv enum RepeatedFieldEncoding {
 } derive(Eq)
 
 ///|
+priv enum EnumOpenness {
+  EnumOpen
+  EnumClosed
+} derive(Eq)
+
+///|
 fn known_feature_field_presence(
   features : @protobuf.FeatureSet?,
 ) -> @protobuf.FeatureSet_FieldPresence? {
@@ -130,6 +136,19 @@ fn known_feature_repeated_field_encoding(
         ..,
       }
     ) => Some(@protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED)
+    _ => None
+  }
+}
+
+///|
+fn known_feature_enum_type(
+  features : @protobuf.FeatureSet?,
+) -> @protobuf.FeatureSet_EnumType? {
+  match features {
+    Some({ enum_type: Some(@protobuf.FeatureSet_EnumType::OPEN), .. }) =>
+      Some(@protobuf.FeatureSet_EnumType::OPEN)
+    Some({ enum_type: Some(@protobuf.FeatureSet_EnumType::CLOSED), .. }) =>
+      Some(@protobuf.FeatureSet_EnumType::CLOSED)
     _ => None
   }
 }
@@ -404,6 +423,14 @@ fn Package::feature_repeated_field_encoding(
 }
 
 ///|
+fn Package::feature_enum_type(self : Package) -> @protobuf.FeatureSet_EnumType? {
+  match self.options {
+    Some({ features, .. }) => known_feature_enum_type(features)
+    _ => None
+  }
+}
+
+///|
 fn Package::find_message(self : Package, path : ImportPath) -> Message? {
   if !path.has_prefix(self.import_path) {
     return None
@@ -475,6 +502,57 @@ fn Enum::from_message(
     options: desc.options,
     value: desc.value,
   }
+}
+
+///|
+fn Enum::own_feature_enum_type(self : Enum) -> @protobuf.FeatureSet_EnumType? {
+  match self.options {
+    Some({ features, .. }) => known_feature_enum_type(features)
+    _ => None
+  }
+}
+
+///|
+fn Enum::file_package(self : Enum) -> Package? {
+  match self.file {
+    Some(file) => Some(file)
+    None =>
+      match self.parent {
+        Some(parent) => parent.file
+        None => None
+      }
+  }
+}
+
+///|
+fn Enum::feature_enum_type(self : Enum) -> @protobuf.FeatureSet_EnumType? {
+  match self.own_feature_enum_type() {
+    Some(enum_type) => Some(enum_type)
+    None =>
+      match self.file_package() {
+        Some(file) => file.feature_enum_type()
+        None => None
+      }
+  }
+}
+
+///|
+fn Enum::openness(self : Enum) -> EnumOpenness {
+  match self.feature_enum_type() {
+    Some(@protobuf.FeatureSet_EnumType::OPEN) => EnumOpen
+    Some(@protobuf.FeatureSet_EnumType::CLOSED) => EnumClosed
+    _ =>
+      match self.file_package() {
+        Some({ syntax: Proto2, .. }) => EnumClosed
+        Some({ syntax: Proto3 | Editions, .. }) => EnumOpen
+        None => EnumClosed
+      }
+  }
+}
+
+///|
+fn Enum::is_open(self : Enum) -> Bool {
+  self.openness() == EnumOpen
 }
 
 ///|

--- a/cli/utils.mbt
+++ b/cli/utils.mbt
@@ -2,18 +2,40 @@
 fn convert_args(args : String) -> Map[String, String] {
   let params = {}
   let parts = args.split(",")
+  let mut current_key = None
   for part in parts {
     let key_value = part.split("=").collect()
     if key_value.length() == 2 {
       let key = key_value[0].trim()
       let value = key_value[1].trim()
       if key.is_empty() || value.is_empty() {
+        current_key = None
         continue
       }
       params[key.to_owned()] = value.to_owned()
+      current_key = Some(key.to_owned())
+    } else if key_value.length() == 1 {
+      let value = part.trim()
+      if !value.is_empty() {
+        if current_key is Some(key) {
+          params[key] = "\{params.get(key).unwrap()},\{value}"
+        }
+      }
     }
   }
   return params
+}
+
+///|
+test "convert_args preserves comma-separated derive values" {
+  let args = convert_args(
+    "json=true,derive=Debug,Eq,Hash,Compare,Arbitrary,username=moon",
+  )
+  inspect(
+    args.get("derive").unwrap(),
+    content="Debug,Eq,Hash,Compare,Arbitrary",
+  )
+  inspect(args.get("username").unwrap(), content="moon")
 }
 
 ///|

--- a/lib/moon.pkg
+++ b/lib/moon.pkg
@@ -2,4 +2,5 @@ import {
   "moonbitlang/core/buffer",
   "moonbitlang/core/cmp",
   "moonbitlang/core/debug",
+  "moonbitlang/core/quickcheck",
 }

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "moonbitlang/protobuf"
 import {
   "moonbitlang/core/buffer",
   "moonbitlang/core/debug",
+  "moonbitlang/core/quickcheck",
 }
 
 // Values
@@ -184,7 +185,7 @@ pub impl Show for BytesReader
 pub impl AsyncReader for BytesReader
 pub impl Reader for BytesReader
 
-pub(all) struct Enum(UInt) derive(Default, Eq, @debug.Debug)
+pub(all) struct Enum(UInt) derive(Compare, Default, Eq, Hash, @debug.Debug, @quickcheck.Arbitrary)
 pub impl Show for Enum
 pub impl Sized for Enum
 

--- a/lib/types.mbt
+++ b/lib/types.mbt
@@ -41,7 +41,7 @@ pub impl Show for Len with fn output(self, logger) {
 
 ///|
 /// Enum
-pub(all) struct Enum(UInt) derive(Default, Eq, Debug)
+pub(all) struct Enum(UInt) derive(Default, Eq, Debug, Hash, Compare, Arbitrary)
 
 ///|
 pub impl Show for Enum with fn output(self, logger) {

--- a/scripts/workflow.py
+++ b/scripts/workflow.py
@@ -335,6 +335,7 @@ def generate_harness_case(case_dir: Path) -> None:
         output_dir=HARNESS_WORK_DIR,
         project_name=generated_project,
         proto_files=config["proto_files"],
+        options=config.get("options", []),
     )
 
 

--- a/test/harness/cases/edition/case.toml
+++ b/test/harness/cases/edition/case.toml
@@ -1,3 +1,3 @@
 generated_project = "harness_edition"
-proto_files = ["edition.proto", "inherited_file.proto"]
+proto_files = ["edition.proto", "inherited_file.proto", "open_enum.proto"]
 test_args = ["test", "src", "--target", "native", "--deny-warn"]

--- a/test/harness/cases/edition/proto/open_enum.proto
+++ b/test/harness/cases/edition/proto/open_enum.proto
@@ -1,0 +1,33 @@
+edition = "2023";
+
+package harness.open_enum;
+
+enum State {
+  STATE_UNSPECIFIED = 0;
+  STATE_READY = 1;
+}
+
+enum ClosedState {
+  option features.enum_type = CLOSED;
+
+  CLOSED_STATE_UNSPECIFIED = 0;
+  CLOSED_STATE_READY = 1;
+}
+
+enum UnknownNameState {
+  unknown = 0;
+  UNKNOWN_NAME_STATE_READY = 1;
+  unknown1 = 2;
+}
+
+message OpenEnumPayload {
+  State state = 1;
+}
+
+message ClosedEnumPayload {
+  ClosedState state = 1;
+}
+
+message UnknownNamePayload {
+  UnknownNameState state = 1;
+}

--- a/test/harness/cases/edition/runner/src/edition_test.mbt
+++ b/test/harness/cases/edition/runner/src/edition_test.mbt
@@ -43,3 +43,66 @@ test "edition file inherited repeated encoding writes expanded values" {
   @protobuf.Write::write(message, writer)
   @debug.assert_eq(writer.to_bytes(), b"\x08\x01\x08\x96\x01")
 }
+
+///|
+/// Open enum fields should preserve unknown numeric wire values.
+test "edition open enum preserves unknown wire values" {
+  let reader = @protobuf.BytesReader::from_bytes(b"\x08\x07")
+  let message : @open_enum.OpenEnumPayload = @protobuf.Read::read(reader)
+  @debug.assert_eq(
+    message.state,
+    Some(@open_enum.State::Unknown(@protobuf.Enum(7))),
+  )
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x08\x07")
+}
+
+///|
+/// Open enum JSON parsing should preserve unknown numeric values.
+test "edition open enum preserves unknown json numbers" {
+  let unknown = Json::number(7.0)
+  let state : @open_enum.State = @json.from_json(unknown)
+  @debug.assert_eq(state, @open_enum.State::Unknown(@protobuf.Enum(7)))
+  @debug.assert_eq(state.to_json(), unknown)
+}
+
+///|
+/// Open enum JSON parsing should reject fractional numeric enum values.
+test "edition open enum rejects fractional json numbers" {
+  try {
+    let _ : @open_enum.State = @json.from_json(Json::number(7.5))
+    fail("expected JsonDecodeError")
+  } catch {
+    @json.JsonDecodeError(_) => ()
+    err => raise err
+  }
+}
+
+///|
+/// Enum-level CLOSED should override the Editions open-enum default.
+test "edition closed enum override rejects unknown enum values" {
+  @debug.assert_eq(
+    @open_enum.ClosedState::from_enum(@protobuf.Enum(7)),
+    @open_enum.ClosedState::CLOSED_STATE_UNSPECIFIED,
+  )
+}
+
+///|
+/// The synthetic open-enum unknown carrier should not collide with real values.
+test "edition open enum unknown carrier avoids generated value name collision" {
+  @debug.assert_eq(
+    @open_enum.UnknownNameState::Unknown.to_enum(),
+    @protobuf.Enum(0),
+  )
+  @debug.assert_eq(
+    @open_enum.UnknownNameState::Unknown1.to_enum(),
+    @protobuf.Enum(2),
+  )
+  let unknown = @open_enum.UnknownNameState::from_enum(@protobuf.Enum(7))
+  @debug.assert_eq(
+    unknown,
+    @open_enum.UnknownNameState::Unknown2(@protobuf.Enum(7)),
+  )
+  @debug.assert_eq(unknown.to_json(), Json::number(7.0))
+}

--- a/test/harness/cases/edition/runner/src/moon.pkg
+++ b/test/harness/cases/edition/runner/src/moon.pkg
@@ -4,7 +4,9 @@ import {
 import {
   "username/harness_edition/harness/edition",
   "username/harness_edition/harness/inherited/file" @file_inherited,
+  "username/harness_edition/harness/open_enum",
   "moonbitlang/protobuf",
   "moonbitlang/core/buffer",
   "moonbitlang/core/debug",
+  "moonbitlang/core/json",
 } for "test"

--- a/test/harness/cases/enum-derive/case.toml
+++ b/test/harness/cases/enum-derive/case.toml
@@ -1,0 +1,4 @@
+generated_project = "harness_enum_derive"
+proto_files = ["enum_derive.proto"]
+options = ["derive=Debug,Eq,Hash,Compare,Arbitrary"]
+test_args = ["test", "src", "--target", "native", "--deny-warn"]

--- a/test/harness/cases/enum-derive/moon.work
+++ b/test/harness/cases/enum-derive/moon.work
@@ -1,0 +1,5 @@
+members = [
+  "../../../../lib",
+  "../../__gen/harness_enum_derive",
+  "runner",
+]

--- a/test/harness/cases/enum-derive/proto/enum_derive.proto
+++ b/test/harness/cases/enum-derive/proto/enum_derive.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package harness.enum_derive;
+
+enum DerivedState {
+  DERIVED_STATE_UNSPECIFIED = 0;
+  DERIVED_STATE_READY = 1;
+}

--- a/test/harness/cases/enum-derive/runner/moon.mod
+++ b/test/harness/cases/enum-derive/runner/moon.mod
@@ -1,0 +1,18 @@
+name = "username/harness_enum_derive_runner"
+
+version = "0.1.0"
+
+import {
+  "moonbitlang/protobuf@0.1.2",
+  "username/harness_enum_derive@0.1.0",
+}
+
+readme = ""
+
+repository = ""
+
+license = ""
+
+keywords = []
+
+description = ""

--- a/test/harness/cases/enum-derive/runner/src/enum_derive_test.mbt
+++ b/test/harness/cases/enum-derive/runner/src/enum_derive_test.mbt
@@ -1,0 +1,7 @@
+///|
+/// Open enum unknown carriers should remain compilable with requested derives.
+test "open enum supports requested arbitrary derive" {
+  let generated : @enum_derive.DerivedState = @quickcheck.gen(size=4)
+  let roundtrip = @enum_derive.DerivedState::from_enum(generated.to_enum())
+  @debug.assert_eq(roundtrip.to_enum(), generated.to_enum())
+}

--- a/test/harness/cases/enum-derive/runner/src/moon.pkg
+++ b/test/harness/cases/enum-derive/runner/src/moon.pkg
@@ -1,0 +1,9 @@
+import {
+}
+
+import {
+  "username/harness_enum_derive/harness/enum_derive",
+  "moonbitlang/protobuf",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/quickcheck",
+} for "test"

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -1,18 +1,20 @@
 pub(all) enum FooEnum {
   FIRST_VALUE
   SECOND_VALUE
+  Unknown(@lib.Enum)
 } derive(Eq, Debug)
 pub fn FooEnum::to_enum(self : FooEnum) -> @lib.Enum {
   match self {
     FooEnum::FIRST_VALUE => 0
     FooEnum::SECOND_VALUE => 2
+    FooEnum::Unknown(value) => value
   }
 }
 pub fn FooEnum::from_enum(i : @lib.Enum) -> FooEnum {
   match i.0 {
     0 => FooEnum::FIRST_VALUE
     2 => FooEnum::SECOND_VALUE
-    _ => Default::default()
+    _ => FooEnum::Unknown(i)
   }
 }
 pub impl Default for FooEnum with fn default() -> FooEnum {
@@ -27,6 +29,12 @@ pub impl @json.FromJson for FooEnum with fn from_json(json: Json, path: @json.Js
     String("SECOND_VALUE") => FooEnum::SECOND_VALUE
     Number(0, ..) => FooEnum::FIRST_VALUE
     Number(2, ..) => FooEnum::SECOND_VALUE
+    Number(value, ..) =>
+      if value.trunc() == value {
+        FooEnum::Unknown(@lib.Enum(value.to_uint()))
+      } else {
+        raise @json.JsonDecodeError((path, "Expected an integer number or string for enum"))
+      }
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
@@ -34,6 +42,7 @@ pub impl ToJson for FooEnum with fn to_json(self : FooEnum) -> Json {
   match self {
     FooEnum::FIRST_VALUE => "FIRST_VALUE"
     FooEnum::SECOND_VALUE => "SECOND_VALUE"
+    FooEnum::Unknown(value) => value.0.to_json()
   }
 }
 pub(all) struct BarMessage {
@@ -837,12 +846,14 @@ pub(all) enum BazMessage_Nested_NestedEnum {
   Foo
   Bar
   Baz
+  Unknown(@lib.Enum)
 } derive(Eq, Debug)
 pub fn BazMessage_Nested_NestedEnum::to_enum(self : BazMessage_Nested_NestedEnum) -> @lib.Enum {
   match self {
     BazMessage_Nested_NestedEnum::Foo => 0
     BazMessage_Nested_NestedEnum::Bar => 1
     BazMessage_Nested_NestedEnum::Baz => 2
+    BazMessage_Nested_NestedEnum::Unknown(value) => value
   }
 }
 pub fn BazMessage_Nested_NestedEnum::from_enum(i : @lib.Enum) -> BazMessage_Nested_NestedEnum {
@@ -850,7 +861,7 @@ pub fn BazMessage_Nested_NestedEnum::from_enum(i : @lib.Enum) -> BazMessage_Nest
     0 => BazMessage_Nested_NestedEnum::Foo
     1 => BazMessage_Nested_NestedEnum::Bar
     2 => BazMessage_Nested_NestedEnum::Baz
-    _ => Default::default()
+    _ => BazMessage_Nested_NestedEnum::Unknown(i)
   }
 }
 pub impl Default for BazMessage_Nested_NestedEnum with fn default() -> BazMessage_Nested_NestedEnum {
@@ -867,6 +878,12 @@ pub impl @json.FromJson for BazMessage_Nested_NestedEnum with fn from_json(json:
     Number(0, ..) => BazMessage_Nested_NestedEnum::Foo
     Number(1, ..) => BazMessage_Nested_NestedEnum::Bar
     Number(2, ..) => BazMessage_Nested_NestedEnum::Baz
+    Number(value, ..) =>
+      if value.trunc() == value {
+        BazMessage_Nested_NestedEnum::Unknown(@lib.Enum(value.to_uint()))
+      } else {
+        raise @json.JsonDecodeError((path, "Expected an integer number or string for enum"))
+      }
     _ =>  raise @json.JsonDecodeError((path, "Expected a number or string for enum"))
   }
 }
@@ -875,6 +892,7 @@ pub impl ToJson for BazMessage_Nested_NestedEnum with fn to_json(self : BazMessa
     BazMessage_Nested_NestedEnum::Foo => "Foo"
     BazMessage_Nested_NestedEnum::Bar => "Bar"
     BazMessage_Nested_NestedEnum::Baz => "Baz"
+    BazMessage_Nested_NestedEnum::Unknown(value) => value.0.to_json()
   }
 }
 pub(all) struct BazMessage_Nested_NestedMessage {


### PR DESCRIPTION
## Summary

- Add a Generator-side enum openness resolver for protobuf Editions feature metadata and syntax defaults.
- Generate `Unknown(@lib.Enum)` variants for open enums so unknown numeric wire and JSON values are preserved.
- Add a focused Editions harness fixture that covers default open enums and an enum-level `features.enum_type = CLOSED` override.

## Root Cause

Open enum fields used the same generated fallback as closed enums: unknown numeric values returned `Default::default()`. That collapsed valid open-enum unknown values during read, write, and JSON conversion.

## Validation

- `moon fmt`
- `moon -C cli check --deny-warn`
- `moon -C lib check --deny-warn`
- `moon -C plugin check --deny-warn`
- `moon -C cli info`
- `python3 -m py_compile scripts/workflow.py`
- `python3 scripts/workflow.py generated-code-test`
- `python3 scripts/workflow.py snapshot-test`

Note: `python3 scripts/workflow.py reader-test --update` also passed earlier while validating the Generator behavior; it refreshes reader fixtures in-place, so I restored unrelated generated reader drift before committing this focused PR.