### PR TITLE
refactor: extract cli descriptor model package

### DIFF
--- a/cli/message_template.mbt
+++ b/cli/message_template.mbt
@@ -4,7 +4,7 @@ fn CodeGenerator::get_moonbit_type(
   field : Field,
   parent_path? : ImportPath,
 ) -> String raise {
-  guard field.type_ is Some(typ) else { raise UnsupportedType("Group") }
+  guard field.type_ is Some(typ) else { raise @model.UnsupportedType("Group") }
   return match typ {
     FieldDescriptorProto_Type::TYPE_DOUBLE => "Double"
     FieldDescriptorProto_Type::TYPE_FLOAT => "Float"
@@ -15,7 +15,8 @@ fn CodeGenerator::get_moonbit_type(
     FieldDescriptorProto_Type::TYPE_FIXED32 => "UInt"
     FieldDescriptorProto_Type::TYPE_BOOL => "Bool"
     FieldDescriptorProto_Type::TYPE_STRING => "String"
-    FieldDescriptorProto_Type::TYPE_GROUP => raise UnsupportedType("Group")
+    FieldDescriptorProto_Type::TYPE_GROUP =>
+      raise @model.UnsupportedType("Group")
     FieldDescriptorProto_Type::TYPE_MESSAGE => {
       let message_name = field.type_name.unwrap()
       if self.find_message(message_name) is Some(message) {
@@ -26,7 +27,7 @@ fn CodeGenerator::get_moonbit_type(
         }
         return message_path.path() |> to_camel_case
       }
-      raise UnsupportedType("Message \{message_name} not found")
+      raise @model.UnsupportedType("Message \{message_name} not found")
     }
     FieldDescriptorProto_Type::TYPE_BYTES => "Bytes"
     FieldDescriptorProto_Type::TYPE_UINT32 => "UInt"
@@ -40,7 +41,7 @@ fn CodeGenerator::get_moonbit_type(
         }
         return enum_path.path() |> to_camel_case
       }
-      raise UnsupportedType("Enum \{enum_name} not found")
+      raise @model.UnsupportedType("Enum \{enum_name} not found")
     }
     FieldDescriptorProto_Type::TYPE_SFIXED32 => "Int"
     FieldDescriptorProto_Type::TYPE_SFIXED64 => "Int64"

--- a/cli/model/moon.pkg
+++ b/cli/model/moon.pkg
@@ -1,0 +1,3 @@
+import {
+  "moonbitlang/plugin/google/protobuf",
+}

--- a/cli/model/pkg.generated.mbti
+++ b/cli/model/pkg.generated.mbti
@@ -1,0 +1,112 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/protoc-gen-mbt/model"
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/plugin/google/protobuf",
+}
+
+// Values
+
+// Errors
+pub(all) suberror GenerateError {
+  UnsupportedType(String)
+  UnexpectedType(String)
+}
+
+// Types and methods
+pub(all) struct Enum {
+  desc : @protobuf.EnumDescriptorProto
+  file : Package?
+  import_path : ImportPath
+  name : String
+  parent : Message?
+  options : @protobuf.EnumOptions?
+  value : Array[@protobuf.EnumValueDescriptorProto]
+} derive(Eq, @debug.Debug)
+pub fn Enum::is_open(Self) -> Bool
+
+pub(all) struct Field {
+  desc : @protobuf.FieldDescriptorProto
+  import_path : ImportPath
+  parent : Message
+  type_ : @protobuf.FieldDescriptorProto_Type?
+  type_name : String?
+  json_name : String?
+  options : @protobuf.FieldOptions?
+  name : String
+  oneof_index : Int?
+  number : Int?
+  proto3optional : Bool?
+} derive(Eq, @debug.Debug)
+pub fn Field::default_value(Self) -> String?
+pub fn Field::is_enum(Self) -> Bool
+pub fn Field::is_list(Self) -> Bool
+pub fn Field::is_map(Self) -> Bool
+pub fn Field::is_message(Self) -> Bool
+pub fn Field::is_oneof(Self) -> Bool
+pub fn Field::is_optional(Self) -> Bool
+pub fn Field::is_pack(Self) -> Bool
+pub fn Field::is_packable_scalar(Self) -> Bool
+pub fn Field::is_synthetic_oneof(Self) -> Bool
+pub fn Field::map_key_value(Self) -> Message?
+
+pub(all) struct ImportPath {
+  path : Array[String]
+  package_name : String
+} derive(Eq, Hash, @debug.Debug)
+pub fn ImportPath::append(Self, String) -> Self
+pub fn ImportPath::from(String, package_name? : String) -> Self
+pub fn ImportPath::has_prefix(Self, Self) -> Bool
+pub fn ImportPath::name(Self) -> String
+pub fn ImportPath::path(Self) -> String
+
+pub(all) struct Message {
+  desc : @protobuf.DescriptorProto
+  import_path : ImportPath
+  name : String
+  file : Package?
+  parent : Message?
+  fields : Array[Field]
+  oneofs : Array[OneOf]
+  messages : Array[Message]
+  enums : Array[Enum]
+  options : @protobuf.MessageOptions?
+} derive(Eq, @debug.Debug)
+pub fn Message::is_map(Self) -> Bool
+
+pub(all) struct OneOf {
+  desc : @protobuf.OneofDescriptorProto
+  import_path : ImportPath
+  file : Package?
+  parent : Message?
+  options : @protobuf.OneofOptions?
+  field : Array[Field]
+  name : String
+} derive(Eq, @debug.Debug)
+
+pub(all) struct Package {
+  desc : @protobuf.FileDescriptorProto
+  message_type : Array[Message]
+  enums : Array[Enum]
+  name : String
+  package_name : String
+  import_path : ImportPath
+  options : @protobuf.FileOptions?
+  dependency : Array[Package]
+  syntax : Syntax
+} derive(Eq, @debug.Debug)
+pub fn Package::find_enum(Self, ImportPath) -> Enum?
+pub fn Package::find_message(Self, ImportPath) -> Message?
+pub fn Package::from(@protobuf.FileDescriptorProto, file_descriptors_map~ : Map[String, Self]) -> Self
+
+pub(all) enum Syntax {
+  Proto2
+  Proto3
+  Editions
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/cli/model/types.mbt
+++ b/cli/model/types.mbt
@@ -2,19 +2,22 @@
 using @protobuf {type FieldDescriptorProto_Type}
 
 ///|
-suberror GenerateError {
+pub(all) suberror GenerateError {
   UnsupportedType(String)
   UnexpectedType(String)
 }
 
 ///|
-struct ImportPath {
+pub(all) struct ImportPath {
   path : Array[String]
   package_name : String
 } derive(Eq, Debug, Hash)
 
 ///|
-fn ImportPath::from(path : String, package_name? : String = "") -> ImportPath {
+pub fn ImportPath::from(
+  path : String,
+  package_name? : String = "",
+) -> ImportPath {
   let parts = path.split(".")
   let import_path = []
   for part in parts {
@@ -27,7 +30,7 @@ fn ImportPath::from(path : String, package_name? : String = "") -> ImportPath {
 }
 
 ///|
-fn ImportPath::has_prefix(self : ImportPath, path : ImportPath) -> Bool {
+pub fn ImportPath::has_prefix(self : ImportPath, path : ImportPath) -> Bool {
   if self.package_name != path.package_name {
     return false
   }
@@ -43,7 +46,7 @@ fn ImportPath::has_prefix(self : ImportPath, path : ImportPath) -> Bool {
 }
 
 ///|
-fn ImportPath::append(self : ImportPath, part : String) -> ImportPath {
+pub fn ImportPath::append(self : ImportPath, part : String) -> ImportPath {
   let new_path = self.path.copy()
   new_path.push_iter(
     part
@@ -54,7 +57,7 @@ fn ImportPath::append(self : ImportPath, part : String) -> ImportPath {
 }
 
 ///|
-fn ImportPath::name(self : ImportPath) -> String {
+pub fn ImportPath::name(self : ImportPath) -> String {
   if self.path.is_empty() {
     return ""
   }
@@ -62,12 +65,12 @@ fn ImportPath::name(self : ImportPath) -> String {
 }
 
 ///|
-fn ImportPath::path(self : ImportPath) -> String {
+pub fn ImportPath::path(self : ImportPath) -> String {
   self.path.join(".")
 }
 
 ///|
-enum Syntax {
+pub(all) enum Syntax {
   Proto2
   Proto3
   Editions
@@ -154,7 +157,7 @@ fn known_feature_enum_type(
 }
 
 ///|
-struct Field {
+pub(all) struct Field {
   desc : @protobuf.FieldDescriptorProto
   import_path : ImportPath
   parent : Message
@@ -189,7 +192,7 @@ fn Field::from(
 }
 
 ///|
-fn Field::is_pack(self : Field) -> Bool {
+pub fn Field::is_pack(self : Field) -> Bool {
   self.repeated_field_encoding() == RepeatedPacked
 }
 
@@ -291,17 +294,17 @@ fn Field::repeated_field_encoding(self : Field) -> RepeatedFieldEncoding {
 }
 
 ///|
-fn Field::is_map(self : Field) -> Bool {
+pub fn Field::is_map(self : Field) -> Bool {
   self.is_list() && self.is_message()
 }
 
 ///|
-fn Field::is_list(self : Field) -> Bool {
+pub fn Field::is_list(self : Field) -> Bool {
   return self.desc.label is Some(LABEL_REPEATED)
 }
 
 ///|
-fn Field::is_packable_scalar(self : Field) -> Bool {
+pub fn Field::is_packable_scalar(self : Field) -> Bool {
   guard self.type_ is Some(type_) else { return false }
   return match type_ {
     FieldDescriptorProto_Type::TYPE_BOOL
@@ -323,22 +326,22 @@ fn Field::is_packable_scalar(self : Field) -> Bool {
 }
 
 ///|
-fn Field::is_message(self : Field) -> Bool {
+pub fn Field::is_message(self : Field) -> Bool {
   return self.desc.type_ is Some(FieldDescriptorProto_Type::TYPE_MESSAGE)
 }
 
 ///|
-fn Field::is_enum(self : Field) -> Bool {
+pub fn Field::is_enum(self : Field) -> Bool {
   return self.desc.type_ is Some(FieldDescriptorProto_Type::TYPE_ENUM)
 }
 
 ///|
-fn Field::is_optional(self : Field) -> Bool {
+pub fn Field::is_optional(self : Field) -> Bool {
   self.field_presence() == PresenceExplicit
 }
 
 ///|
-fn Field::map_key_value(self : Field) -> Message? {
+pub fn Field::map_key_value(self : Field) -> Message? {
   if !self.is_map() {
     return None
   }
@@ -352,7 +355,7 @@ fn Field::map_key_value(self : Field) -> Message? {
 }
 
 ///|
-struct Package {
+pub(all) struct Package {
   desc : @protobuf.FileDescriptorProto
   message_type : Array[Message]
   enums : Array[Enum]
@@ -365,7 +368,7 @@ struct Package {
 } derive(Eq, Debug)
 
 ///|
-fn Package::from(
+pub fn Package::from(
   desc : @protobuf.FileDescriptorProto,
   file_descriptors_map~ : Map[String, Package],
 ) -> Package {
@@ -431,7 +434,7 @@ fn Package::feature_enum_type(self : Package) -> @protobuf.FeatureSet_EnumType? 
 }
 
 ///|
-fn Package::find_message(self : Package, path : ImportPath) -> Message? {
+pub fn Package::find_message(self : Package, path : ImportPath) -> Message? {
   if !path.has_prefix(self.import_path) {
     return None
   }
@@ -444,7 +447,7 @@ fn Package::find_message(self : Package, path : ImportPath) -> Message? {
 }
 
 ///|
-fn Package::find_enum(self : Package, path : ImportPath) -> Enum? {
+pub fn Package::find_enum(self : Package, path : ImportPath) -> Enum? {
   if !path.has_prefix(self.import_path) {
     return None
   }
@@ -462,7 +465,7 @@ fn Package::find_enum(self : Package, path : ImportPath) -> Enum? {
 }
 
 ///|
-struct Enum {
+pub(all) struct Enum {
   desc : @protobuf.EnumDescriptorProto
   file : Package?
   import_path : ImportPath
@@ -551,12 +554,12 @@ fn Enum::openness(self : Enum) -> EnumOpenness {
 }
 
 ///|
-fn Enum::is_open(self : Enum) -> Bool {
+pub fn Enum::is_open(self : Enum) -> Bool {
   self.openness() == EnumOpen
 }
 
 ///|
-struct OneOf {
+pub(all) struct OneOf {
   desc : @protobuf.OneofDescriptorProto
   import_path : ImportPath
   file : Package?
@@ -584,7 +587,7 @@ fn OneOf::from_message(
 }
 
 ///|
-struct Message {
+pub(all) struct Message {
   desc : @protobuf.DescriptorProto
   import_path : ImportPath
   name : String
@@ -681,7 +684,7 @@ fn Message::child(
 }
 
 ///|
-fn Message::is_map(self : Message) -> Bool {
+pub fn Message::is_map(self : Message) -> Bool {
   return self.options is Some(options) && options.map_entry is Some(true)
 }
 
@@ -713,17 +716,17 @@ fn Message::find_message(self : Message, path : ImportPath) -> Message? {
 }
 
 ///|
-fn Field::is_oneof(self : Field) -> Bool {
+pub fn Field::is_oneof(self : Field) -> Bool {
   return self.oneof_index is Some(_) && self.proto3optional is None
 }
 
 ///|
-fn Field::is_synthetic_oneof(self : Field) -> Bool {
+pub fn Field::is_synthetic_oneof(self : Field) -> Bool {
   return self.oneof_index is Some(_) && self.proto3optional is Some(true)
 }
 
 ///|
-fn Field::default_value(self : Field) -> String? {
+pub fn Field::default_value(self : Field) -> String? {
   self.desc.default_value
 }
 

--- a/cli/model_imports.mbt
+++ b/cli/model_imports.mbt
@@ -1,0 +1,12 @@
+///|
+using @protobuf {type FieldDescriptorProto_Type}
+
+///|
+using @model {
+  type Enum,
+  type Field,
+  type ImportPath,
+  type Message,
+  type OneOf,
+  type Package,
+}

--- a/cli/moon.pkg
+++ b/cli/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/plugin/google/protobuf/compiler",
   "moonbitlang/plugin/google/protobuf",
+  "moonbitlang/protoc-gen-mbt/model",
   "moonbitlang/protobuf" @lib,
   "moonbitlang/async",
   "moonbitlang/async/stdio",

--- a/cli/pkg.generated.mbti
+++ b/cli/pkg.generated.mbti
@@ -2,40 +2,24 @@
 package "moonbitlang/protoc-gen-mbt"
 
 import {
-  "moonbitlang/core/debug",
   "moonbitlang/plugin/google/protobuf/compiler",
 }
 
 // Values
 
 // Errors
-type GenerateError
 
 // Types and methods
 type CodeGenerator
 pub fn CodeGenerator::generate(Self) -> @compiler.CodeGeneratorResponse
 
-type Enum derive(Eq, @debug.Debug)
-
-type Field derive(Eq, @debug.Debug)
-
 type File
 
 type ImportNameAlias
 
-type ImportPath derive(Eq, Hash, @debug.Debug)
-
-type Message derive(Eq, @debug.Debug)
-
-type OneOf derive(Eq, @debug.Debug)
-
-type Package derive(Eq, @debug.Debug)
-
 type Stdin
 
 type Stdout
-
-type Syntax derive(Eq, @debug.Debug)
 
 // Type aliases
 

--- a/cli/reader_template.mbt
+++ b/cli/reader_template.mbt
@@ -111,7 +111,7 @@ fn CodeGenerator::gen_repeated_field_read(
       FieldDescriptorProto_Type::TYPE_SFIXED32
       | FieldDescriptorProto_Type::TYPE_FIXED32
       | FieldDescriptorProto_Type::TYPE_FLOAT => 5
-      _ => raise UnexpectedType("unexpected packable field type")
+      _ => raise @model.UnexpectedType("unexpected packable field type")
     }
     let packed_size = match kind {
       FieldDescriptorProto_Type::TYPE_BOOL
@@ -128,7 +128,7 @@ fn CodeGenerator::gen_repeated_field_read(
       FieldDescriptorProto_Type::TYPE_SFIXED32
       | FieldDescriptorProto_Type::TYPE_FIXED32
       | FieldDescriptorProto_Type::TYPE_FLOAT => "Some(4)"
-      _ => raise UnexpectedType("unexpected packable field type")
+      _ => raise @model.UnexpectedType("unexpected packable field type")
     }
     let packed_reader = packed_kind_read_func(kind, is_async~)
     let packed_read = "reader |> @lib.\{async_keyword_to_snake}read_packed(\{packed_reader}, \{packed_size})"
@@ -221,10 +221,12 @@ fn kind_read_func(
     FieldDescriptorProto_Type::TYPE_DOUBLE => "@lib.\{async_keyword}read_double"
     FieldDescriptorProto_Type::TYPE_STRING => "@lib.\{async_keyword}read_string"
     FieldDescriptorProto_Type::TYPE_BYTES => "@lib.\{async_keyword}read_bytes"
-    FieldDescriptorProto_Type::TYPE_ENUM => raise UnsupportedType("enum type")
+    FieldDescriptorProto_Type::TYPE_ENUM =>
+      raise @model.UnsupportedType("enum type")
     FieldDescriptorProto_Type::TYPE_MESSAGE =>
-      raise UnexpectedType("message type")
-    FieldDescriptorProto_Type::TYPE_GROUP => raise UnsupportedType("Group")
+      raise @model.UnexpectedType("message type")
+    FieldDescriptorProto_Type::TYPE_GROUP =>
+      raise @model.UnsupportedType("Group")
   }
 }
 
@@ -257,6 +259,7 @@ fn gen_kind_read(
       "reader |> @lib.\{async_keyword}read_enum() |> \{type_name}::from_enum"
     FieldDescriptorProto_Type::TYPE_MESSAGE =>
       "(reader |> @lib.\{async_keyword}read_message() : \{type_name})"
-    FieldDescriptorProto_Type::TYPE_GROUP => raise UnsupportedType("Group")
+    FieldDescriptorProto_Type::TYPE_GROUP =>
+      raise @model.UnsupportedType("Group")
   }
 }

--- a/cli/size_template.mbt
+++ b/cli/size_template.mbt
@@ -84,7 +84,7 @@ fn CodeGenerator::gen_message_size(
             let tag_size = size_tag(field_number)
             "\{tag_size}U + { let size = self.\{field_name}.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }"
           }
-          _ => raise UnsupportedType("unexpected packed field type")
+          _ => raise @model.UnsupportedType("unexpected packed field type")
         }
         content.write_string("  size += \{delta_size}\n")
       }

--- a/cli/writer_template.mbt
+++ b/cli/writer_template.mbt
@@ -58,7 +58,7 @@ fn CodeGenerator::gen_message_writer(
           content.write_string(
             "  let size = self.\{field_name}.iter().map(@lib.size_of).fold(init=0U, UInt::add)\n",
           )
-        _ => raise UnexpectedType("unexpected packed field type")
+        _ => raise @model.UnexpectedType("unexpected packed field type")
       }
       let field_write_type = self.gen_kind_write(field, "item", is_async~)
       content.write_string(
@@ -244,7 +244,9 @@ fn CodeGenerator::gen_kind_write(
   is_async? : Bool = false,
 ) -> String raise {
   guard field.type_ is Some(field_type) else {
-    raise UnexpectedType("Field type is not set: \{field.import_path.name()}")
+    raise @model.UnexpectedType(
+      "Field type is not set: \{field.import_path.name()}",
+    )
   }
   let async_keyword = if is_async { "async_" } else { "" }
   let async_kewyord_to_title = if is_async { "Async" } else { "" }
@@ -283,6 +285,6 @@ fn CodeGenerator::gen_kind_write(
       "writer |> @lib.\{async_keyword}write_uint64(\{variable})\n"
     FieldDescriptorProto_Type::TYPE_ENUM =>
       "writer |> @lib.\{async_keyword}write_enum(\{variable}.to_enum())\n"
-    _ => raise UnexpectedType("unsupported field type")
+    _ => raise @model.UnexpectedType("unsupported field type")
   }
 }


### PR DESCRIPTION
## Summary
- Move descriptor/model types from the CLI executable package into `moonbitlang/protoc-gen-mbt/model`.
- Import the model package from the CLI and keep generated CLI public interface focused on generator entry points.
- Qualify model-owned generation errors at the package boundary.

## Verification
- `moon check --target native --deny-warn`
- `moon test --target native --deny-warn`
- `git diff --check`