### PR TITLE
fix: resolve protobuf feature behavior

### DIFF
--- a/cli/model/pkg.generated.mbti
+++ b/cli/model/pkg.generated.mbti
@@ -50,6 +50,7 @@ pub fn Field::is_pack(Self) -> Bool
 pub fn Field::is_packable_scalar(Self) -> Bool
 pub fn Field::is_synthetic_oneof(Self) -> Bool
 pub fn Field::map_key_value(Self) -> Message?
+pub fn Field::omits_default_value(Self) -> Bool
 
 pub(all) struct ImportPath {
   path : Array[String]

--- a/cli/model/types.mbt
+++ b/cli/model/types.mbt
@@ -98,14 +98,14 @@ priv enum EnumOpenness {
 ///|
 fn known_feature_field_presence(
   features : @protobuf.FeatureSet?,
-) -> @protobuf.FeatureSet_FieldPresence? {
+) -> FieldPresence? {
   match features {
     Some(
       { field_presence: Some(@protobuf.FeatureSet_FieldPresence::EXPLICIT), .. }
-    ) => Some(@protobuf.FeatureSet_FieldPresence::EXPLICIT)
+    ) => Some(PresenceExplicit)
     Some(
       { field_presence: Some(@protobuf.FeatureSet_FieldPresence::IMPLICIT), .. }
-    ) => Some(@protobuf.FeatureSet_FieldPresence::IMPLICIT)
+    ) => Some(PresenceImplicit)
     Some(
       {
         field_presence: Some(
@@ -113,7 +113,7 @@ fn known_feature_field_presence(
         ),
         ..,
       }
-    ) => Some(@protobuf.FeatureSet_FieldPresence::LEGACY_REQUIRED)
+    ) => Some(PresenceRequired)
     _ => None
   }
 }
@@ -121,7 +121,7 @@ fn known_feature_field_presence(
 ///|
 fn known_feature_repeated_field_encoding(
   features : @protobuf.FeatureSet?,
-) -> @protobuf.FeatureSet_RepeatedFieldEncoding? {
+) -> RepeatedFieldEncoding? {
   match features {
     Some(
       {
@@ -130,7 +130,7 @@ fn known_feature_repeated_field_encoding(
         ),
         ..,
       }
-    ) => Some(@protobuf.FeatureSet_RepeatedFieldEncoding::PACKED)
+    ) => Some(RepeatedPacked)
     Some(
       {
         repeated_field_encoding: Some(
@@ -138,7 +138,7 @@ fn known_feature_repeated_field_encoding(
         ),
         ..,
       }
-    ) => Some(@protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED)
+    ) => Some(RepeatedExpanded)
     _ => None
   }
 }
@@ -197,30 +197,45 @@ pub fn Field::is_pack(self : Field) -> Bool {
 }
 
 ///|
-fn Field::feature_field_presence(
-  self : Field,
-) -> @protobuf.FeatureSet_FieldPresence? {
-  let field_feature = match self.options {
-    Some({ features, .. }) => known_feature_field_presence(features)
-    None => None
+fn Field::feature_field_presence(self : Field) -> FieldPresence {
+  if self.desc.label is Some(LABEL_REQUIRED) {
+    return PresenceRequired
   }
-  match field_feature {
-    Some(presence) => Some(presence)
-    None =>
-      match self.parent.file {
-        Some(file) => file.feature_field_presence()
-        None => None
-      }
+  if self.desc.proto3_optional is Some(true) {
+    return PresenceExplicit
+  }
+  if self.options is Some({ features, .. }) {
+    if known_feature_field_presence(features) is Some(presence) {
+      return presence
+    }
+  }
+  if self.parent.file is Some(file) {
+    file.feature_field_presence()
+  } else if self.desc.label is Some(LABEL_OPTIONAL) {
+    PresenceExplicit
+  } else {
+    PresenceImplicit
   }
 }
 
 ///|
-fn Field::own_feature_repeated_field_encoding(
+fn Field::feature_repeated_field_encoding(
   self : Field,
-) -> @protobuf.FeatureSet_RepeatedFieldEncoding? {
-  match self.options {
-    Some({ features, .. }) => known_feature_repeated_field_encoding(features)
-    _ => None
+) -> RepeatedFieldEncoding {
+  if self.options is Some({ features, .. }) {
+    if known_feature_repeated_field_encoding(features) is Some(encoding) {
+      return encoding
+    }
+  }
+  match self.desc.options {
+    Some({ packed: Some(true), .. }) => return RepeatedPacked
+    Some({ packed: Some(false), .. }) => return RepeatedExpanded
+    _ => ()
+  }
+  if self.parent.file is Some(file) {
+    file.feature_repeated_field_encoding()
+  } else {
+    RepeatedExpanded
   }
 }
 
@@ -229,37 +244,14 @@ fn Field::field_presence(self : Field) -> FieldPresence {
   if self.is_list() {
     return PresenceImplicit
   }
-  match self.feature_field_presence() {
-    Some(@protobuf.FeatureSet_FieldPresence::EXPLICIT) => PresenceExplicit
-    Some(@protobuf.FeatureSet_FieldPresence::IMPLICIT) => PresenceImplicit
-    Some(@protobuf.FeatureSet_FieldPresence::LEGACY_REQUIRED) =>
-      PresenceRequired
-    _ =>
-      if self.parent.file is Some(file) {
-        match file.syntax {
-          Proto3 =>
-            if self.desc.proto3_optional is Some(true) {
-              PresenceExplicit
-            } else {
-              PresenceImplicit
-            }
-          Proto2 =>
-            if self.desc.label is Some(LABEL_REQUIRED) {
-              PresenceRequired
-            } else if self.desc.label is Some(LABEL_OPTIONAL) {
-              PresenceExplicit
-            } else {
-              PresenceImplicit
-            }
-          Editions => PresenceExplicit
-        }
-      } else if self.desc.proto3_optional is Some(true) ||
-        self.desc.label is Some(LABEL_OPTIONAL) {
-        PresenceExplicit
-      } else {
-        PresenceImplicit
-      }
+  let presence = self.feature_field_presence()
+  if presence == PresenceRequired {
+    return PresenceRequired
   }
+  if self.is_message() || self.is_oneof() {
+    return PresenceExplicit
+  }
+  presence
 }
 
 ///|
@@ -267,30 +259,7 @@ fn Field::repeated_field_encoding(self : Field) -> RepeatedFieldEncoding {
   if !self.is_list() || !self.is_packable_scalar() {
     return RepeatedExpanded
   }
-  match self.own_feature_repeated_field_encoding() {
-    Some(@protobuf.FeatureSet_RepeatedFieldEncoding::PACKED) =>
-      return RepeatedPacked
-    Some(@protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED) =>
-      return RepeatedExpanded
-    _ => ()
-  }
-  match self.desc.options {
-    Some({ packed: Some(true), .. }) => return RepeatedPacked
-    Some({ packed: Some(false), .. }) => return RepeatedExpanded
-    _ => ()
-  }
-  guard self.parent.file is Some(file) else { return RepeatedExpanded }
-  match file.feature_repeated_field_encoding() {
-    Some(@protobuf.FeatureSet_RepeatedFieldEncoding::PACKED) =>
-      return RepeatedPacked
-    Some(@protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED) =>
-      return RepeatedExpanded
-    _ => ()
-  }
-  match file.syntax {
-    Proto3 | Editions => RepeatedPacked
-    Proto2 => RepeatedExpanded
-  }
+  self.feature_repeated_field_encoding()
 }
 
 ///|
@@ -338,6 +307,11 @@ pub fn Field::is_enum(self : Field) -> Bool {
 ///|
 pub fn Field::is_optional(self : Field) -> Bool {
   self.field_presence() == PresenceExplicit
+}
+
+///|
+pub fn Field::omits_default_value(self : Field) -> Bool {
+  self.field_presence() == PresenceImplicit
 }
 
 ///|
@@ -406,22 +380,30 @@ pub fn Package::from(
 }
 
 ///|
-fn Package::feature_field_presence(
-  self : Package,
-) -> @protobuf.FeatureSet_FieldPresence? {
-  match self.options {
-    Some({ features, .. }) => known_feature_field_presence(features)
-    _ => None
+fn Package::feature_field_presence(self : Package) -> FieldPresence {
+  if self.options is Some({ features, .. }) {
+    if known_feature_field_presence(features) is Some(presence) {
+      return presence
+    }
+  }
+  match self.syntax {
+    Proto3 => PresenceImplicit
+    Proto2 | Editions => PresenceExplicit
   }
 }
 
 ///|
 fn Package::feature_repeated_field_encoding(
   self : Package,
-) -> @protobuf.FeatureSet_RepeatedFieldEncoding? {
-  match self.options {
-    Some({ features, .. }) => known_feature_repeated_field_encoding(features)
-    _ => None
+) -> RepeatedFieldEncoding {
+  if self.options is Some({ features, .. }) {
+    if known_feature_repeated_field_encoding(features) is Some(encoding) {
+      return encoding
+    }
+  }
+  match self.syntax {
+    Proto3 | Editions => RepeatedPacked
+    Proto2 => RepeatedExpanded
   }
 }
 

--- a/cli/size_template.mbt
+++ b/cli/size_template.mbt
@@ -86,7 +86,14 @@ fn CodeGenerator::gen_message_size(
           }
           _ => raise @model.UnsupportedType("unexpected packed field type")
         }
-        content.write_string("  size += \{delta_size}\n")
+        content.write_string(
+          (
+            $|  if !self.\{field_name}.is_empty() {
+            $|    size += \{delta_size}
+            $|  }
+            $|
+          ),
+        )
       }
     } else if field.map_key_value() is Some(map_entry) {
       let key_field = map_entry.fields[0]
@@ -156,7 +163,18 @@ fn CodeGenerator::gen_message_size(
         "self.\{field_name}",
         size_tag(field_number),
       )
-      content.write_string("  size += \{delta_size}\n")
+      if field.omits_default_value() {
+        content.write_string(
+          (
+            $|  if self.\{field_name} != Default::default() {
+            $|    size += \{delta_size}
+            $|  }
+            $|
+          ),
+        )
+      } else {
+        content.write_string("  size += \{delta_size}\n")
+      }
     }
   }
   for oneof in message.oneofs {

--- a/cli/writer_template.mbt
+++ b/cli/writer_template.mbt
@@ -27,8 +27,9 @@ fn CodeGenerator::gen_message_writer(
     let field_number = field.number.unwrap()
     if field.is_pack() {
       let tag_val = tag(field.type_.unwrap(), field_number, true)
+      content.write_string("  if !self.\{field_name}.is_empty() {\n")
       content.write_string(
-        "  writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL)\n",
+        "    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL)\n",
       )
       match field.type_.unwrap() {
         FieldDescriptorProto_Type::TYPE_FIXED32
@@ -36,7 +37,7 @@ fn CodeGenerator::gen_message_writer(
         | FieldDescriptorProto_Type::TYPE_FLOAT => {
           let fixed_size = sizeFixed32()
           content.write_string(
-            "  let size = self.\{field_name}.length().reinterpret_as_uint() * \{fixed_size}\n",
+            "    let size = self.\{field_name}.length().reinterpret_as_uint() * \{fixed_size}\n",
           )
         }
         FieldDescriptorProto_Type::TYPE_FIXED64
@@ -44,7 +45,7 @@ fn CodeGenerator::gen_message_writer(
         | FieldDescriptorProto_Type::TYPE_DOUBLE => {
           let fixed_size = sizeFixed64()
           content.write_string(
-            "  let size = self.\{field_name}.length().reinterpret_as_uint() * \{fixed_size}\n",
+            "    let size = self.\{field_name}.length().reinterpret_as_uint() * \{fixed_size}\n",
           )
         }
         FieldDescriptorProto_Type::TYPE_INT32
@@ -56,16 +57,17 @@ fn CodeGenerator::gen_message_writer(
         | FieldDescriptorProto_Type::TYPE_BOOL
         | FieldDescriptorProto_Type::TYPE_ENUM =>
           content.write_string(
-            "  let size = self.\{field_name}.iter().map(@lib.size_of).fold(init=0U, UInt::add)\n",
+            "    let size = self.\{field_name}.iter().map(@lib.size_of).fold(init=0U, UInt::add)\n",
           )
         _ => raise @model.UnexpectedType("unexpected packed field type")
       }
       let field_write_type = self.gen_kind_write(field, "item", is_async~)
       content.write_string(
         (
-          $|  writer |> @lib.\{async_keyword_to_snake}write_uint32(size)
-          $|  for item in self.\{field_name} {
-          $|      \{field_write_type}
+          $|    writer |> @lib.\{async_keyword_to_snake}write_uint32(size)
+          $|    for item in self.\{field_name} {
+          $|        \{field_write_type}
+          $|    }
           $|  }
           $|
         ),
@@ -198,12 +200,18 @@ fn CodeGenerator::gen_message_writer(
         is_async~,
       )
       let tag_val = tag(field.type_.unwrap(), field_number, false)
-      content.write_string(
-        (
-          $|  writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL);
-          $|  \{field_write_type}
-        ),
-      )
+      let field_write =
+        $|  writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL);
+        $|  \{field_write_type}
+      if field.omits_default_value() {
+        content.write_string(
+          "  if self.\{field_name} != Default::default() {\n",
+        )
+        content.write_string(field_write)
+        content.write_string("  }\n")
+      } else {
+        content.write_string(field_write)
+      }
     }
   }
   for oneof in message.oneofs {

--- a/plugin/src/google/protobuf/compiler/top.mbt
+++ b/plugin/src/google/protobuf/compiler/top.mbt
@@ -189,8 +189,11 @@ pub(all) struct CodeGeneratorRequest {
 pub impl @lib.Sized for CodeGeneratorRequest with fn size_of(self) {
   let mut size = 0U
   for s in self.file_to_generate {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.parameter is Some(v) {
     size += 1U +
@@ -200,12 +203,18 @@ pub impl @lib.Sized for CodeGeneratorRequest with fn size_of(self) {
       })
   }
   for s in self.proto_file {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.source_file_descriptors {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.compiler_version is Some(v) {
     size += 1U +
@@ -740,8 +749,11 @@ pub impl @lib.Sized for CodeGeneratorResponse with fn size_of(self) {
     size += 1U + @lib.size_of(v)
   }
   for s in self.file {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }

--- a/plugin/src/google/protobuf/top.mbt
+++ b/plugin/src/google/protobuf/top.mbt
@@ -191,8 +191,11 @@ pub(all) struct FileDescriptorSet {
 pub impl @lib.Sized for FileDescriptorSet with fn size_of(self) {
   let mut size = 0U
   for s in self.file {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -341,36 +344,52 @@ pub impl @lib.Sized for FileDescriptorProto with fn size_of(self) {
       })
   }
   for s in self.dependency {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.public_dependency {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + @lib.size_of(s)
   }
   for s in self.weak_dependency {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U + @lib.size_of(s)
   }
   for s in self.option_dependency {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.message_type {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.enum_type {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.service {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.extension {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.options is Some(v) {
     size += 1U +
@@ -1139,28 +1158,46 @@ pub impl @lib.Sized for DescriptorProto with fn size_of(self) {
       })
   }
   for s in self.field {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.extension {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.nested_type {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.enum_type {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.extension_range {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.oneof_decl {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.options is Some(v) {
     size += 1U +
@@ -1170,12 +1207,18 @@ pub impl @lib.Sized for DescriptorProto with fn size_of(self) {
       })
   }
   for s in self.reserved_range {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.reserved_name {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.visibility is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -1838,12 +1881,18 @@ pub(all) struct ExtensionRangeOptions {
 pub impl @lib.Sized for ExtensionRangeOptions with fn size_of(self) {
   let mut size = 0U
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.declaration {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.features is Some(v) {
     size += 2U +
@@ -2988,8 +3037,11 @@ pub impl @lib.Sized for EnumDescriptorProto with fn size_of(self) {
       })
   }
   for s in self.value {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.options is Some(v) {
     size += 1U +
@@ -2999,12 +3051,18 @@ pub impl @lib.Sized for EnumDescriptorProto with fn size_of(self) {
       })
   }
   for s in self.reserved_range {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.reserved_name {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.visibility is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -3432,8 +3490,11 @@ pub impl @lib.Sized for ServiceDescriptorProto with fn size_of(self) {
       })
   }
   for s in self.method_ {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.options is Some(v) {
     size += 1U +
@@ -4056,8 +4117,11 @@ pub impl @lib.Sized for FileOptions with fn size_of(self) {
       })
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -4629,8 +4693,11 @@ pub impl @lib.Sized for MessageOptions with fn size_of(self) {
       })
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -5634,12 +5701,14 @@ pub impl @lib.Sized for FieldOptions with fn size_of(self) {
     size += 2U + @lib.size_of(v)
   }
   for s in self.targets {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + @lib.size_of(s)
   }
   for s in self.edition_defaults {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.features is Some(v) {
     size += 2U +
@@ -5656,8 +5725,11 @@ pub impl @lib.Sized for FieldOptions with fn size_of(self) {
       })
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -6101,8 +6173,11 @@ pub impl @lib.Sized for OneofOptions with fn size_of(self) {
       })
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -6266,8 +6341,11 @@ pub impl @lib.Sized for EnumOptions with fn size_of(self) {
       })
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -6506,8 +6584,11 @@ pub impl @lib.Sized for EnumValueOptions with fn size_of(self) {
       })
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -6736,8 +6817,11 @@ pub impl @lib.Sized for ServiceOptions with fn size_of(self) {
     size += 2U + @lib.size_of(v)
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -6991,8 +7075,11 @@ pub impl @lib.Sized for MethodOptions with fn size_of(self) {
       })
   }
   for s in self.uninterpreted_option {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -7325,8 +7412,11 @@ pub(all) struct UninterpretedOption {
 pub impl @lib.Sized for UninterpretedOption with fn size_of(self) {
   let mut size = 0U
   for s in self.name {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.identifier_value is Some(v) {
     size += 1U +
@@ -8811,8 +8901,11 @@ pub(all) struct FeatureSetDefaults {
 pub impl @lib.Sized for FeatureSetDefaults with fn size_of(self) {
   let mut size = 0U
   for s in self.defaults {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.minimum_edition is Some(v) {
     size += 1U + @lib.size_of(v)
@@ -9003,16 +9096,20 @@ pub(all) struct SourceCodeInfo_Location {
 ///|
 pub impl @lib.Sized for SourceCodeInfo_Location with fn size_of(self) {
   let mut size = 0U
-  size += 1U +
-    ({
-      let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-      @lib.size_of(size) + size
-    })
-  size += 1U +
-    ({
-      let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-      @lib.size_of(size) + size
-    })
+  if !self.path.is_empty() {
+    size += 1U +
+      ({
+        let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+        @lib.size_of(size) + size
+      })
+  }
+  if !self.span.is_empty() {
+    size += 1U +
+      ({
+        let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+        @lib.size_of(size) + size
+      })
+  }
   if self.leading_comments is Some(v) {
     size += 1U +
       ({
@@ -9028,8 +9125,11 @@ pub impl @lib.Sized for SourceCodeInfo_Location with fn size_of(self) {
       })
   }
   for s in self.leading_detached_comments {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -9099,17 +9199,21 @@ pub impl @lib.Write for SourceCodeInfo_Location with fn write(
   self : SourceCodeInfo_Location,
   writer : &@lib.Writer,
 ) -> Unit raise {
-  writer |> @lib.write_varint(10UL)
-  let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.path {
-    writer |> @lib.write_int32(item)
+  if !self.path.is_empty() {
+    writer |> @lib.write_varint(10UL)
+    let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.path {
+      writer |> @lib.write_int32(item)
+    }
   }
-  writer |> @lib.write_varint(18UL)
-  let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.span {
-    writer |> @lib.write_int32(item)
+  if !self.span.is_empty() {
+    writer |> @lib.write_varint(18UL)
+    let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.span {
+      writer |> @lib.write_int32(item)
+    }
   }
   if self.leading_comments is Some(v) {
     writer |> @lib.write_varint(26UL)
@@ -9218,17 +9322,21 @@ pub impl @lib.AsyncWrite for SourceCodeInfo_Location with fn write(
   self : SourceCodeInfo_Location,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL)
-  let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.path {
-    writer |> @lib.async_write_int32(item)
+  if !self.path.is_empty() {
+    writer |> @lib.async_write_varint(10UL)
+    let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.path {
+      writer |> @lib.async_write_int32(item)
+    }
   }
-  writer |> @lib.async_write_varint(18UL)
-  let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.span {
-    writer |> @lib.async_write_int32(item)
+  if !self.span.is_empty() {
+    writer |> @lib.async_write_varint(18UL)
+    let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.span {
+      writer |> @lib.async_write_int32(item)
+    }
   }
   if self.leading_comments is Some(v) {
     writer |> @lib.async_write_varint(26UL)
@@ -9253,8 +9361,11 @@ pub(all) struct SourceCodeInfo {
 pub impl @lib.Sized for SourceCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.location {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -9451,11 +9562,13 @@ pub(all) struct GeneratedCodeInfo_Annotation {
 ///|
 pub impl @lib.Sized for GeneratedCodeInfo_Annotation with fn size_of(self) {
   let mut size = 0U
-  size += 1U +
-    ({
-      let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-      @lib.size_of(size) + size
-    })
+  if !self.path.is_empty() {
+    size += 1U +
+      ({
+        let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+        @lib.size_of(size) + size
+      })
+  }
   if self.source_file is Some(v) {
     size += 1U +
       ({
@@ -9533,11 +9646,13 @@ pub impl @lib.Write for GeneratedCodeInfo_Annotation with fn write(
   self : GeneratedCodeInfo_Annotation,
   writer : &@lib.Writer,
 ) -> Unit raise {
-  writer |> @lib.write_varint(10UL)
-  let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.path {
-    writer |> @lib.write_int32(item)
+  if !self.path.is_empty() {
+    writer |> @lib.write_varint(10UL)
+    let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.path {
+      writer |> @lib.write_int32(item)
+    }
   }
   if self.source_file is Some(v) {
     writer |> @lib.write_varint(18UL)
@@ -9645,11 +9760,13 @@ pub impl @lib.AsyncWrite for GeneratedCodeInfo_Annotation with fn write(
   self : GeneratedCodeInfo_Annotation,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL)
-  let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.path {
-    writer |> @lib.async_write_int32(item)
+  if !self.path.is_empty() {
+    writer |> @lib.async_write_varint(10UL)
+    let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.path {
+      writer |> @lib.async_write_int32(item)
+    }
   }
   if self.source_file is Some(v) {
     writer |> @lib.async_write_varint(18UL)
@@ -9678,8 +9795,11 @@ pub(all) struct GeneratedCodeInfo {
 pub impl @lib.Sized for GeneratedCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.annotation {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }

--- a/test/harness/cases/edition/proto/edition.proto
+++ b/test/harness/cases/edition/proto/edition.proto
@@ -6,4 +6,5 @@ message Payload {
   repeated int32 values = 1 [features.repeated_field_encoding = EXPANDED];
   int32 implicit_value = 2 [features.field_presence = IMPLICIT];
   int32 explicit_value = 3;
+  repeated int32 packed_values = 4;
 }

--- a/test/harness/cases/edition/proto/inherited_file.proto
+++ b/test/harness/cases/edition/proto/inherited_file.proto
@@ -5,9 +5,14 @@ package harness.inherited.file;
 option features.field_presence = IMPLICIT;
 option features.repeated_field_encoding = EXPANDED;
 
+message FileChild {
+  int32 value = 1;
+}
+
 message FilePresence {
   int32 scalar = 1;
   int32 explicit_scalar = 2 [features.field_presence = EXPLICIT];
+  FileChild child = 3;
 }
 
 message FileRepeatedEncoding {

--- a/test/harness/cases/edition/runner/src/edition_test.mbt
+++ b/test/harness/cases/edition/runner/src/edition_test.mbt
@@ -14,12 +14,22 @@ test "edition expanded repeated scalar size matches writer" {
 }
 
 ///|
+/// Implicit default values and empty packed fields should not be serialized.
+test "edition default payload emits empty wire output" {
+  let message = @edition.Payload::default()
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"")
+  @debug.assert_eq(@protobuf.size_of(message), 0U)
+}
+
+///|
 /// Edition presence features should decide whether generated fields use `?`.
 test "edition field presence controls generated shape" {
-  let message = @edition.Payload::new([], 7)
+  let message = @edition.Payload::new([], 7, [])
   @debug.assert_eq(message.implicit_value, 7)
   @debug.assert_eq(message.explicit_value, None)
-  let with_explicit = @edition.Payload::new([], 7, explicit_value=9)
+  let with_explicit = @edition.Payload::new([], 7, [], explicit_value=9)
   @debug.assert_eq(with_explicit.explicit_value, Some(9))
 }
 
@@ -29,8 +39,15 @@ test "edition file inherited field presence controls generated shape" {
   let message = @file_inherited.FilePresence::new(7)
   @debug.assert_eq(message.scalar, 7)
   @debug.assert_eq(message.explicit_scalar, None)
-  let with_explicit = @file_inherited.FilePresence::new(7, explicit_scalar=9)
+  @debug.assert_eq(message.child, None)
+  let child = @file_inherited.FileChild::new(1)
+  let with_explicit = @file_inherited.FilePresence::new(
+    7,
+    explicit_scalar=9,
+    child~,
+  )
   @debug.assert_eq(with_explicit.explicit_scalar, Some(9))
+  @debug.assert_eq(with_explicit.child, Some(child))
 }
 
 ///|

--- a/test/harness/cases/size/proto/size.proto
+++ b/test/harness/cases/size/proto/size.proto
@@ -5,4 +5,5 @@ package harness.size;
 message Payload {
   repeated int32 values = 1 [packed = false];
   string tail = 2;
+  repeated int32 packed_values = 3;
 }

--- a/test/harness/cases/size/runner/src/size_test.mbt
+++ b/test/harness/cases/size/runner/src/size_test.mbt
@@ -12,3 +12,13 @@ test "sized matches writer for unpacked repeated scalar" {
     writer.to_bytes().length().reinterpret_as_uint(),
   )
 }
+
+///|
+/// Proto3 implicit defaults and empty packed repeated fields should not emit bytes.
+test "proto3 default payload emits empty wire output" {
+  let message = @size.Payload::default()
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"")
+  @debug.assert_eq(@protobuf.size_of(message), 0U)
+}

--- a/test/reader/gen_proto2/src/top.mbt
+++ b/test/reader/gen_proto2/src/top.mbt
@@ -264,22 +264,26 @@ pub impl @lib.Sized for FooMessageP2 with fn size_of(self) {
       })
   }
   for s in self.f_repeated_int32 {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + @lib.size_of(s)
   }
-  size += 2U +
-    ({
-      let size = self.f_repeated_packed_int32
-        .iter()
-        .map(@lib.size_of)
-        .fold(init=0U, UInt::add)
-      @lib.size_of(size) + size
-    })
-  size += 2U +
-    ({
-      let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
-      @lib.size_of(size) + size
-    })
+  if !self.f_repeated_packed_int32.is_empty() {
+    size += 2U +
+      ({
+        let size = self.f_repeated_packed_int32
+          .iter()
+          .map(@lib.size_of)
+          .fold(init=0U, UInt::add)
+        @lib.size_of(size) + size
+      })
+  }
+  if !self.f_repeated_packed_float.is_empty() {
+    size += 2U +
+      ({
+        let size = self.f_repeated_packed_float.length().reinterpret_as_uint() *
+          4
+        @lib.size_of(size) + size
+      })
+  }
   if self.f_baz is Some(v) {
     size += 2U +
       ({
@@ -298,8 +302,11 @@ pub impl @lib.Sized for FooMessageP2 with fn size_of(self) {
     size += 2U + @lib.size_of(v)
   }
   for s in self.f_map {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.f1 is Some(v) {
     size += 2U + @lib.size_of(v)
@@ -315,12 +322,18 @@ pub impl @lib.Sized for FooMessageP2 with fn size_of(self) {
       })
   }
   for s in self.f_repeated_string {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.f_repeated_baz_message {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.f_optional_string is Some(v) {
     size += 2U +
@@ -348,14 +361,16 @@ pub impl @lib.Sized for FooMessageP2 with fn size_of(self) {
   if self.f_default_enum is Some(v) {
     size += 2U + @lib.size_of(v)
   }
-  size += 2U +
-    ({
-      let size = self.f_repeated_packed_enum
-        .iter()
-        .map(@lib.size_of)
-        .fold(init=0U, UInt::add)
-      @lib.size_of(size) + size
-    })
+  if !self.f_repeated_packed_enum.is_empty() {
+    size += 2U +
+      ({
+        let size = self.f_repeated_packed_enum
+          .iter()
+          .map(@lib.size_of)
+          .fold(init=0U, UInt::add)
+        @lib.size_of(size) + size
+      })
+  }
   size
 }
 
@@ -649,20 +664,24 @@ pub impl @lib.Write for FooMessageP2 with fn write(
     writer |> @lib.write_varint(152UL)
     writer |> @lib.write_int32(item)
   }
-  writer |> @lib.write_varint(162UL)
-  let size = self.f_repeated_packed_int32
-    .iter()
-    .map(@lib.size_of)
-    .fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.f_repeated_packed_int32 {
-    writer |> @lib.write_int32(item)
+  if !self.f_repeated_packed_int32.is_empty() {
+    writer |> @lib.write_varint(162UL)
+    let size = self.f_repeated_packed_int32
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.f_repeated_packed_int32 {
+      writer |> @lib.write_int32(item)
+    }
   }
-  writer |> @lib.write_varint(170UL)
-  let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
-  writer |> @lib.write_uint32(size)
-  for item in self.f_repeated_packed_float {
-    writer |> @lib.write_float(item)
+  if !self.f_repeated_packed_float.is_empty() {
+    writer |> @lib.write_varint(170UL)
+    let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
+    writer |> @lib.write_uint32(size)
+    for item in self.f_repeated_packed_float {
+      writer |> @lib.write_float(item)
+    }
   }
   if self.f_baz is Some(v) {
     writer |> @lib.write_varint(186UL)
@@ -728,14 +747,16 @@ pub impl @lib.Write for FooMessageP2 with fn write(
     writer |> @lib.write_varint(304UL)
     writer |> @lib.write_enum(v.to_enum())
   }
-  writer |> @lib.write_varint(314UL)
-  let size = self.f_repeated_packed_enum
-    .iter()
-    .map(@lib.size_of)
-    .fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.f_repeated_packed_enum {
-    writer |> @lib.write_enum(item.to_enum())
+  if !self.f_repeated_packed_enum.is_empty() {
+    writer |> @lib.write_varint(314UL)
+    let size = self.f_repeated_packed_enum
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.f_repeated_packed_enum {
+      writer |> @lib.write_enum(item.to_enum())
+    }
   }
 }
 
@@ -1153,20 +1174,24 @@ pub impl @lib.AsyncWrite for FooMessageP2 with fn write(
     writer |> @lib.async_write_varint(152UL)
     writer |> @lib.async_write_int32(item)
   }
-  writer |> @lib.async_write_varint(162UL)
-  let size = self.f_repeated_packed_int32
-    .iter()
-    .map(@lib.size_of)
-    .fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.f_repeated_packed_int32 {
-    writer |> @lib.async_write_int32(item)
+  if !self.f_repeated_packed_int32.is_empty() {
+    writer |> @lib.async_write_varint(162UL)
+    let size = self.f_repeated_packed_int32
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.f_repeated_packed_int32 {
+      writer |> @lib.async_write_int32(item)
+    }
   }
-  writer |> @lib.async_write_varint(170UL)
-  let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
-  writer |> @lib.async_write_uint32(size)
-  for item in self.f_repeated_packed_float {
-    writer |> @lib.async_write_float(item)
+  if !self.f_repeated_packed_float.is_empty() {
+    writer |> @lib.async_write_varint(170UL)
+    let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
+    writer |> @lib.async_write_uint32(size)
+    for item in self.f_repeated_packed_float {
+      writer |> @lib.async_write_float(item)
+    }
   }
   if self.f_baz is Some(v) {
     writer |> @lib.async_write_varint(186UL)
@@ -1232,14 +1257,16 @@ pub impl @lib.AsyncWrite for FooMessageP2 with fn write(
     writer |> @lib.async_write_varint(304UL)
     writer |> @lib.async_write_enum(v.to_enum())
   }
-  writer |> @lib.async_write_varint(314UL)
-  let size = self.f_repeated_packed_enum
-    .iter()
-    .map(@lib.size_of)
-    .fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.f_repeated_packed_enum {
-    writer |> @lib.async_write_enum(item.to_enum())
+  if !self.f_repeated_packed_enum.is_empty() {
+    writer |> @lib.async_write_varint(314UL)
+    let size = self.f_repeated_packed_enum
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.f_repeated_packed_enum {
+      writer |> @lib.async_write_enum(item.to_enum())
+    }
   }
 }
 
@@ -1854,8 +1881,11 @@ pub(all) struct RepeatedMessageP2 {
 pub impl @lib.Sized for RepeatedMessageP2 with fn size_of(self) {
   let mut size = 0U
   for s in self.bar_message {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -2,6 +2,7 @@
 pub(all) enum FooEnum {
   FIRST_VALUE
   SECOND_VALUE
+  Unknown(@lib.Enum)
 } derive(Eq, Debug)
 
 ///|
@@ -9,6 +10,7 @@ pub fn FooEnum::to_enum(self : FooEnum) -> @lib.Enum {
   match self {
     FooEnum::FIRST_VALUE => 0
     FooEnum::SECOND_VALUE => 2
+    FooEnum::Unknown(value) => value
   }
 }
 
@@ -17,7 +19,7 @@ pub fn FooEnum::from_enum(i : @lib.Enum) -> FooEnum {
   match i.0 {
     0 => FooEnum::FIRST_VALUE
     2 => FooEnum::SECOND_VALUE
-    _ => Default::default()
+    _ => FooEnum::Unknown(i)
   }
 }
 
@@ -41,6 +43,14 @@ pub impl @json.FromJson for FooEnum with fn from_json(
     String("SECOND_VALUE") => FooEnum::SECOND_VALUE
     Number(0, ..) => FooEnum::FIRST_VALUE
     Number(2, ..) => FooEnum::SECOND_VALUE
+    Number(value, ..) =>
+      if value.trunc() == value {
+        FooEnum::Unknown(@lib.Enum(value.to_uint()))
+      } else {
+        raise @json.JsonDecodeError(
+          (path, "Expected an integer number or string for enum"),
+        )
+      }
     _ =>
       raise @json.JsonDecodeError(
         (path, "Expected a number or string for enum"),
@@ -53,6 +63,7 @@ pub impl ToJson for FooEnum with fn to_json(self : FooEnum) -> Json {
   match self {
     FooEnum::FIRST_VALUE => "FIRST_VALUE"
     FooEnum::SECOND_VALUE => "SECOND_VALUE"
+    FooEnum::Unknown(value) => value.0.to_json()
   }
 }
 
@@ -64,7 +75,9 @@ pub(all) struct BarMessage {
 ///|
 pub impl @lib.Sized for BarMessage with fn size_of(self) {
   let mut size = 0U
-  size += 1U + @lib.size_of(self.b_int32)
+  if self.b_int32 != Default::default() {
+    size += 1U + @lib.size_of(self.b_int32)
+  }
   size
 }
 
@@ -102,8 +115,10 @@ pub impl @lib.Write for BarMessage with fn write(
   self : BarMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
-  writer |> @lib.write_varint(8UL)
-  writer |> @lib.write_int32(self.b_int32)
+  if self.b_int32 != Default::default() {
+    writer |> @lib.write_varint(8UL)
+    writer |> @lib.write_int32(self.b_int32)
+  }
 }
 
 ///|
@@ -157,8 +172,10 @@ pub impl @lib.AsyncWrite for BarMessage with fn write(
   self : BarMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
-  writer |> @lib.async_write_varint(8UL)
-  writer |> @lib.async_write_int32(self.b_int32)
+  if self.b_int32 != Default::default() {
+    writer |> @lib.async_write_varint(8UL)
+    writer |> @lib.async_write_int32(self.b_int32)
+  }
 }
 
 ///|
@@ -170,12 +187,16 @@ pub(all) struct FooMessage_FMapEntry {
 ///|
 pub impl @lib.Sized for FooMessage_FMapEntry with fn size_of(self) {
   let mut size = 0U
-  size += 1U +
-    ({
-      let size = @lib.size_of(self.key)
-      @lib.size_of(size) + size
-    })
-  size += 1U + @lib.size_of(self.value)
+  if self.key != Default::default() {
+    size += 1U +
+      ({
+        let size = @lib.size_of(self.key)
+        @lib.size_of(size) + size
+      })
+  }
+  if self.value != Default::default() {
+    size += 1U + @lib.size_of(self.value)
+  }
   size
 }
 
@@ -217,10 +238,14 @@ pub impl @lib.Write for FooMessage_FMapEntry with fn write(
   self : FooMessage_FMapEntry,
   writer : &@lib.Writer,
 ) -> Unit raise {
-  writer |> @lib.write_varint(10UL)
-  writer |> @lib.write_string(self.key)
-  writer |> @lib.write_varint(16UL)
-  writer |> @lib.write_int32(self.value)
+  if self.key != Default::default() {
+    writer |> @lib.write_varint(10UL)
+    writer |> @lib.write_string(self.key)
+  }
+  if self.value != Default::default() {
+    writer |> @lib.write_varint(16UL)
+    writer |> @lib.write_int32(self.value)
+  }
 }
 
 ///|
@@ -281,10 +306,14 @@ pub impl @lib.AsyncWrite for FooMessage_FMapEntry with fn write(
   self : FooMessage_FMapEntry,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL)
-  writer |> @lib.async_write_string(self.key)
-  writer |> @lib.async_write_varint(16UL)
-  writer |> @lib.async_write_int32(self.value)
+  if self.key != Default::default() {
+    writer |> @lib.async_write_varint(10UL)
+    writer |> @lib.async_write_string(self.key)
+  }
+  if self.value != Default::default() {
+    writer |> @lib.async_write_varint(16UL)
+    writer |> @lib.async_write_int32(self.value)
+  }
 }
 
 ///|
@@ -305,12 +334,12 @@ pub(all) struct FooMessage {
   mut f_float : Float
   mut f_bytes : Bytes
   mut f_string : String
-  mut f_bar_message : BarMessage
+  mut f_bar_message : BarMessage?
   mut f_repeated_int32 : Array[Int]
   mut f_repeated_packed_int32 : Array[Int]
   mut f_repeated_packed_float : Array[Float]
-  mut f_baz : BazMessage
-  mut f_nested : BazMessage_Nested
+  mut f_baz : BazMessage?
+  mut f_nested : BazMessage_Nested?
   mut f_nested_enum : BazMessage_Nested_NestedEnum
   mut f_map : Map[String, Int]
   mut f_repeated_string : Array[String]
@@ -373,67 +402,114 @@ pub impl ToJson for FooMessage_TestOneof with fn to_json(
 ///|
 pub impl @lib.Sized for FooMessage with fn size_of(self) {
   let mut size = 0U
-  size += 1U + @lib.size_of(self.f_int32)
-  size += 1U + @lib.size_of(self.f_int64)
-  size += 1U + @lib.size_of(self.f_uint32)
-  size += 1U + @lib.size_of(self.f_uint64)
-  size += 1U + @lib.size_of(self.f_sint32)
-  size += 1U + @lib.size_of(self.f_sint64)
-  size += 1U + @lib.size_of(self.f_bool)
-  size += 1U + @lib.size_of(self.f_foo_enum)
-  size += 1U + 8U
-  size += 1U + 8U
-  size += 1U + 4U
-  size += 1U + 4U
-  size += 1U + 8U
-  size += 1U + 4U
-  size += 1U +
-    ({
-      let size = @lib.size_of(self.f_bytes)
-      @lib.size_of(size) + size
-    })
-  size += 2U +
-    ({
-      let size = @lib.size_of(self.f_string)
-      @lib.size_of(size) + size
-    })
-  size += 2U +
-    ({
-      let size = @lib.size_of(self.f_bar_message)
-      @lib.size_of(size) + size
-    })
-  size += 2U +
-    ({
-      let size = self.f_repeated_int32
-        .iter()
-        .map(@lib.size_of)
-        .fold(init=0U, UInt::add)
-      @lib.size_of(size) + size
-    })
-  size += 2U +
-    ({
-      let size = self.f_repeated_packed_int32
-        .iter()
-        .map(@lib.size_of)
-        .fold(init=0U, UInt::add)
-      @lib.size_of(size) + size
-    })
-  size += 2U +
-    ({
-      let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
-      @lib.size_of(size) + size
-    })
-  size += 2U +
-    ({
-      let size = @lib.size_of(self.f_baz)
-      @lib.size_of(size) + size
-    })
-  size += 2U +
-    ({
-      let size = @lib.size_of(self.f_nested)
-      @lib.size_of(size) + size
-    })
-  size += 2U + @lib.size_of(self.f_nested_enum)
+  if self.f_int32 != Default::default() {
+    size += 1U + @lib.size_of(self.f_int32)
+  }
+  if self.f_int64 != Default::default() {
+    size += 1U + @lib.size_of(self.f_int64)
+  }
+  if self.f_uint32 != Default::default() {
+    size += 1U + @lib.size_of(self.f_uint32)
+  }
+  if self.f_uint64 != Default::default() {
+    size += 1U + @lib.size_of(self.f_uint64)
+  }
+  if self.f_sint32 != Default::default() {
+    size += 1U + @lib.size_of(self.f_sint32)
+  }
+  if self.f_sint64 != Default::default() {
+    size += 1U + @lib.size_of(self.f_sint64)
+  }
+  if self.f_bool != Default::default() {
+    size += 1U + @lib.size_of(self.f_bool)
+  }
+  if self.f_foo_enum != Default::default() {
+    size += 1U + @lib.size_of(self.f_foo_enum)
+  }
+  if self.f_fixed64 != Default::default() {
+    size += 1U + 8U
+  }
+  if self.f_sfixed64 != Default::default() {
+    size += 1U + 8U
+  }
+  if self.f_fixed32 != Default::default() {
+    size += 1U + 4U
+  }
+  if self.f_sfixed32 != Default::default() {
+    size += 1U + 4U
+  }
+  if self.f_double != Default::default() {
+    size += 1U + 8U
+  }
+  if self.f_float != Default::default() {
+    size += 1U + 4U
+  }
+  if self.f_bytes != Default::default() {
+    size += 1U +
+      ({
+        let size = @lib.size_of(self.f_bytes)
+        @lib.size_of(size) + size
+      })
+  }
+  if self.f_string != Default::default() {
+    size += 2U +
+      ({
+        let size = @lib.size_of(self.f_string)
+        @lib.size_of(size) + size
+      })
+  }
+  if self.f_bar_message is Some(v) {
+    size += 2U +
+      ({
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
+      })
+  }
+  if !self.f_repeated_int32.is_empty() {
+    size += 2U +
+      ({
+        let size = self.f_repeated_int32
+          .iter()
+          .map(@lib.size_of)
+          .fold(init=0U, UInt::add)
+        @lib.size_of(size) + size
+      })
+  }
+  if !self.f_repeated_packed_int32.is_empty() {
+    size += 2U +
+      ({
+        let size = self.f_repeated_packed_int32
+          .iter()
+          .map(@lib.size_of)
+          .fold(init=0U, UInt::add)
+        @lib.size_of(size) + size
+      })
+  }
+  if !self.f_repeated_packed_float.is_empty() {
+    size += 2U +
+      ({
+        let size = self.f_repeated_packed_float.length().reinterpret_as_uint() *
+          4
+        @lib.size_of(size) + size
+      })
+  }
+  if self.f_baz is Some(v) {
+    size += 2U +
+      ({
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
+      })
+  }
+  if self.f_nested is Some(v) {
+    size += 2U +
+      ({
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
+      })
+  }
+  if self.f_nested_enum != Default::default() {
+    size += 2U + @lib.size_of(self.f_nested_enum)
+  }
   for k, v in self.f_map {
     let key_size = 1U +
       ({
@@ -444,12 +520,18 @@ pub impl @lib.Sized for FooMessage with fn size_of(self) {
     size += 2U + @lib.size_of(key_size + value_size) + key_size + value_size
   }
   for s in self.f_repeated_string {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   for s in self.f_repeated_baz_message {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   if self.f_optional_string is Some(v) {
     size += 2U +
@@ -458,22 +540,25 @@ pub impl @lib.Sized for FooMessage with fn size_of(self) {
         @lib.size_of(size) + size
       })
   }
-  size += 2U +
-    ({
-      let size = @lib.size_of(self.with_json_name)
-      @lib.size_of(size) + size
-    })
-  size += 2U +
-    ({
-      let size = self.f_repeated_packed_enum
-        .iter()
-        .map(@lib.size_of)
-        .fold(init=0U, UInt::add)
-      @lib.size_of(size) + size
-    })
+  if self.with_json_name != Default::default() {
+    size += 2U +
+      ({
+        let size = @lib.size_of(self.with_json_name)
+        @lib.size_of(size) + size
+      })
+  }
+  if !self.f_repeated_packed_enum.is_empty() {
+    size += 2U +
+      ({
+        let size = self.f_repeated_packed_enum
+          .iter()
+          .map(@lib.size_of)
+          .fold(init=0U, UInt::add)
+        @lib.size_of(size) + size
+      })
+  }
   for s in self.f_repeated_unpacked_enum {
-    let s = @lib.size_of(s)
-    size += 2U + @lib.size_of(s) + s
+    size += 2U + @lib.size_of(s)
   }
   match self.test_oneof {
     F1(v) => size += 2U + @lib.size_of(v)
@@ -508,12 +593,12 @@ pub impl Default for FooMessage with fn default() -> FooMessage {
     f_float: Float::default(),
     f_bytes: Bytes::default(),
     f_string: String::default(),
-    f_bar_message: BarMessage::default(),
+    f_bar_message: None,
     f_repeated_int32: [],
     f_repeated_packed_int32: [],
     f_repeated_packed_float: [],
-    f_baz: BazMessage::default(),
-    f_nested: BazMessage_Nested::default(),
+    f_baz: None,
+    f_nested: None,
     f_nested_enum: BazMessage_Nested_NestedEnum::default(),
     f_map: {},
     f_repeated_string: [],
@@ -544,12 +629,12 @@ pub fn FooMessage::new(
   f_float : Float,
   f_bytes : Bytes,
   f_string : String,
-  f_bar_message : BarMessage,
+  f_bar_message? : BarMessage,
   f_repeated_int32 : Array[Int],
   f_repeated_packed_int32 : Array[Int],
   f_repeated_packed_float : Array[Float],
-  f_baz : BazMessage,
-  f_nested : BazMessage_Nested,
+  f_baz? : BazMessage,
+  f_nested? : BazMessage_Nested,
   f_nested_enum : BazMessage_Nested_NestedEnum,
   f_map : Map[String, Int],
   f_repeated_string : Array[String],
@@ -622,6 +707,7 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(
         (16, _) => msg.f_string = reader |> @lib.read_string()
         (18, _) =>
           msg.f_bar_message = (reader |> @lib.read_message() : BarMessage)
+            |> Some
         (19, 2) =>
           msg.f_repeated_int32.push_iter(
             (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
@@ -637,9 +723,11 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(
             (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
           )
         (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-        (23, _) => msg.f_baz = (reader |> @lib.read_message() : BazMessage)
+        (23, _) =>
+          msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
         (24, _) =>
           msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested)
+            |> Some
         (25, _) =>
           msg.f_nested_enum = reader
             |> @lib.read_enum()
@@ -703,73 +791,119 @@ pub impl @lib.Write for FooMessage with fn write(
   self : FooMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
-  writer |> @lib.write_varint(8UL)
-  writer |> @lib.write_int32(self.f_int32)
-  writer |> @lib.write_varint(16UL)
-  writer |> @lib.write_int64(self.f_int64)
-  writer |> @lib.write_varint(24UL)
-  writer |> @lib.write_uint32(self.f_uint32)
-  writer |> @lib.write_varint(32UL)
-  writer |> @lib.write_uint64(self.f_uint64)
-  writer |> @lib.write_varint(40UL)
-  writer |> @lib.write_sint32(self.f_sint32)
-  writer |> @lib.write_varint(48UL)
-  writer |> @lib.write_sint64(self.f_sint64)
-  writer |> @lib.write_varint(56UL)
-  writer |> @lib.write_bool(self.f_bool)
-  writer |> @lib.write_varint(64UL)
-  writer |> @lib.write_enum(self.f_foo_enum.to_enum())
-  writer |> @lib.write_varint(73UL)
-  writer |> @lib.write_fixed64(self.f_fixed64)
-  writer |> @lib.write_varint(81UL)
-  writer |> @lib.write_sfixed64(self.f_sfixed64)
-  writer |> @lib.write_varint(93UL)
-  writer |> @lib.write_fixed32(self.f_fixed32)
-  writer |> @lib.write_varint(101UL)
-  writer |> @lib.write_sfixed32(self.f_sfixed32)
-  writer |> @lib.write_varint(105UL)
-  writer |> @lib.write_double(self.f_double)
-  writer |> @lib.write_varint(117UL)
-  writer |> @lib.write_float(self.f_float)
-  writer |> @lib.write_varint(122UL)
-  writer |> @lib.write_bytes(self.f_bytes)
-  writer |> @lib.write_varint(130UL)
-  writer |> @lib.write_string(self.f_string)
-  writer |> @lib.write_varint(146UL)
-  writer |> @lib.write_uint32(@lib.size_of(self.f_bar_message))
-  @lib.Write::write(self.f_bar_message, writer)
-  writer |> @lib.write_varint(154UL)
-  let size = self.f_repeated_int32
-    .iter()
-    .map(@lib.size_of)
-    .fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.f_repeated_int32 {
-    writer |> @lib.write_int32(item)
+  if self.f_int32 != Default::default() {
+    writer |> @lib.write_varint(8UL)
+    writer |> @lib.write_int32(self.f_int32)
   }
-  writer |> @lib.write_varint(162UL)
-  let size = self.f_repeated_packed_int32
-    .iter()
-    .map(@lib.size_of)
-    .fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.f_repeated_packed_int32 {
-    writer |> @lib.write_int32(item)
+  if self.f_int64 != Default::default() {
+    writer |> @lib.write_varint(16UL)
+    writer |> @lib.write_int64(self.f_int64)
   }
-  writer |> @lib.write_varint(170UL)
-  let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
-  writer |> @lib.write_uint32(size)
-  for item in self.f_repeated_packed_float {
-    writer |> @lib.write_float(item)
+  if self.f_uint32 != Default::default() {
+    writer |> @lib.write_varint(24UL)
+    writer |> @lib.write_uint32(self.f_uint32)
   }
-  writer |> @lib.write_varint(186UL)
-  writer |> @lib.write_uint32(@lib.size_of(self.f_baz))
-  @lib.Write::write(self.f_baz, writer)
-  writer |> @lib.write_varint(194UL)
-  writer |> @lib.write_uint32(@lib.size_of(self.f_nested))
-  @lib.Write::write(self.f_nested, writer)
-  writer |> @lib.write_varint(200UL)
-  writer |> @lib.write_enum(self.f_nested_enum.to_enum())
+  if self.f_uint64 != Default::default() {
+    writer |> @lib.write_varint(32UL)
+    writer |> @lib.write_uint64(self.f_uint64)
+  }
+  if self.f_sint32 != Default::default() {
+    writer |> @lib.write_varint(40UL)
+    writer |> @lib.write_sint32(self.f_sint32)
+  }
+  if self.f_sint64 != Default::default() {
+    writer |> @lib.write_varint(48UL)
+    writer |> @lib.write_sint64(self.f_sint64)
+  }
+  if self.f_bool != Default::default() {
+    writer |> @lib.write_varint(56UL)
+    writer |> @lib.write_bool(self.f_bool)
+  }
+  if self.f_foo_enum != Default::default() {
+    writer |> @lib.write_varint(64UL)
+    writer |> @lib.write_enum(self.f_foo_enum.to_enum())
+  }
+  if self.f_fixed64 != Default::default() {
+    writer |> @lib.write_varint(73UL)
+    writer |> @lib.write_fixed64(self.f_fixed64)
+  }
+  if self.f_sfixed64 != Default::default() {
+    writer |> @lib.write_varint(81UL)
+    writer |> @lib.write_sfixed64(self.f_sfixed64)
+  }
+  if self.f_fixed32 != Default::default() {
+    writer |> @lib.write_varint(93UL)
+    writer |> @lib.write_fixed32(self.f_fixed32)
+  }
+  if self.f_sfixed32 != Default::default() {
+    writer |> @lib.write_varint(101UL)
+    writer |> @lib.write_sfixed32(self.f_sfixed32)
+  }
+  if self.f_double != Default::default() {
+    writer |> @lib.write_varint(105UL)
+    writer |> @lib.write_double(self.f_double)
+  }
+  if self.f_float != Default::default() {
+    writer |> @lib.write_varint(117UL)
+    writer |> @lib.write_float(self.f_float)
+  }
+  if self.f_bytes != Default::default() {
+    writer |> @lib.write_varint(122UL)
+    writer |> @lib.write_bytes(self.f_bytes)
+  }
+  if self.f_string != Default::default() {
+    writer |> @lib.write_varint(130UL)
+    writer |> @lib.write_string(self.f_string)
+  }
+  if self.f_bar_message is Some(v) {
+    writer |> @lib.write_varint(146UL)
+    writer |> @lib.write_uint32(@lib.size_of(v))
+    @lib.Write::write(v, writer)
+  }
+  if !self.f_repeated_int32.is_empty() {
+    writer |> @lib.write_varint(154UL)
+    let size = self.f_repeated_int32
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.f_repeated_int32 {
+      writer |> @lib.write_int32(item)
+    }
+  }
+  if !self.f_repeated_packed_int32.is_empty() {
+    writer |> @lib.write_varint(162UL)
+    let size = self.f_repeated_packed_int32
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.f_repeated_packed_int32 {
+      writer |> @lib.write_int32(item)
+    }
+  }
+  if !self.f_repeated_packed_float.is_empty() {
+    writer |> @lib.write_varint(170UL)
+    let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
+    writer |> @lib.write_uint32(size)
+    for item in self.f_repeated_packed_float {
+      writer |> @lib.write_float(item)
+    }
+  }
+  if self.f_baz is Some(v) {
+    writer |> @lib.write_varint(186UL)
+    writer |> @lib.write_uint32(@lib.size_of(v))
+    @lib.Write::write(v, writer)
+  }
+  if self.f_nested is Some(v) {
+    writer |> @lib.write_varint(194UL)
+    writer |> @lib.write_uint32(@lib.size_of(v))
+    @lib.Write::write(v, writer)
+  }
+  if self.f_nested_enum != Default::default() {
+    writer |> @lib.write_varint(200UL)
+    writer |> @lib.write_enum(self.f_nested_enum.to_enum())
+  }
   let keys = self.f_map.keys().collect()
   for i in 0..<keys.length() {
     let k = keys[i]
@@ -801,16 +935,20 @@ pub impl @lib.Write for FooMessage with fn write(
     writer |> @lib.write_varint(258UL)
     writer |> @lib.write_string(v)
   }
-  writer |> @lib.write_varint(266UL)
-  writer |> @lib.write_string(self.with_json_name)
-  writer |> @lib.write_varint(274UL)
-  let size = self.f_repeated_packed_enum
-    .iter()
-    .map(@lib.size_of)
-    .fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.f_repeated_packed_enum {
-    writer |> @lib.write_enum(item.to_enum())
+  if self.with_json_name != Default::default() {
+    writer |> @lib.write_varint(266UL)
+    writer |> @lib.write_string(self.with_json_name)
+  }
+  if !self.f_repeated_packed_enum.is_empty() {
+    writer |> @lib.write_varint(274UL)
+    let size = self.f_repeated_packed_enum
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.f_repeated_packed_enum {
+      writer |> @lib.write_enum(item.to_enum())
+    }
   }
   for item in self.f_repeated_unpacked_enum {
     writer |> @lib.write_varint(280UL)
@@ -884,8 +1022,9 @@ pub impl ToJson for FooMessage with fn to_json(self) {
   if self.f_string != Default::default() {
     json["fString"] = self.f_string.to_json()
   }
-  if self.f_bar_message != Default::default() {
-    json["fBarMessage"] = self.f_bar_message.to_json()
+  match self.f_bar_message {
+    Some(v) => json["fBarMessage"] = v.to_json()
+    _ => ()
   }
   if self.f_repeated_int32 != Default::default() {
     json["fRepeatedInt32"] = self.f_repeated_int32.to_json()
@@ -896,11 +1035,13 @@ pub impl ToJson for FooMessage with fn to_json(self) {
   if self.f_repeated_packed_float != Default::default() {
     json["fRepeatedPackedFloat"] = self.f_repeated_packed_float.to_json()
   }
-  if self.f_baz != Default::default() {
-    json["fBaz"] = self.f_baz.to_json()
+  match self.f_baz {
+    Some(v) => json["fBaz"] = v.to_json()
+    _ => ()
   }
-  if self.f_nested != Default::default() {
-    json["fNested"] = self.f_nested.to_json()
+  match self.f_nested {
+    Some(v) => json["fNested"] = v.to_json()
+    _ => ()
   }
   if self.f_nested_enum != Default::default() {
     json["fNestedEnum"] = self.f_nested_enum.to_json()
@@ -965,7 +1106,7 @@ pub impl @json.FromJson for FooMessage with fn from_json(
       ("fBytes", String(value)) => message.f_bytes = @lib.base64_decode(value)
       ("fString", value) => message.f_string = @json.from_json(value, path~)
       ("fBarMessage", value) =>
-        message.f_bar_message = @json.from_json(value, path~)
+        message.f_bar_message = Some(@json.from_json(value, path~))
       ("fRepeatedInt32", Array(value)) =>
         message.f_repeated_int32 = value.map(v => @json.from_json(v, path~))
       ("fRepeatedPackedInt32", Array(value)) =>
@@ -976,8 +1117,9 @@ pub impl @json.FromJson for FooMessage with fn from_json(
         message.f_repeated_packed_float = value.map(v => {
           Float::from_double(@json.from_json(v, path~))
         })
-      ("fBaz", value) => message.f_baz = @json.from_json(value, path~)
-      ("fNested", value) => message.f_nested = @json.from_json(value, path~)
+      ("fBaz", value) => message.f_baz = Some(@json.from_json(value, path~))
+      ("fNested", value) =>
+        message.f_nested = Some(@json.from_json(value, path~))
       ("fNestedEnum", value) =>
         message.f_nested_enum = @json.from_json(value, path~)
       ("fMap", _) => message.f_map = @json.from_json(value, path~)
@@ -1036,6 +1178,7 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(
         (16, _) => msg.f_string = reader |> @lib.async_read_string()
         (18, _) =>
           msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage)
+            |> Some
         (19, 2) =>
           msg.f_repeated_int32.push_iter(
             (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
@@ -1054,10 +1197,11 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(
         (21, 5) =>
           msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
         (23, _) =>
-          msg.f_baz = (reader |> @lib.async_read_message() : BazMessage)
+          msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
         (24, _) =>
           msg.f_nested = (
-            reader |> @lib.async_read_message() : BazMessage_Nested)
+              reader |> @lib.async_read_message() : BazMessage_Nested)
+            |> Some
         (25, _) =>
           msg.f_nested_enum = reader
             |> @lib.async_read_enum()
@@ -1125,73 +1269,119 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(
   self : FooMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
-  writer |> @lib.async_write_varint(8UL)
-  writer |> @lib.async_write_int32(self.f_int32)
-  writer |> @lib.async_write_varint(16UL)
-  writer |> @lib.async_write_int64(self.f_int64)
-  writer |> @lib.async_write_varint(24UL)
-  writer |> @lib.async_write_uint32(self.f_uint32)
-  writer |> @lib.async_write_varint(32UL)
-  writer |> @lib.async_write_uint64(self.f_uint64)
-  writer |> @lib.async_write_varint(40UL)
-  writer |> @lib.async_write_sint32(self.f_sint32)
-  writer |> @lib.async_write_varint(48UL)
-  writer |> @lib.async_write_sint64(self.f_sint64)
-  writer |> @lib.async_write_varint(56UL)
-  writer |> @lib.async_write_bool(self.f_bool)
-  writer |> @lib.async_write_varint(64UL)
-  writer |> @lib.async_write_enum(self.f_foo_enum.to_enum())
-  writer |> @lib.async_write_varint(73UL)
-  writer |> @lib.async_write_fixed64(self.f_fixed64)
-  writer |> @lib.async_write_varint(81UL)
-  writer |> @lib.async_write_sfixed64(self.f_sfixed64)
-  writer |> @lib.async_write_varint(93UL)
-  writer |> @lib.async_write_fixed32(self.f_fixed32)
-  writer |> @lib.async_write_varint(101UL)
-  writer |> @lib.async_write_sfixed32(self.f_sfixed32)
-  writer |> @lib.async_write_varint(105UL)
-  writer |> @lib.async_write_double(self.f_double)
-  writer |> @lib.async_write_varint(117UL)
-  writer |> @lib.async_write_float(self.f_float)
-  writer |> @lib.async_write_varint(122UL)
-  writer |> @lib.async_write_bytes(self.f_bytes)
-  writer |> @lib.async_write_varint(130UL)
-  writer |> @lib.async_write_string(self.f_string)
-  writer |> @lib.async_write_varint(146UL)
-  writer |> @lib.async_write_uint32(@lib.size_of(self.f_bar_message))
-  @lib.AsyncWrite::write(self.f_bar_message, writer)
-  writer |> @lib.async_write_varint(154UL)
-  let size = self.f_repeated_int32
-    .iter()
-    .map(@lib.size_of)
-    .fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.f_repeated_int32 {
-    writer |> @lib.async_write_int32(item)
+  if self.f_int32 != Default::default() {
+    writer |> @lib.async_write_varint(8UL)
+    writer |> @lib.async_write_int32(self.f_int32)
   }
-  writer |> @lib.async_write_varint(162UL)
-  let size = self.f_repeated_packed_int32
-    .iter()
-    .map(@lib.size_of)
-    .fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.f_repeated_packed_int32 {
-    writer |> @lib.async_write_int32(item)
+  if self.f_int64 != Default::default() {
+    writer |> @lib.async_write_varint(16UL)
+    writer |> @lib.async_write_int64(self.f_int64)
   }
-  writer |> @lib.async_write_varint(170UL)
-  let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
-  writer |> @lib.async_write_uint32(size)
-  for item in self.f_repeated_packed_float {
-    writer |> @lib.async_write_float(item)
+  if self.f_uint32 != Default::default() {
+    writer |> @lib.async_write_varint(24UL)
+    writer |> @lib.async_write_uint32(self.f_uint32)
   }
-  writer |> @lib.async_write_varint(186UL)
-  writer |> @lib.async_write_uint32(@lib.size_of(self.f_baz))
-  @lib.AsyncWrite::write(self.f_baz, writer)
-  writer |> @lib.async_write_varint(194UL)
-  writer |> @lib.async_write_uint32(@lib.size_of(self.f_nested))
-  @lib.AsyncWrite::write(self.f_nested, writer)
-  writer |> @lib.async_write_varint(200UL)
-  writer |> @lib.async_write_enum(self.f_nested_enum.to_enum())
+  if self.f_uint64 != Default::default() {
+    writer |> @lib.async_write_varint(32UL)
+    writer |> @lib.async_write_uint64(self.f_uint64)
+  }
+  if self.f_sint32 != Default::default() {
+    writer |> @lib.async_write_varint(40UL)
+    writer |> @lib.async_write_sint32(self.f_sint32)
+  }
+  if self.f_sint64 != Default::default() {
+    writer |> @lib.async_write_varint(48UL)
+    writer |> @lib.async_write_sint64(self.f_sint64)
+  }
+  if self.f_bool != Default::default() {
+    writer |> @lib.async_write_varint(56UL)
+    writer |> @lib.async_write_bool(self.f_bool)
+  }
+  if self.f_foo_enum != Default::default() {
+    writer |> @lib.async_write_varint(64UL)
+    writer |> @lib.async_write_enum(self.f_foo_enum.to_enum())
+  }
+  if self.f_fixed64 != Default::default() {
+    writer |> @lib.async_write_varint(73UL)
+    writer |> @lib.async_write_fixed64(self.f_fixed64)
+  }
+  if self.f_sfixed64 != Default::default() {
+    writer |> @lib.async_write_varint(81UL)
+    writer |> @lib.async_write_sfixed64(self.f_sfixed64)
+  }
+  if self.f_fixed32 != Default::default() {
+    writer |> @lib.async_write_varint(93UL)
+    writer |> @lib.async_write_fixed32(self.f_fixed32)
+  }
+  if self.f_sfixed32 != Default::default() {
+    writer |> @lib.async_write_varint(101UL)
+    writer |> @lib.async_write_sfixed32(self.f_sfixed32)
+  }
+  if self.f_double != Default::default() {
+    writer |> @lib.async_write_varint(105UL)
+    writer |> @lib.async_write_double(self.f_double)
+  }
+  if self.f_float != Default::default() {
+    writer |> @lib.async_write_varint(117UL)
+    writer |> @lib.async_write_float(self.f_float)
+  }
+  if self.f_bytes != Default::default() {
+    writer |> @lib.async_write_varint(122UL)
+    writer |> @lib.async_write_bytes(self.f_bytes)
+  }
+  if self.f_string != Default::default() {
+    writer |> @lib.async_write_varint(130UL)
+    writer |> @lib.async_write_string(self.f_string)
+  }
+  if self.f_bar_message is Some(v) {
+    writer |> @lib.async_write_varint(146UL)
+    writer |> @lib.async_write_uint32(@lib.size_of(v))
+    @lib.AsyncWrite::write(v, writer)
+  }
+  if !self.f_repeated_int32.is_empty() {
+    writer |> @lib.async_write_varint(154UL)
+    let size = self.f_repeated_int32
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.f_repeated_int32 {
+      writer |> @lib.async_write_int32(item)
+    }
+  }
+  if !self.f_repeated_packed_int32.is_empty() {
+    writer |> @lib.async_write_varint(162UL)
+    let size = self.f_repeated_packed_int32
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.f_repeated_packed_int32 {
+      writer |> @lib.async_write_int32(item)
+    }
+  }
+  if !self.f_repeated_packed_float.is_empty() {
+    writer |> @lib.async_write_varint(170UL)
+    let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
+    writer |> @lib.async_write_uint32(size)
+    for item in self.f_repeated_packed_float {
+      writer |> @lib.async_write_float(item)
+    }
+  }
+  if self.f_baz is Some(v) {
+    writer |> @lib.async_write_varint(186UL)
+    writer |> @lib.async_write_uint32(@lib.size_of(v))
+    @lib.AsyncWrite::write(v, writer)
+  }
+  if self.f_nested is Some(v) {
+    writer |> @lib.async_write_varint(194UL)
+    writer |> @lib.async_write_uint32(@lib.size_of(v))
+    @lib.AsyncWrite::write(v, writer)
+  }
+  if self.f_nested_enum != Default::default() {
+    writer |> @lib.async_write_varint(200UL)
+    writer |> @lib.async_write_enum(self.f_nested_enum.to_enum())
+  }
   let keys = self.f_map.keys().collect()
   for i in 0..<keys.length() {
     let k = keys[i]
@@ -1223,16 +1413,20 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(
     writer |> @lib.async_write_varint(258UL)
     writer |> @lib.async_write_string(v)
   }
-  writer |> @lib.async_write_varint(266UL)
-  writer |> @lib.async_write_string(self.with_json_name)
-  writer |> @lib.async_write_varint(274UL)
-  let size = self.f_repeated_packed_enum
-    .iter()
-    .map(@lib.size_of)
-    .fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.f_repeated_packed_enum {
-    writer |> @lib.async_write_enum(item.to_enum())
+  if self.with_json_name != Default::default() {
+    writer |> @lib.async_write_varint(266UL)
+    writer |> @lib.async_write_string(self.with_json_name)
+  }
+  if !self.f_repeated_packed_enum.is_empty() {
+    writer |> @lib.async_write_varint(274UL)
+    let size = self.f_repeated_packed_enum
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.f_repeated_packed_enum {
+      writer |> @lib.async_write_enum(item.to_enum())
+    }
   }
   for item in self.f_repeated_unpacked_enum {
     writer |> @lib.async_write_varint(280UL)
@@ -1260,6 +1454,7 @@ pub(all) enum BazMessage_Nested_NestedEnum {
   Foo
   Bar
   Baz
+  Unknown(@lib.Enum)
 } derive(Eq, Debug)
 
 ///|
@@ -1270,6 +1465,7 @@ pub fn BazMessage_Nested_NestedEnum::to_enum(
     BazMessage_Nested_NestedEnum::Foo => 0
     BazMessage_Nested_NestedEnum::Bar => 1
     BazMessage_Nested_NestedEnum::Baz => 2
+    BazMessage_Nested_NestedEnum::Unknown(value) => value
   }
 }
 
@@ -1281,7 +1477,7 @@ pub fn BazMessage_Nested_NestedEnum::from_enum(
     0 => BazMessage_Nested_NestedEnum::Foo
     1 => BazMessage_Nested_NestedEnum::Bar
     2 => BazMessage_Nested_NestedEnum::Baz
-    _ => Default::default()
+    _ => BazMessage_Nested_NestedEnum::Unknown(i)
   }
 }
 
@@ -1309,6 +1505,14 @@ pub impl @json.FromJson for BazMessage_Nested_NestedEnum with fn from_json(
     Number(0, ..) => BazMessage_Nested_NestedEnum::Foo
     Number(1, ..) => BazMessage_Nested_NestedEnum::Bar
     Number(2, ..) => BazMessage_Nested_NestedEnum::Baz
+    Number(value, ..) =>
+      if value.trunc() == value {
+        BazMessage_Nested_NestedEnum::Unknown(@lib.Enum(value.to_uint()))
+      } else {
+        raise @json.JsonDecodeError(
+          (path, "Expected an integer number or string for enum"),
+        )
+      }
     _ =>
       raise @json.JsonDecodeError(
         (path, "Expected a number or string for enum"),
@@ -1324,6 +1528,7 @@ pub impl ToJson for BazMessage_Nested_NestedEnum with fn to_json(
     BazMessage_Nested_NestedEnum::Foo => "Foo"
     BazMessage_Nested_NestedEnum::Bar => "Bar"
     BazMessage_Nested_NestedEnum::Baz => "Baz"
+    BazMessage_Nested_NestedEnum::Unknown(value) => value.0.to_json()
   }
 }
 
@@ -1335,7 +1540,9 @@ pub(all) struct BazMessage_Nested_NestedMessage {
 ///|
 pub impl @lib.Sized for BazMessage_Nested_NestedMessage with fn size_of(self) {
   let mut size = 0U
-  size += 1U + @lib.size_of(self.f_nested)
+  if self.f_nested != Default::default() {
+    size += 1U + @lib.size_of(self.f_nested)
+  }
   size
 }
 
@@ -1375,8 +1582,10 @@ pub impl @lib.Write for BazMessage_Nested_NestedMessage with fn write(
   self : BazMessage_Nested_NestedMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
-  writer |> @lib.write_varint(8UL)
-  writer |> @lib.write_int32(self.f_nested)
+  if self.f_nested != Default::default() {
+    writer |> @lib.write_varint(8UL)
+    writer |> @lib.write_int32(self.f_nested)
+  }
 }
 
 ///|
@@ -1432,34 +1641,38 @@ pub impl @lib.AsyncWrite for BazMessage_Nested_NestedMessage with fn write(
   self : BazMessage_Nested_NestedMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
-  writer |> @lib.async_write_varint(8UL)
-  writer |> @lib.async_write_int32(self.f_nested)
+  if self.f_nested != Default::default() {
+    writer |> @lib.async_write_varint(8UL)
+    writer |> @lib.async_write_int32(self.f_nested)
+  }
 }
 
 ///|
 pub(all) struct BazMessage_Nested {
-  mut f_nested : BazMessage_Nested_NestedMessage
+  mut f_nested : BazMessage_Nested_NestedMessage?
 } derive(Eq, Debug)
 
 ///|
 pub impl @lib.Sized for BazMessage_Nested with fn size_of(self) {
   let mut size = 0U
-  size += 1U +
-    ({
-      let size = @lib.size_of(self.f_nested)
-      @lib.size_of(size) + size
-    })
+  if self.f_nested is Some(v) {
+    size += 1U +
+      ({
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
+      })
+  }
   size
 }
 
 ///|
 pub impl Default for BazMessage_Nested with fn default() -> BazMessage_Nested {
-  BazMessage_Nested::{ f_nested: BazMessage_Nested_NestedMessage::default() }
+  BazMessage_Nested::{ f_nested: None }
 }
 
 ///|
 pub fn BazMessage_Nested::new(
-  f_nested : BazMessage_Nested_NestedMessage,
+  f_nested? : BazMessage_Nested_NestedMessage,
 ) -> BazMessage_Nested {
   BazMessage_Nested::{ f_nested, }
 }
@@ -1474,7 +1687,8 @@ pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(
       match (reader |> @lib.read_tag()) {
         (1, _) =>
           msg.f_nested = (
-            reader |> @lib.read_message() : BazMessage_Nested_NestedMessage)
+              reader |> @lib.read_message() : BazMessage_Nested_NestedMessage)
+            |> Some
         (_, wire) => reader |> @lib.read_unknown(wire)
       }
     }
@@ -1490,16 +1704,19 @@ pub impl @lib.Write for BazMessage_Nested with fn write(
   self : BazMessage_Nested,
   writer : &@lib.Writer,
 ) -> Unit raise {
-  writer |> @lib.write_varint(10UL)
-  writer |> @lib.write_uint32(@lib.size_of(self.f_nested))
-  @lib.Write::write(self.f_nested, writer)
+  if self.f_nested is Some(v) {
+    writer |> @lib.write_varint(10UL)
+    writer |> @lib.write_uint32(@lib.size_of(v))
+    @lib.Write::write(v, writer)
+  }
 }
 
 ///|
 pub impl ToJson for BazMessage_Nested with fn to_json(self) {
   let json : Map[String, Json] = {}
-  if self.f_nested != Default::default() {
-    json["fNested"] = self.f_nested.to_json()
+  match self.f_nested {
+    Some(v) => json["fNested"] = v.to_json()
+    _ => ()
   }
   Json::object(json)
 }
@@ -1517,7 +1734,8 @@ pub impl @json.FromJson for BazMessage_Nested with fn from_json(
   let message = BazMessage_Nested::default()
   for key, value in obj {
     match (key, value) {
-      ("fNested", value) => message.f_nested = @json.from_json(value, path~)
+      ("fNested", value) =>
+        message.f_nested = Some(@json.from_json(value, path~))
       (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
@@ -1534,8 +1752,9 @@ pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(
       match (reader |> @lib.async_read_tag()) {
         (1, _) =>
           msg.f_nested = (
-            reader |> @lib.async_read_message() :
-            BazMessage_Nested_NestedMessage)
+              reader |> @lib.async_read_message() :
+              BazMessage_Nested_NestedMessage)
+            |> Some
         (_, wire) => reader |> @lib.async_read_unknown(wire)
       }
     }
@@ -1551,14 +1770,16 @@ pub impl @lib.AsyncWrite for BazMessage_Nested with fn write(
   self : BazMessage_Nested,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL)
-  writer |> @lib.async_write_uint32(@lib.size_of(self.f_nested))
-  @lib.AsyncWrite::write(self.f_nested, writer)
+  if self.f_nested is Some(v) {
+    writer |> @lib.async_write_varint(10UL)
+    writer |> @lib.async_write_uint32(@lib.size_of(v))
+    @lib.AsyncWrite::write(v, writer)
+  }
 }
 
 ///|
 pub(all) struct BazMessage {
-  mut nested : BazMessage_Nested
+  mut nested : BazMessage_Nested?
   mut b_int64 : Int64
   mut b_string : String
 } derive(Eq, Debug)
@@ -1566,24 +1787,30 @@ pub(all) struct BazMessage {
 ///|
 pub impl @lib.Sized for BazMessage with fn size_of(self) {
   let mut size = 0U
-  size += 1U +
-    ({
-      let size = @lib.size_of(self.nested)
-      @lib.size_of(size) + size
-    })
-  size += 1U + @lib.size_of(self.b_int64)
-  size += 1U +
-    ({
-      let size = @lib.size_of(self.b_string)
-      @lib.size_of(size) + size
-    })
+  if self.nested is Some(v) {
+    size += 1U +
+      ({
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
+      })
+  }
+  if self.b_int64 != Default::default() {
+    size += 1U + @lib.size_of(self.b_int64)
+  }
+  if self.b_string != Default::default() {
+    size += 1U +
+      ({
+        let size = @lib.size_of(self.b_string)
+        @lib.size_of(size) + size
+      })
+  }
   size
 }
 
 ///|
 pub impl Default for BazMessage with fn default() -> BazMessage {
   BazMessage::{
-    nested: BazMessage_Nested::default(),
+    nested: None,
     b_int64: Int64::default(),
     b_string: String::default(),
   }
@@ -1591,7 +1818,7 @@ pub impl Default for BazMessage with fn default() -> BazMessage {
 
 ///|
 pub fn BazMessage::new(
-  nested : BazMessage_Nested,
+  nested? : BazMessage_Nested,
   b_int64 : Int64,
   b_string : String,
 ) -> BazMessage {
@@ -1608,6 +1835,7 @@ pub impl @lib.Read for BazMessage with fn read_with_limit(
       match (reader |> @lib.read_tag()) {
         (1, _) =>
           msg.nested = (reader |> @lib.read_message() : BazMessage_Nested)
+            |> Some
         (2, _) => msg.b_int64 = reader |> @lib.read_int64()
         (3, _) => msg.b_string = reader |> @lib.read_string()
         (_, wire) => reader |> @lib.read_unknown(wire)
@@ -1625,20 +1853,27 @@ pub impl @lib.Write for BazMessage with fn write(
   self : BazMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
-  writer |> @lib.write_varint(10UL)
-  writer |> @lib.write_uint32(@lib.size_of(self.nested))
-  @lib.Write::write(self.nested, writer)
-  writer |> @lib.write_varint(16UL)
-  writer |> @lib.write_int64(self.b_int64)
-  writer |> @lib.write_varint(26UL)
-  writer |> @lib.write_string(self.b_string)
+  if self.nested is Some(v) {
+    writer |> @lib.write_varint(10UL)
+    writer |> @lib.write_uint32(@lib.size_of(v))
+    @lib.Write::write(v, writer)
+  }
+  if self.b_int64 != Default::default() {
+    writer |> @lib.write_varint(16UL)
+    writer |> @lib.write_int64(self.b_int64)
+  }
+  if self.b_string != Default::default() {
+    writer |> @lib.write_varint(26UL)
+    writer |> @lib.write_string(self.b_string)
+  }
 }
 
 ///|
 pub impl ToJson for BazMessage with fn to_json(self) {
   let json : Map[String, Json] = {}
-  if self.nested != Default::default() {
-    json["nested"] = self.nested.to_json()
+  match self.nested {
+    Some(v) => json["nested"] = v.to_json()
+    _ => ()
   }
   if self.b_int64 != Default::default() {
     json["bInt64"] = self.b_int64.to_json()
@@ -1660,7 +1895,7 @@ pub impl @json.FromJson for BazMessage with fn from_json(
   let message = BazMessage::default()
   for key, value in obj {
     match (key, value) {
-      ("nested", value) => message.nested = @json.from_json(value, path~)
+      ("nested", value) => message.nested = Some(@json.from_json(value, path~))
       ("bInt64", value) => message.b_int64 = @json.from_json(value, path~)
       ("bString", value) => message.b_string = @json.from_json(value, path~)
       (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
@@ -1679,6 +1914,7 @@ pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(
       match (reader |> @lib.async_read_tag()) {
         (1, _) =>
           msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested)
+            |> Some
         (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
         (3, _) => msg.b_string = reader |> @lib.async_read_string()
         (_, wire) => reader |> @lib.async_read_unknown(wire)
@@ -1696,13 +1932,19 @@ pub impl @lib.AsyncWrite for BazMessage with fn write(
   self : BazMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL)
-  writer |> @lib.async_write_uint32(@lib.size_of(self.nested))
-  @lib.AsyncWrite::write(self.nested, writer)
-  writer |> @lib.async_write_varint(16UL)
-  writer |> @lib.async_write_int64(self.b_int64)
-  writer |> @lib.async_write_varint(26UL)
-  writer |> @lib.async_write_string(self.b_string)
+  if self.nested is Some(v) {
+    writer |> @lib.async_write_varint(10UL)
+    writer |> @lib.async_write_uint32(@lib.size_of(v))
+    @lib.AsyncWrite::write(v, writer)
+  }
+  if self.b_int64 != Default::default() {
+    writer |> @lib.async_write_varint(16UL)
+    writer |> @lib.async_write_int64(self.b_int64)
+  }
+  if self.b_string != Default::default() {
+    writer |> @lib.async_write_varint(26UL)
+    writer |> @lib.async_write_string(self.b_string)
+  }
 }
 
 ///|
@@ -1714,8 +1956,11 @@ pub(all) struct RepeatedMessage {
 pub impl @lib.Sized for RepeatedMessage with fn size_of(self) {
   let mut size = 0U
   for s in self.bar_message {
-    let s = @lib.size_of(s)
-    size += 1U + @lib.size_of(s) + s
+    size += 1U +
+      ({
+        let size = @lib.size_of(s)
+        @lib.size_of(size) + size
+      })
   }
   size
 }
@@ -1834,7 +2079,9 @@ pub(all) struct EmptyMessage {
 ///|
 pub impl @lib.Sized for EmptyMessage with fn size_of(self) {
   let mut size = 0U
-  size += 1U + @lib.size_of(self.field)
+  if self.field != Default::default() {
+    size += 1U + @lib.size_of(self.field)
+  }
   size
 }
 
@@ -1872,8 +2119,10 @@ pub impl @lib.Write for EmptyMessage with fn write(
   self : EmptyMessage,
   writer : &@lib.Writer,
 ) -> Unit raise {
-  writer |> @lib.write_varint(8UL)
-  writer |> @lib.write_int32(self.field)
+  if self.field != Default::default() {
+    writer |> @lib.write_varint(8UL)
+    writer |> @lib.write_int32(self.field)
+  }
 }
 
 ///|
@@ -1927,34 +2176,38 @@ pub impl @lib.AsyncWrite for EmptyMessage with fn write(
   self : EmptyMessage,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
-  writer |> @lib.async_write_varint(8UL)
-  writer |> @lib.async_write_int32(self.field)
+  if self.field != Default::default() {
+    writer |> @lib.async_write_varint(8UL)
+    writer |> @lib.async_write_int32(self.field)
+  }
 }
 
 ///|
 pub(all) struct EmptyMessageWithField {
-  mut empty_message : EmptyMessage
+  mut empty_message : EmptyMessage?
 } derive(Eq, Debug)
 
 ///|
 pub impl @lib.Sized for EmptyMessageWithField with fn size_of(self) {
   let mut size = 0U
-  size += 1U +
-    ({
-      let size = @lib.size_of(self.empty_message)
-      @lib.size_of(size) + size
-    })
+  if self.empty_message is Some(v) {
+    size += 1U +
+      ({
+        let size = @lib.size_of(v)
+        @lib.size_of(size) + size
+      })
+  }
   size
 }
 
 ///|
 pub impl Default for EmptyMessageWithField with fn default() -> EmptyMessageWithField {
-  EmptyMessageWithField::{ empty_message: EmptyMessage::default() }
+  EmptyMessageWithField::{ empty_message: None }
 }
 
 ///|
 pub fn EmptyMessageWithField::new(
-  empty_message : EmptyMessage,
+  empty_message? : EmptyMessage,
 ) -> EmptyMessageWithField {
   EmptyMessageWithField::{ empty_message, }
 }
@@ -1969,6 +2222,7 @@ pub impl @lib.Read for EmptyMessageWithField with fn read_with_limit(
       match (reader |> @lib.read_tag()) {
         (1, _) =>
           msg.empty_message = (reader |> @lib.read_message() : EmptyMessage)
+            |> Some
         (_, wire) => reader |> @lib.read_unknown(wire)
       }
     }
@@ -1984,16 +2238,19 @@ pub impl @lib.Write for EmptyMessageWithField with fn write(
   self : EmptyMessageWithField,
   writer : &@lib.Writer,
 ) -> Unit raise {
-  writer |> @lib.write_varint(10UL)
-  writer |> @lib.write_uint32(@lib.size_of(self.empty_message))
-  @lib.Write::write(self.empty_message, writer)
+  if self.empty_message is Some(v) {
+    writer |> @lib.write_varint(10UL)
+    writer |> @lib.write_uint32(@lib.size_of(v))
+    @lib.Write::write(v, writer)
+  }
 }
 
 ///|
 pub impl ToJson for EmptyMessageWithField with fn to_json(self) {
   let json : Map[String, Json] = {}
-  if self.empty_message != Default::default() {
-    json["emptyMessage"] = self.empty_message.to_json()
+  match self.empty_message {
+    Some(v) => json["emptyMessage"] = v.to_json()
+    _ => ()
   }
   Json::object(json)
 }
@@ -2012,7 +2269,7 @@ pub impl @json.FromJson for EmptyMessageWithField with fn from_json(
   for key, value in obj {
     match (key, value) {
       ("emptyMessage", value) =>
-        message.empty_message = @json.from_json(value, path~)
+        message.empty_message = Some(@json.from_json(value, path~))
       (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
@@ -2029,7 +2286,8 @@ pub impl @lib.AsyncRead for EmptyMessageWithField with fn read_with_limit(
       match (reader |> @lib.async_read_tag()) {
         (1, _) =>
           msg.empty_message = (
-            reader |> @lib.async_read_message() : EmptyMessage)
+              reader |> @lib.async_read_message() : EmptyMessage)
+            |> Some
         (_, wire) => reader |> @lib.async_read_unknown(wire)
       }
     }
@@ -2045,9 +2303,11 @@ pub impl @lib.AsyncWrite for EmptyMessageWithField with fn write(
   self : EmptyMessageWithField,
   writer : &@lib.AsyncWriter,
 ) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL)
-  writer |> @lib.async_write_uint32(@lib.size_of(self.empty_message))
-  @lib.AsyncWrite::write(self.empty_message, writer)
+  if self.empty_message is Some(v) {
+    writer |> @lib.async_write_varint(10UL)
+    writer |> @lib.async_write_uint32(@lib.size_of(v))
+    @lib.AsyncWrite::write(v, writer)
+  }
 }
 
 ///|

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -50,7 +50,9 @@ pub(all) struct BarMessage {
 } derive(Eq, Debug)
 pub impl @lib.Sized for BarMessage with fn size_of(self) {
   let mut size = 0U
-  size += 1U + @lib.size_of(self.b_int32)
+  if self.b_int32 != Default::default() {
+    size += 1U + @lib.size_of(self.b_int32)
+  }
   size
 }
 pub impl Default for BarMessage with fn default() -> BarMessage {
@@ -79,8 +81,10 @@ pub impl @lib.Read for BarMessage with fn read_with_limit(reader : @lib.LimitedR
   msg
 }
 pub impl @lib.Write for BarMessage with fn write(self: BarMessage, writer : &@lib.Writer) -> Unit raise {
+  if self.b_int32 != Default::default() {
   writer |> @lib.write_varint(8UL);
   writer |> @lib.write_int32(self.b_int32)
+  }
 }
 pub impl ToJson for BarMessage with fn to_json(self) {
   let json: Map[String, Json] = {}
@@ -118,8 +122,10 @@ pub impl @lib.AsyncRead for BarMessage with fn read_with_limit(reader : @lib.Lim
   msg
 }
 pub impl @lib.AsyncWrite for BarMessage with fn write(self: BarMessage, writer : &@lib.AsyncWriter) -> Unit raise {
+  if self.b_int32 != Default::default() {
   writer |> @lib.async_write_varint(8UL);
   writer |> @lib.async_write_int32(self.b_int32)
+  }
 }
 pub(all) struct FooMessage_FMapEntry {
   mut key : String
@@ -127,8 +133,12 @@ pub(all) struct FooMessage_FMapEntry {
 } derive(Eq, Debug)
 pub impl @lib.Sized for FooMessage_FMapEntry with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
-  size += 1U + @lib.size_of(self.value)
+  if self.key != Default::default() {
+    size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
+  }
+  if self.value != Default::default() {
+    size += 1U + @lib.size_of(self.value)
+  }
   size
 }
 pub impl Default for FooMessage_FMapEntry with fn default() -> FooMessage_FMapEntry {
@@ -160,10 +170,14 @@ pub impl @lib.Read for FooMessage_FMapEntry with fn read_with_limit(reader : @li
   msg
 }
 pub impl @lib.Write for FooMessage_FMapEntry with fn write(self: FooMessage_FMapEntry, writer : &@lib.Writer) -> Unit raise {
+  if self.key != Default::default() {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.key)
+  }
+  if self.value != Default::default() {
   writer |> @lib.write_varint(16UL);
   writer |> @lib.write_int32(self.value)
+  }
 }
 pub impl ToJson for FooMessage_FMapEntry with fn to_json(self) {
   let json: Map[String, Json] = {}
@@ -206,10 +220,14 @@ pub impl @lib.AsyncRead for FooMessage_FMapEntry with fn read_with_limit(reader 
   msg
 }
 pub impl @lib.AsyncWrite for FooMessage_FMapEntry with fn write(self: FooMessage_FMapEntry, writer : &@lib.AsyncWriter) -> Unit raise {
+  if self.key != Default::default() {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.key)
+  }
+  if self.value != Default::default() {
   writer |> @lib.async_write_varint(16UL);
   writer |> @lib.async_write_int32(self.value)
+  }
 }
 pub(all) struct FooMessage {
   mut f_int32 : Int
@@ -228,12 +246,12 @@ pub(all) struct FooMessage {
   mut f_float : Float
   mut f_bytes : Bytes
   mut f_string : String
-  mut f_bar_message : BarMessage 
+  mut f_bar_message : BarMessage?
   mut f_repeated_int32 : Array[Int]
   mut f_repeated_packed_int32 : Array[Int]
   mut f_repeated_packed_float : Array[Float]
-  mut f_baz : BazMessage 
-  mut f_nested : BazMessage_Nested 
+  mut f_baz : BazMessage?
+  mut f_nested : BazMessage_Nested?
   mut f_nested_enum : BazMessage_Nested_NestedEnum 
   mut f_map : Map[String, Int]
   mut f_repeated_string : Array[String]
@@ -278,29 +296,75 @@ pub impl ToJson for FooMessage_TestOneof with fn to_json(self : FooMessage_TestO
 }
 pub impl @lib.Sized for FooMessage with fn size_of(self) {
   let mut size = 0U
-  size += 1U + @lib.size_of(self.f_int32)
-  size += 1U + @lib.size_of(self.f_int64)
-  size += 1U + @lib.size_of(self.f_uint32)
-  size += 1U + @lib.size_of(self.f_uint64)
-  size += 1U + @lib.size_of(self.f_sint32)
-  size += 1U + @lib.size_of(self.f_sint64)
-  size += 1U + @lib.size_of(self.f_bool)
-  size += 1U + @lib.size_of(self.f_foo_enum)
-  size += 1U + 8U
-  size += 1U + 8U
-  size += 1U + 4U
-  size += 1U + 4U
-  size += 1U + 8U
-  size += 1U + 4U
-  size += 1U + { let size = @lib.size_of(self.f_bytes); @lib.size_of(size) + size }
-  size += 2U + { let size = @lib.size_of(self.f_string); @lib.size_of(size) + size }
-  size += 2U + { let size = @lib.size_of(self.f_bar_message); @lib.size_of(size) + size }
-  size += 2U + { let size = self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
-  size += 2U + { let size = self.f_repeated_packed_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
-  size += 2U + { let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4; @lib.size_of(size) + size}
-  size += 2U + { let size = @lib.size_of(self.f_baz); @lib.size_of(size) + size }
-  size += 2U + { let size = @lib.size_of(self.f_nested); @lib.size_of(size) + size }
-  size += 2U + @lib.size_of(self.f_nested_enum)
+  if self.f_int32 != Default::default() {
+    size += 1U + @lib.size_of(self.f_int32)
+  }
+  if self.f_int64 != Default::default() {
+    size += 1U + @lib.size_of(self.f_int64)
+  }
+  if self.f_uint32 != Default::default() {
+    size += 1U + @lib.size_of(self.f_uint32)
+  }
+  if self.f_uint64 != Default::default() {
+    size += 1U + @lib.size_of(self.f_uint64)
+  }
+  if self.f_sint32 != Default::default() {
+    size += 1U + @lib.size_of(self.f_sint32)
+  }
+  if self.f_sint64 != Default::default() {
+    size += 1U + @lib.size_of(self.f_sint64)
+  }
+  if self.f_bool != Default::default() {
+    size += 1U + @lib.size_of(self.f_bool)
+  }
+  if self.f_foo_enum != Default::default() {
+    size += 1U + @lib.size_of(self.f_foo_enum)
+  }
+  if self.f_fixed64 != Default::default() {
+    size += 1U + 8U
+  }
+  if self.f_sfixed64 != Default::default() {
+    size += 1U + 8U
+  }
+  if self.f_fixed32 != Default::default() {
+    size += 1U + 4U
+  }
+  if self.f_sfixed32 != Default::default() {
+    size += 1U + 4U
+  }
+  if self.f_double != Default::default() {
+    size += 1U + 8U
+  }
+  if self.f_float != Default::default() {
+    size += 1U + 4U
+  }
+  if self.f_bytes != Default::default() {
+    size += 1U + { let size = @lib.size_of(self.f_bytes); @lib.size_of(size) + size }
+  }
+  if self.f_string != Default::default() {
+    size += 2U + { let size = @lib.size_of(self.f_string); @lib.size_of(size) + size }
+  }
+  if self.f_bar_message is Some(v) {
+    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+  }
+  if !self.f_repeated_int32.is_empty() {
+    size += 2U + { let size = self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+  }
+  if !self.f_repeated_packed_int32.is_empty() {
+    size += 2U + { let size = self.f_repeated_packed_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+  }
+  if !self.f_repeated_packed_float.is_empty() {
+    size += 2U + { let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4; @lib.size_of(size) + size}
+  }
+  if self.f_baz is Some(v) {
+    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+  }
+  if self.f_nested is Some(v) {
+    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+  }
+  if self.f_nested_enum != Default::default() {
+    size += 2U + @lib.size_of(self.f_nested_enum)
+  }
   for k, v in self.f_map {
     let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }
     let value_size = 1U + @lib.size_of(v)
@@ -341,12 +405,12 @@ pub impl Default for FooMessage with fn default() -> FooMessage {
     f_float : Float::default(),
     f_bytes : Bytes::default(),
     f_string : String::default(),
-    f_bar_message : BarMessage::default(),
+    f_bar_message : None,
     f_repeated_int32 : [],
     f_repeated_packed_int32 : [],
     f_repeated_packed_float : [],
-    f_baz : BazMessage::default(),
-    f_nested : BazMessage_Nested::default(),
+    f_baz : None,
+    f_nested : None,
     f_nested_enum : BazMessage_Nested_NestedEnum::default(),
     f_map : {},
     f_repeated_string : [],
@@ -355,7 +419,7 @@ pub impl Default for FooMessage with fn default() -> FooMessage {
     test_oneof : FooMessage_TestOneof::NotSet,
   }
 }
-pub fn FooMessage::new(f_int32 : Int, f_int64 : Int64, f_uint32 : UInt, f_uint64 : UInt64, f_sint32 : Int, f_sint64 : Int64, f_bool : Bool, f_foo_enum : FooEnum, f_fixed64 : UInt64, f_sfixed64 : Int64, f_fixed32 : UInt, f_sfixed32 : Int, f_double : Double, f_float : Float, f_bytes : Bytes, f_string : String, f_bar_message : BarMessage, f_repeated_int32 : Array[Int], f_repeated_packed_int32 : Array[Int], f_repeated_packed_float : Array[Float], f_baz : BazMessage, f_nested : BazMessage_Nested, f_nested_enum : BazMessage_Nested_NestedEnum, f_map : Map[String, Int], f_repeated_string : Array[String], f_repeated_baz_message : Array[BazMessage], f_optional_string? : String, test_oneof?: FooMessage_TestOneof = FooMessage_TestOneof::NotSet) -> FooMessage {
+pub fn FooMessage::new(f_int32 : Int, f_int64 : Int64, f_uint32 : UInt, f_uint64 : UInt64, f_sint32 : Int, f_sint64 : Int64, f_bool : Bool, f_foo_enum : FooEnum, f_fixed64 : UInt64, f_sfixed64 : Int64, f_fixed32 : UInt, f_sfixed32 : Int, f_double : Double, f_float : Float, f_bytes : Bytes, f_string : String, f_bar_message? : BarMessage, f_repeated_int32 : Array[Int], f_repeated_packed_int32 : Array[Int], f_repeated_packed_float : Array[Float], f_baz? : BazMessage, f_nested? : BazMessage_Nested, f_nested_enum : BazMessage_Nested_NestedEnum, f_map : Map[String, Int], f_repeated_string : Array[String], f_repeated_baz_message : Array[BazMessage], f_optional_string? : String, test_oneof?: FooMessage_TestOneof = FooMessage_TestOneof::NotSet) -> FooMessage {
   FooMessage::{
     f_int32,
     f_int64,
@@ -408,15 +472,15 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(reader : @lib.LimitedR
       (14, _) => msg.f_float = reader |> @lib.read_float()
       (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
       (16, _) => msg.f_string = reader |> @lib.read_string()
-      (18, _) => msg.f_bar_message = (reader |> @lib.read_message() : BarMessage)
+      (18, _) => msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
       (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
       (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
       (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
       (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
       (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()) }
       (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-      (23, _) => msg.f_baz = (reader |> @lib.read_message() : BazMessage)
-      (24, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested)
+      (23, _) => msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
+      (24, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
       (25, _) => msg.f_nested_enum = reader |> @lib.read_enum() |> BazMessage_Nested_NestedEnum::from_enum
       (26, _) => { let {key, value} = (reader |> @lib.read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
       (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
@@ -435,67 +499,116 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(reader : @lib.LimitedR
   msg
 }
 pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@lib.Writer) -> Unit raise {
+  if self.f_int32 != Default::default() {
   writer |> @lib.write_varint(8UL);
   writer |> @lib.write_int32(self.f_int32)
+  }
+  if self.f_int64 != Default::default() {
   writer |> @lib.write_varint(16UL);
   writer |> @lib.write_int64(self.f_int64)
+  }
+  if self.f_uint32 != Default::default() {
   writer |> @lib.write_varint(24UL);
   writer |> @lib.write_uint32(self.f_uint32)
+  }
+  if self.f_uint64 != Default::default() {
   writer |> @lib.write_varint(32UL);
   writer |> @lib.write_uint64(self.f_uint64)
+  }
+  if self.f_sint32 != Default::default() {
   writer |> @lib.write_varint(40UL);
   writer |> @lib.write_sint32(self.f_sint32)
+  }
+  if self.f_sint64 != Default::default() {
   writer |> @lib.write_varint(48UL);
   writer |> @lib.write_sint64(self.f_sint64)
+  }
+  if self.f_bool != Default::default() {
   writer |> @lib.write_varint(56UL);
   writer |> @lib.write_bool(self.f_bool)
+  }
+  if self.f_foo_enum != Default::default() {
   writer |> @lib.write_varint(64UL);
   writer |> @lib.write_enum(self.f_foo_enum.to_enum())
+  }
+  if self.f_fixed64 != Default::default() {
   writer |> @lib.write_varint(73UL);
   writer |> @lib.write_fixed64(self.f_fixed64)
+  }
+  if self.f_sfixed64 != Default::default() {
   writer |> @lib.write_varint(81UL);
   writer |> @lib.write_sfixed64(self.f_sfixed64)
+  }
+  if self.f_fixed32 != Default::default() {
   writer |> @lib.write_varint(93UL);
   writer |> @lib.write_fixed32(self.f_fixed32)
+  }
+  if self.f_sfixed32 != Default::default() {
   writer |> @lib.write_varint(101UL);
   writer |> @lib.write_sfixed32(self.f_sfixed32)
+  }
+  if self.f_double != Default::default() {
   writer |> @lib.write_varint(105UL);
   writer |> @lib.write_double(self.f_double)
+  }
+  if self.f_float != Default::default() {
   writer |> @lib.write_varint(117UL);
   writer |> @lib.write_float(self.f_float)
+  }
+  if self.f_bytes != Default::default() {
   writer |> @lib.write_varint(122UL);
   writer |> @lib.write_bytes(self.f_bytes)
+  }
+  if self.f_string != Default::default() {
   writer |> @lib.write_varint(130UL);
   writer |> @lib.write_string(self.f_string)
-  writer |> @lib.write_varint(146UL);
-  writer |> @lib.write_uint32(@lib.size_of(self.f_bar_message)); @lib.Write::write(self.f_bar_message, writer)
-  writer |> @lib.write_varint(154UL)
-  let size = self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.f_repeated_int32 {
-      writer |> @lib.write_int32(item)
+  }
+  if self.f_bar_message is Some(v) {
+    writer |> @lib.write_varint(146UL);
+    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
 
   }
-  writer |> @lib.write_varint(162UL)
-  let size = self.f_repeated_packed_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.f_repeated_packed_int32 {
-      writer |> @lib.write_int32(item)
+  if !self.f_repeated_int32.is_empty() {
+    writer |> @lib.write_varint(154UL)
+    let size = self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.f_repeated_int32 {
+        writer |> @lib.write_int32(item)
+
+    }
+  }
+  if !self.f_repeated_packed_int32.is_empty() {
+    writer |> @lib.write_varint(162UL)
+    let size = self.f_repeated_packed_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.f_repeated_packed_int32 {
+        writer |> @lib.write_int32(item)
+
+    }
+  }
+  if !self.f_repeated_packed_float.is_empty() {
+    writer |> @lib.write_varint(170UL)
+    let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
+    writer |> @lib.write_uint32(size)
+    for item in self.f_repeated_packed_float {
+        writer |> @lib.write_float(item)
+
+    }
+  }
+  if self.f_baz is Some(v) {
+    writer |> @lib.write_varint(186UL);
+    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
 
   }
-  writer |> @lib.write_varint(170UL)
-  let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
-  writer |> @lib.write_uint32(size)
-  for item in self.f_repeated_packed_float {
-      writer |> @lib.write_float(item)
+  if self.f_nested is Some(v) {
+    writer |> @lib.write_varint(194UL);
+    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
 
   }
-  writer |> @lib.write_varint(186UL);
-  writer |> @lib.write_uint32(@lib.size_of(self.f_baz)); @lib.Write::write(self.f_baz, writer)
-  writer |> @lib.write_varint(194UL);
-  writer |> @lib.write_uint32(@lib.size_of(self.f_nested)); @lib.Write::write(self.f_nested, writer)
+  if self.f_nested_enum != Default::default() {
   writer |> @lib.write_varint(200UL);
   writer |> @lib.write_enum(self.f_nested_enum.to_enum())
+  }
   let keys = self.f_map.keys().collect()
   for i in 0..<keys.length() {
     let k = keys[i]
@@ -595,9 +708,10 @@ pub impl ToJson for FooMessage with fn to_json(self) {
   if self.f_string != Default::default() {
   json["fString"] = self.f_string.to_json()
   }
-  if self.f_bar_message != Default::default() {
-  json["fBarMessage"] = self.f_bar_message.to_json()
-  }
+  match self.f_bar_message {
+      Some(v) => json["fBarMessage"] = v.to_json()
+      _ => ()
+    }
   if self.f_repeated_int32 != Default::default() {
   json["fRepeatedInt32"] = self.f_repeated_int32.to_json()
   }
@@ -607,12 +721,14 @@ pub impl ToJson for FooMessage with fn to_json(self) {
   if self.f_repeated_packed_float != Default::default() {
   json["fRepeatedPackedFloat"] = self.f_repeated_packed_float.to_json()
   }
-  if self.f_baz != Default::default() {
-  json["fBaz"] = self.f_baz.to_json()
-  }
-  if self.f_nested != Default::default() {
-  json["fNested"] = self.f_nested.to_json()
-  }
+  match self.f_baz {
+      Some(v) => json["fBaz"] = v.to_json()
+      _ => ()
+    }
+  match self.f_nested {
+      Some(v) => json["fNested"] = v.to_json()
+      _ => ()
+    }
   if self.f_nested_enum != Default::default() {
   json["fNestedEnum"] = self.f_nested_enum.to_json()
   }
@@ -660,15 +776,15 @@ pub impl @json.FromJson for FooMessage with fn from_json(json: Json, path: @json
       ("fFloat", Number(value, ..)) => message.f_float = Float::from_double(value)
       ("fBytes", String(value)) => message.f_bytes = @lib.base64_decode(value)
       ("fString", value) => message.f_string = @json.from_json(value, path~)
-      ("fBarMessage", value) => message.f_bar_message = @json.from_json(value, path~)
+      ("fBarMessage", value) => message.f_bar_message = Some(@json.from_json(value, path~))
       ("fRepeatedInt32", Array(value)) => message.f_repeated_int32 = value.map(v => 
 @json.from_json(v, path~))
       ("fRepeatedPackedInt32", Array(value)) => message.f_repeated_packed_int32 = value.map(v => 
 @json.from_json(v, path~))
       ("fRepeatedPackedFloat", Array(value)) => message.f_repeated_packed_float = value.map(v => 
 Float::from_double(@json.from_json(v, path~)))
-      ("fBaz", value) => message.f_baz = @json.from_json(value, path~)
-      ("fNested", value) => message.f_nested = @json.from_json(value, path~)
+      ("fBaz", value) => message.f_baz = Some(@json.from_json(value, path~))
+      ("fNested", value) => message.f_nested = Some(@json.from_json(value, path~))
       ("fNestedEnum", value) => message.f_nested_enum = @json.from_json(value, path~)
       ("fMap", _) => message.f_map = @json.from_json(value, path~)
       ("fRepeatedString", Array(value)) => message.f_repeated_string = value.map(v => 
@@ -705,15 +821,15 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(reader : @lib.Lim
       (14, _) => msg.f_float = reader |> @lib.async_read_float()
       (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
       (16, _) => msg.f_string = reader |> @lib.async_read_string()
-      (18, _) => msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage)
+      (18, _) => msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage) |> Some
       (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
       (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
       (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
       (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
       (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()) }
       (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-      (23, _) => msg.f_baz = (reader |> @lib.async_read_message() : BazMessage)
-      (24, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested)
+      (23, _) => msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
+      (24, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
       (25, _) => msg.f_nested_enum = reader |> @lib.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum
       (26, _) => { let {key, value} = (reader |> @lib.async_read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
       (30, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
@@ -732,67 +848,116 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(reader : @lib.Lim
   msg
 }
 pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer : &@lib.AsyncWriter) -> Unit raise {
+  if self.f_int32 != Default::default() {
   writer |> @lib.async_write_varint(8UL);
   writer |> @lib.async_write_int32(self.f_int32)
+  }
+  if self.f_int64 != Default::default() {
   writer |> @lib.async_write_varint(16UL);
   writer |> @lib.async_write_int64(self.f_int64)
+  }
+  if self.f_uint32 != Default::default() {
   writer |> @lib.async_write_varint(24UL);
   writer |> @lib.async_write_uint32(self.f_uint32)
+  }
+  if self.f_uint64 != Default::default() {
   writer |> @lib.async_write_varint(32UL);
   writer |> @lib.async_write_uint64(self.f_uint64)
+  }
+  if self.f_sint32 != Default::default() {
   writer |> @lib.async_write_varint(40UL);
   writer |> @lib.async_write_sint32(self.f_sint32)
+  }
+  if self.f_sint64 != Default::default() {
   writer |> @lib.async_write_varint(48UL);
   writer |> @lib.async_write_sint64(self.f_sint64)
+  }
+  if self.f_bool != Default::default() {
   writer |> @lib.async_write_varint(56UL);
   writer |> @lib.async_write_bool(self.f_bool)
+  }
+  if self.f_foo_enum != Default::default() {
   writer |> @lib.async_write_varint(64UL);
   writer |> @lib.async_write_enum(self.f_foo_enum.to_enum())
+  }
+  if self.f_fixed64 != Default::default() {
   writer |> @lib.async_write_varint(73UL);
   writer |> @lib.async_write_fixed64(self.f_fixed64)
+  }
+  if self.f_sfixed64 != Default::default() {
   writer |> @lib.async_write_varint(81UL);
   writer |> @lib.async_write_sfixed64(self.f_sfixed64)
+  }
+  if self.f_fixed32 != Default::default() {
   writer |> @lib.async_write_varint(93UL);
   writer |> @lib.async_write_fixed32(self.f_fixed32)
+  }
+  if self.f_sfixed32 != Default::default() {
   writer |> @lib.async_write_varint(101UL);
   writer |> @lib.async_write_sfixed32(self.f_sfixed32)
+  }
+  if self.f_double != Default::default() {
   writer |> @lib.async_write_varint(105UL);
   writer |> @lib.async_write_double(self.f_double)
+  }
+  if self.f_float != Default::default() {
   writer |> @lib.async_write_varint(117UL);
   writer |> @lib.async_write_float(self.f_float)
+  }
+  if self.f_bytes != Default::default() {
   writer |> @lib.async_write_varint(122UL);
   writer |> @lib.async_write_bytes(self.f_bytes)
+  }
+  if self.f_string != Default::default() {
   writer |> @lib.async_write_varint(130UL);
   writer |> @lib.async_write_string(self.f_string)
-  writer |> @lib.async_write_varint(146UL);
-  writer |> @lib.async_write_uint32(@lib.size_of(self.f_bar_message)); @lib.AsyncWrite::write(self.f_bar_message, writer)
-  writer |> @lib.async_write_varint(154UL)
-  let size = self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.f_repeated_int32 {
-      writer |> @lib.async_write_int32(item)
+  }
+  if self.f_bar_message is Some(v) {
+    writer |> @lib.async_write_varint(146UL);
+    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
 
   }
-  writer |> @lib.async_write_varint(162UL)
-  let size = self.f_repeated_packed_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.f_repeated_packed_int32 {
-      writer |> @lib.async_write_int32(item)
+  if !self.f_repeated_int32.is_empty() {
+    writer |> @lib.async_write_varint(154UL)
+    let size = self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.f_repeated_int32 {
+        writer |> @lib.async_write_int32(item)
+
+    }
+  }
+  if !self.f_repeated_packed_int32.is_empty() {
+    writer |> @lib.async_write_varint(162UL)
+    let size = self.f_repeated_packed_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.f_repeated_packed_int32 {
+        writer |> @lib.async_write_int32(item)
+
+    }
+  }
+  if !self.f_repeated_packed_float.is_empty() {
+    writer |> @lib.async_write_varint(170UL)
+    let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
+    writer |> @lib.async_write_uint32(size)
+    for item in self.f_repeated_packed_float {
+        writer |> @lib.async_write_float(item)
+
+    }
+  }
+  if self.f_baz is Some(v) {
+    writer |> @lib.async_write_varint(186UL);
+    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
 
   }
-  writer |> @lib.async_write_varint(170UL)
-  let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4
-  writer |> @lib.async_write_uint32(size)
-  for item in self.f_repeated_packed_float {
-      writer |> @lib.async_write_float(item)
+  if self.f_nested is Some(v) {
+    writer |> @lib.async_write_varint(194UL);
+    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
 
   }
-  writer |> @lib.async_write_varint(186UL);
-  writer |> @lib.async_write_uint32(@lib.size_of(self.f_baz)); @lib.AsyncWrite::write(self.f_baz, writer)
-  writer |> @lib.async_write_varint(194UL);
-  writer |> @lib.async_write_uint32(@lib.size_of(self.f_nested)); @lib.AsyncWrite::write(self.f_nested, writer)
+  if self.f_nested_enum != Default::default() {
   writer |> @lib.async_write_varint(200UL);
   writer |> @lib.async_write_enum(self.f_nested_enum.to_enum())
+  }
   let keys = self.f_map.keys().collect()
   for i in 0..<keys.length() {
     let k = keys[i]
@@ -900,7 +1065,9 @@ pub(all) struct BazMessage_Nested_NestedMessage {
 } derive(Eq, Debug)
 pub impl @lib.Sized for BazMessage_Nested_NestedMessage with fn size_of(self) {
   let mut size = 0U
-  size += 1U + @lib.size_of(self.f_nested)
+  if self.f_nested != Default::default() {
+    size += 1U + @lib.size_of(self.f_nested)
+  }
   size
 }
 pub impl Default for BazMessage_Nested_NestedMessage with fn default() -> BazMessage_Nested_NestedMessage {
@@ -929,8 +1096,10 @@ pub impl @lib.Read for BazMessage_Nested_NestedMessage with fn read_with_limit(r
   msg
 }
 pub impl @lib.Write for BazMessage_Nested_NestedMessage with fn write(self: BazMessage_Nested_NestedMessage, writer : &@lib.Writer) -> Unit raise {
+  if self.f_nested != Default::default() {
   writer |> @lib.write_varint(8UL);
   writer |> @lib.write_int32(self.f_nested)
+  }
 }
 pub impl ToJson for BazMessage_Nested_NestedMessage with fn to_json(self) {
   let json: Map[String, Json] = {}
@@ -968,23 +1137,27 @@ pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with fn read_with_li
   msg
 }
 pub impl @lib.AsyncWrite for BazMessage_Nested_NestedMessage with fn write(self: BazMessage_Nested_NestedMessage, writer : &@lib.AsyncWriter) -> Unit raise {
+  if self.f_nested != Default::default() {
   writer |> @lib.async_write_varint(8UL);
   writer |> @lib.async_write_int32(self.f_nested)
+  }
 }
 pub(all) struct BazMessage_Nested {
-  mut f_nested : BazMessage_Nested_NestedMessage 
+  mut f_nested : BazMessage_Nested_NestedMessage?
 } derive(Eq, Debug)
 pub impl @lib.Sized for BazMessage_Nested with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.f_nested); @lib.size_of(size) + size }
+  if self.f_nested is Some(v) {
+    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+  }
   size
 }
 pub impl Default for BazMessage_Nested with fn default() -> BazMessage_Nested {
   BazMessage_Nested::{
-    f_nested : BazMessage_Nested_NestedMessage::default(),
+    f_nested : None,
   }
 }
-pub fn BazMessage_Nested::new(f_nested : BazMessage_Nested_NestedMessage) -> BazMessage_Nested {
+pub fn BazMessage_Nested::new(f_nested? : BazMessage_Nested_NestedMessage) -> BazMessage_Nested {
   BazMessage_Nested::{
     f_nested,
   }
@@ -994,7 +1167,7 @@ pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(reader : @lib.L
   try {
     for ;; {
       match (reader |> @lib.read_tag()) {
-      (1, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage)
+      (1, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage) |> Some
        (_, wire) => reader |> @lib.read_unknown(wire)
       }
     }
@@ -1005,14 +1178,18 @@ pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(reader : @lib.L
   msg
 }
 pub impl @lib.Write for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.Writer) -> Unit raise {
-  writer |> @lib.write_varint(10UL);
-  writer |> @lib.write_uint32(@lib.size_of(self.f_nested)); @lib.Write::write(self.f_nested, writer)
+  if self.f_nested is Some(v) {
+    writer |> @lib.write_varint(10UL);
+    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+
+  }
 }
 pub impl ToJson for BazMessage_Nested with fn to_json(self) {
   let json: Map[String, Json] = {}
-  if self.f_nested != Default::default() {
-  json["fNested"] = self.f_nested.to_json()
-  }
+  match self.f_nested {
+      Some(v) => json["fNested"] = v.to_json()
+      _ => ()
+    }
   Json::object(json)
 }
 pub impl @json.FromJson for BazMessage_Nested with fn from_json(json: Json, path: @json.JsonPath) -> BazMessage_Nested raise {
@@ -1022,7 +1199,7 @@ pub impl @json.FromJson for BazMessage_Nested with fn from_json(json: Json, path
   let message = BazMessage_Nested::default()
   for key, value in obj {
     match (key, value) {
-      ("fNested", value) => message.f_nested = @json.from_json(value, path~)
+      ("fNested", value) => message.f_nested = Some(@json.from_json(value, path~))
       (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
@@ -1033,7 +1210,7 @@ pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(reader : @
   try {
     for ;; {
       match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage)
+      (1, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage) |> Some
        (_, wire) => reader |> @lib.async_read_unknown(wire)
       }
     }
@@ -1044,29 +1221,38 @@ pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(reader : @
   msg
 }
 pub impl @lib.AsyncWrite for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.AsyncWriter) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL);
-  writer |> @lib.async_write_uint32(@lib.size_of(self.f_nested)); @lib.AsyncWrite::write(self.f_nested, writer)
+  if self.f_nested is Some(v) {
+    writer |> @lib.async_write_varint(10UL);
+    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+
+  }
 }
 pub(all) struct BazMessage {
-  mut nested : BazMessage_Nested 
+  mut nested : BazMessage_Nested?
   mut b_int64 : Int64
   mut b_string : String
 } derive(Eq, Debug)
 pub impl @lib.Sized for BazMessage with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.nested); @lib.size_of(size) + size }
-  size += 1U + @lib.size_of(self.b_int64)
-  size += 1U + { let size = @lib.size_of(self.b_string); @lib.size_of(size) + size }
+  if self.nested is Some(v) {
+    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+  }
+  if self.b_int64 != Default::default() {
+    size += 1U + @lib.size_of(self.b_int64)
+  }
+  if self.b_string != Default::default() {
+    size += 1U + { let size = @lib.size_of(self.b_string); @lib.size_of(size) + size }
+  }
   size
 }
 pub impl Default for BazMessage with fn default() -> BazMessage {
   BazMessage::{
-    nested : BazMessage_Nested::default(),
+    nested : None,
     b_int64 : Int64::default(),
     b_string : String::default(),
   }
 }
-pub fn BazMessage::new(nested : BazMessage_Nested, b_int64 : Int64, b_string : String) -> BazMessage {
+pub fn BazMessage::new(nested? : BazMessage_Nested, b_int64 : Int64, b_string : String) -> BazMessage {
   BazMessage::{
     nested,
     b_int64,
@@ -1078,7 +1264,7 @@ pub impl @lib.Read for BazMessage with fn read_with_limit(reader : @lib.LimitedR
   try {
     for ;; {
       match (reader |> @lib.read_tag()) {
-      (1, _) => msg.nested = (reader |> @lib.read_message() : BazMessage_Nested)
+      (1, _) => msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
       (2, _) => msg.b_int64 = reader |> @lib.read_int64()
       (3, _) => msg.b_string = reader |> @lib.read_string()
        (_, wire) => reader |> @lib.read_unknown(wire)
@@ -1091,18 +1277,26 @@ pub impl @lib.Read for BazMessage with fn read_with_limit(reader : @lib.LimitedR
   msg
 }
 pub impl @lib.Write for BazMessage with fn write(self: BazMessage, writer : &@lib.Writer) -> Unit raise {
-  writer |> @lib.write_varint(10UL);
-  writer |> @lib.write_uint32(@lib.size_of(self.nested)); @lib.Write::write(self.nested, writer)
+  if self.nested is Some(v) {
+    writer |> @lib.write_varint(10UL);
+    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+
+  }
+  if self.b_int64 != Default::default() {
   writer |> @lib.write_varint(16UL);
   writer |> @lib.write_int64(self.b_int64)
+  }
+  if self.b_string != Default::default() {
   writer |> @lib.write_varint(26UL);
   writer |> @lib.write_string(self.b_string)
+  }
 }
 pub impl ToJson for BazMessage with fn to_json(self) {
   let json: Map[String, Json] = {}
-  if self.nested != Default::default() {
-  json["nested"] = self.nested.to_json()
-  }
+  match self.nested {
+      Some(v) => json["nested"] = v.to_json()
+      _ => ()
+    }
   if self.b_int64 != Default::default() {
   json["bInt64"] = self.b_int64.to_json()
   }
@@ -1118,7 +1312,7 @@ pub impl @json.FromJson for BazMessage with fn from_json(json: Json, path: @json
   let message = BazMessage::default()
   for key, value in obj {
     match (key, value) {
-      ("nested", value) => message.nested = @json.from_json(value, path~)
+      ("nested", value) => message.nested = Some(@json.from_json(value, path~))
       ("bInt64", value) => message.b_int64 = @json.from_json(value, path~)
       ("bString", value) => message.b_string = @json.from_json(value, path~)
       (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
@@ -1131,7 +1325,7 @@ pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(reader : @lib.Lim
   try {
     for ;; {
       match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested)
+      (1, _) => msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
       (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
       (3, _) => msg.b_string = reader |> @lib.async_read_string()
        (_, wire) => reader |> @lib.async_read_unknown(wire)
@@ -1144,12 +1338,19 @@ pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(reader : @lib.Lim
   msg
 }
 pub impl @lib.AsyncWrite for BazMessage with fn write(self: BazMessage, writer : &@lib.AsyncWriter) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL);
-  writer |> @lib.async_write_uint32(@lib.size_of(self.nested)); @lib.AsyncWrite::write(self.nested, writer)
+  if self.nested is Some(v) {
+    writer |> @lib.async_write_varint(10UL);
+    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+
+  }
+  if self.b_int64 != Default::default() {
   writer |> @lib.async_write_varint(16UL);
   writer |> @lib.async_write_int64(self.b_int64)
+  }
+  if self.b_string != Default::default() {
   writer |> @lib.async_write_varint(26UL);
   writer |> @lib.async_write_string(self.b_string)
+  }
 }
 pub(all) struct RepeatedMessage {
   mut bar_message : Array[BarMessage]

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -4,8 +4,12 @@ pub(all) struct Hello_MetadataEntry {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Hello_MetadataEntry with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
-  size += 1U + { let size = @lib.size_of(self.value); @lib.size_of(size) + size }
+  if self.key != Default::default() {
+    size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
+  }
+  if self.value != Default::default() {
+    size += 1U + { let size = @lib.size_of(self.value); @lib.size_of(size) + size }
+  }
   size
 }
 pub impl Default for Hello_MetadataEntry with fn default() -> Hello_MetadataEntry {
@@ -37,10 +41,14 @@ pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib
   msg
 }
 pub impl @lib.Write for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.Writer) -> Unit raise {
+  if self.key != Default::default() {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.key)
+  }
+  if self.value != Default::default() {
   writer |> @lib.write_varint(18UL);
   writer |> @lib.write_string(self.value)
+  }
 }
 pub impl ToJson for Hello_MetadataEntry with fn to_json(self) {
   let json: Map[String, Json] = {}
@@ -83,10 +91,14 @@ pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader :
   msg
 }
 pub impl @lib.AsyncWrite for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.AsyncWriter) -> Unit raise {
+  if self.key != Default::default() {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.key)
+  }
+  if self.value != Default::default() {
   writer |> @lib.async_write_varint(18UL);
   writer |> @lib.async_write_string(self.value)
+  }
 }
 pub(all) struct Hello {
   mut name : String
@@ -97,8 +109,12 @@ pub(all) struct Hello {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Hello with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
-  size += 1U + @lib.size_of(self.age)
+  if self.name != Default::default() {
+    size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
+  }
+  if self.age != Default::default() {
+    size += 1U + @lib.size_of(self.age)
+  }
   for s in self.hobbies {
     size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
@@ -150,10 +166,14 @@ pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader
   msg
 }
 pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) -> Unit raise {
+  if self.name != Default::default() {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.name)
+  }
+  if self.age != Default::default() {
   writer |> @lib.write_varint(16UL);
   writer |> @lib.write_int32(self.age)
+  }
   for item in self.hobbies {
     writer |> @lib.write_varint(26UL)
     writer |> @lib.write_string(item)
@@ -238,10 +258,14 @@ pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedR
   msg
 }
 pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.AsyncWriter) -> Unit raise {
+  if self.name != Default::default() {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.name)
+  }
+  if self.age != Default::default() {
   writer |> @lib.async_write_varint(16UL);
   writer |> @lib.async_write_int32(self.age)
+  }
   for item in self.hobbies {
     writer |> @lib.async_write_varint(26UL)
     writer |> @lib.async_write_string(item)

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
@@ -1,17 +1,19 @@
 pub(all) struct Test {
-  mut test_hello : @lib1.Hello 
+  mut test_hello : @lib1.Hello?
 } derive(Eq, Debug)
 pub impl @lib.Sized for Test with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.test_hello); @lib.size_of(size) + size }
+  if self.test_hello is Some(v) {
+    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+  }
   size
 }
 pub impl Default for Test with fn default() -> Test {
   Test::{
-    test_hello : @lib1.Hello::default(),
+    test_hello : None,
   }
 }
-pub fn Test::new(test_hello : @lib1.Hello) -> Test {
+pub fn Test::new(test_hello? : @lib1.Hello) -> Test {
   Test::{
     test_hello,
   }
@@ -21,7 +23,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   try {
     for ;; {
       match (reader |> @lib.read_tag()) {
-      (1, _) => msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello)
+      (1, _) => msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello) |> Some
        (_, wire) => reader |> @lib.read_unknown(wire)
       }
     }
@@ -32,14 +34,18 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   msg
 }
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
-  writer |> @lib.write_varint(10UL);
-  writer |> @lib.write_uint32(@lib.size_of(self.test_hello)); @lib.Write::write(self.test_hello, writer)
+  if self.test_hello is Some(v) {
+    writer |> @lib.write_varint(10UL);
+    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+
+  }
 }
 pub impl ToJson for Test with fn to_json(self) {
   let json: Map[String, Json] = {}
-  if self.test_hello != Default::default() {
-  json["testHello"] = self.test_hello.to_json()
-  }
+  match self.test_hello {
+      Some(v) => json["testHello"] = v.to_json()
+      _ => ()
+    }
   Json::object(json)
 }
 pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonPath) -> Test raise {
@@ -49,7 +55,7 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
   let message = Test::default()
   for key, value in obj {
     match (key, value) {
-      ("testHello", value) => message.test_hello = @json.from_json(value, path~)
+      ("testHello", value) => message.test_hello = Some(@json.from_json(value, path~))
       (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
@@ -60,7 +66,7 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   try {
     for ;; {
       match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello)
+      (1, _) => msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello) |> Some
        (_, wire) => reader |> @lib.async_read_unknown(wire)
       }
     }
@@ -71,6 +77,9 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   msg
 }
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL);
-  writer |> @lib.async_write_uint32(@lib.size_of(self.test_hello)); @lib.AsyncWrite::write(self.test_hello, writer)
+  if self.test_hello is Some(v) {
+    writer |> @lib.async_write_varint(10UL);
+    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+
+  }
 }

--- a/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
@@ -1,17 +1,19 @@
 pub(all) struct Test {
-  mut created_at : @protobuf.Timestamp 
+  mut created_at : @protobuf.Timestamp?
 } derive(Eq, Debug)
 pub impl @lib.Sized for Test with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.created_at); @lib.size_of(size) + size }
+  if self.created_at is Some(v) {
+    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+  }
   size
 }
 pub impl Default for Test with fn default() -> Test {
   Test::{
-    created_at : @protobuf.Timestamp::default(),
+    created_at : None,
   }
 }
-pub fn Test::new(created_at : @protobuf.Timestamp) -> Test {
+pub fn Test::new(created_at? : @protobuf.Timestamp) -> Test {
   Test::{
     created_at,
   }
@@ -21,7 +23,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   try {
     for ;; {
       match (reader |> @lib.read_tag()) {
-      (1, _) => msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp)
+      (1, _) => msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp) |> Some
        (_, wire) => reader |> @lib.read_unknown(wire)
       }
     }
@@ -32,14 +34,18 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   msg
 }
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
-  writer |> @lib.write_varint(10UL);
-  writer |> @lib.write_uint32(@lib.size_of(self.created_at)); @lib.Write::write(self.created_at, writer)
+  if self.created_at is Some(v) {
+    writer |> @lib.write_varint(10UL);
+    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+
+  }
 }
 pub impl ToJson for Test with fn to_json(self) {
   let json: Map[String, Json] = {}
-  if self.created_at != Default::default() {
-  json["createdAt"] = self.created_at.to_json()
-  }
+  match self.created_at {
+      Some(v) => json["createdAt"] = v.to_json()
+      _ => ()
+    }
   Json::object(json)
 }
 pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonPath) -> Test raise {
@@ -49,7 +55,7 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
   let message = Test::default()
   for key, value in obj {
     match (key, value) {
-      ("createdAt", value) => message.created_at = @json.from_json(value, path~)
+      ("createdAt", value) => message.created_at = Some(@json.from_json(value, path~))
       (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
@@ -60,7 +66,7 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   try {
     for ;; {
       match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp)
+      (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp) |> Some
        (_, wire) => reader |> @lib.async_read_unknown(wire)
       }
     }
@@ -71,6 +77,9 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   msg
 }
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL);
-  writer |> @lib.async_write_uint32(@lib.size_of(self.created_at)); @lib.AsyncWrite::write(self.created_at, writer)
+  if self.created_at is Some(v) {
+    writer |> @lib.async_write_varint(10UL);
+    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+
+  }
 }

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -4,8 +4,12 @@ pub(all) struct Hello_MetadataEntry {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Hello_MetadataEntry with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
-  size += 1U + { let size = @lib.size_of(self.value); @lib.size_of(size) + size }
+  if self.key != Default::default() {
+    size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
+  }
+  if self.value != Default::default() {
+    size += 1U + { let size = @lib.size_of(self.value); @lib.size_of(size) + size }
+  }
   size
 }
 pub impl Default for Hello_MetadataEntry with fn default() -> Hello_MetadataEntry {
@@ -37,10 +41,14 @@ pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib
   msg
 }
 pub impl @lib.Write for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.Writer) -> Unit raise {
+  if self.key != Default::default() {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.key)
+  }
+  if self.value != Default::default() {
   writer |> @lib.write_varint(18UL);
   writer |> @lib.write_string(self.value)
+  }
 }
 pub impl ToJson for Hello_MetadataEntry with fn to_json(self) {
   let json: Map[String, Json] = {}
@@ -83,10 +91,14 @@ pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader :
   msg
 }
 pub impl @lib.AsyncWrite for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.AsyncWriter) -> Unit raise {
+  if self.key != Default::default() {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.key)
+  }
+  if self.value != Default::default() {
   writer |> @lib.async_write_varint(18UL);
   writer |> @lib.async_write_string(self.value)
+  }
 }
 pub(all) struct Hello {
   mut name : String
@@ -97,8 +109,12 @@ pub(all) struct Hello {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Hello with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
-  size += 1U + @lib.size_of(self.age)
+  if self.name != Default::default() {
+    size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
+  }
+  if self.age != Default::default() {
+    size += 1U + @lib.size_of(self.age)
+  }
   for s in self.hobbies {
     size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
   }
@@ -150,10 +166,14 @@ pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader
   msg
 }
 pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) -> Unit raise {
+  if self.name != Default::default() {
   writer |> @lib.write_varint(10UL);
   writer |> @lib.write_string(self.name)
+  }
+  if self.age != Default::default() {
   writer |> @lib.write_varint(16UL);
   writer |> @lib.write_int32(self.age)
+  }
   for item in self.hobbies {
     writer |> @lib.write_varint(26UL)
     writer |> @lib.write_string(item)
@@ -238,10 +258,14 @@ pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedR
   msg
 }
 pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.AsyncWriter) -> Unit raise {
+  if self.name != Default::default() {
   writer |> @lib.async_write_varint(10UL);
   writer |> @lib.async_write_string(self.name)
+  }
+  if self.age != Default::default() {
   writer |> @lib.async_write_varint(16UL);
   writer |> @lib.async_write_int32(self.age)
+  }
   for item in self.hobbies {
     writer |> @lib.async_write_varint(26UL)
     writer |> @lib.async_write_string(item)

--- a/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
@@ -1,17 +1,19 @@
 pub(all) struct Test {
-  mut created_at : @test2.Hello 
+  mut created_at : @test2.Hello?
 } derive(Eq, Debug)
 pub impl @lib.Sized for Test with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.created_at); @lib.size_of(size) + size }
+  if self.created_at is Some(v) {
+    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+  }
   size
 }
 pub impl Default for Test with fn default() -> Test {
   Test::{
-    created_at : @test2.Hello::default(),
+    created_at : None,
   }
 }
-pub fn Test::new(created_at : @test2.Hello) -> Test {
+pub fn Test::new(created_at? : @test2.Hello) -> Test {
   Test::{
     created_at,
   }
@@ -21,7 +23,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   try {
     for ;; {
       match (reader |> @lib.read_tag()) {
-      (1, _) => msg.created_at = (reader |> @lib.read_message() : @test2.Hello)
+      (1, _) => msg.created_at = (reader |> @lib.read_message() : @test2.Hello) |> Some
        (_, wire) => reader |> @lib.read_unknown(wire)
       }
     }
@@ -32,14 +34,18 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   msg
 }
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
-  writer |> @lib.write_varint(10UL);
-  writer |> @lib.write_uint32(@lib.size_of(self.created_at)); @lib.Write::write(self.created_at, writer)
+  if self.created_at is Some(v) {
+    writer |> @lib.write_varint(10UL);
+    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+
+  }
 }
 pub impl ToJson for Test with fn to_json(self) {
   let json: Map[String, Json] = {}
-  if self.created_at != Default::default() {
-  json["createdAt"] = self.created_at.to_json()
-  }
+  match self.created_at {
+      Some(v) => json["createdAt"] = v.to_json()
+      _ => ()
+    }
   Json::object(json)
 }
 pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonPath) -> Test raise {
@@ -49,7 +55,7 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
   let message = Test::default()
   for key, value in obj {
     match (key, value) {
-      ("createdAt", value) => message.created_at = @json.from_json(value, path~)
+      ("createdAt", value) => message.created_at = Some(@json.from_json(value, path~))
       (key, _) => raise @json.JsonDecodeError((path, "Unknown field \{key}"))
     }
   }
@@ -60,7 +66,7 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   try {
     for ;; {
       match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello)
+      (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello) |> Some
        (_, wire) => reader |> @lib.async_read_unknown(wire)
       }
     }
@@ -71,6 +77,9 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   msg
 }
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL);
-  writer |> @lib.async_write_uint32(@lib.size_of(self.created_at)); @lib.AsyncWrite::write(self.created_at, writer)
+  if self.created_at is Some(v) {
+    writer |> @lib.async_write_varint(10UL);
+    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+
+  }
 }

--- a/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
@@ -4,8 +4,12 @@ pub(all) struct Timestamp {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Timestamp with fn size_of(self) {
   let mut size = 0U
-  size += 1U + @lib.size_of(self.seconds)
-  size += 1U + @lib.size_of(self.nanos)
+  if self.seconds != Default::default() {
+    size += 1U + @lib.size_of(self.seconds)
+  }
+  if self.nanos != Default::default() {
+    size += 1U + @lib.size_of(self.nanos)
+  }
   size
 }
 pub impl Default for Timestamp with fn default() -> Timestamp {
@@ -37,10 +41,14 @@ pub impl @lib.Read for Timestamp with fn read_with_limit(reader : @lib.LimitedRe
   msg
 }
 pub impl @lib.Write for Timestamp with fn write(self: Timestamp, writer : &@lib.Writer) -> Unit raise {
+  if self.seconds != Default::default() {
   writer |> @lib.write_varint(8UL);
   writer |> @lib.write_int64(self.seconds)
+  }
+  if self.nanos != Default::default() {
   writer |> @lib.write_varint(16UL);
   writer |> @lib.write_int32(self.nanos)
+  }
 }
 pub impl ToJson for Timestamp with fn to_json(self) {
   let json: Map[String, Json] = {}
@@ -83,8 +91,12 @@ pub impl @lib.AsyncRead for Timestamp with fn read_with_limit(reader : @lib.Limi
   msg
 }
 pub impl @lib.AsyncWrite for Timestamp with fn write(self: Timestamp, writer : &@lib.AsyncWriter) -> Unit raise {
+  if self.seconds != Default::default() {
   writer |> @lib.async_write_varint(8UL);
   writer |> @lib.async_write_int64(self.seconds)
+  }
+  if self.nanos != Default::default() {
   writer |> @lib.async_write_varint(16UL);
   writer |> @lib.async_write_int32(self.nanos)
+  }
 }

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -6605,8 +6605,12 @@ pub(all) struct SourceCodeInfo_Location {
 } derive(Eq, Debug)
 pub impl @lib.Sized for SourceCodeInfo_Location with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
-  size += 1U + { let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+  if !self.path.is_empty() {
+    size += 1U + { let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+  }
+  if !self.span.is_empty() {
+    size += 1U + { let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+  }
   if self.leading_comments is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
@@ -6658,19 +6662,23 @@ pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(reader : 
   msg
 }
 pub impl @lib.Write for SourceCodeInfo_Location with fn write(self: SourceCodeInfo_Location, writer : &@lib.Writer) -> Unit raise {
-  writer |> @lib.write_varint(10UL)
-  let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.path {
-      writer |> @lib.write_int32(item)
+  if !self.path.is_empty() {
+    writer |> @lib.write_varint(10UL)
+    let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.path {
+        writer |> @lib.write_int32(item)
 
+    }
   }
-  writer |> @lib.write_varint(18UL)
-  let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.span {
-      writer |> @lib.write_int32(item)
+  if !self.span.is_empty() {
+    writer |> @lib.write_varint(18UL)
+    let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.span {
+        writer |> @lib.write_int32(item)
 
+    }
   }
   if self.leading_comments is Some(v) {
     writer |> @lib.write_varint(26UL);
@@ -6751,19 +6759,23 @@ pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(read
   msg
 }
 pub impl @lib.AsyncWrite for SourceCodeInfo_Location with fn write(self: SourceCodeInfo_Location, writer : &@lib.AsyncWriter) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL)
-  let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.path {
-      writer |> @lib.async_write_int32(item)
+  if !self.path.is_empty() {
+    writer |> @lib.async_write_varint(10UL)
+    let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.path {
+        writer |> @lib.async_write_int32(item)
 
+    }
   }
-  writer |> @lib.async_write_varint(18UL)
-  let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.span {
-      writer |> @lib.async_write_int32(item)
+  if !self.span.is_empty() {
+    writer |> @lib.async_write_varint(18UL)
+    let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.span {
+        writer |> @lib.async_write_int32(item)
 
+    }
   }
   if self.leading_comments is Some(v) {
     writer |> @lib.async_write_varint(26UL);
@@ -6919,7 +6931,9 @@ pub(all) struct GeneratedCodeInfo_Annotation {
 } derive(Eq, Debug)
 pub impl @lib.Sized for GeneratedCodeInfo_Annotation with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+  if !self.path.is_empty() {
+    size += 1U + { let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+  }
   if self.source_file is Some(v) {
     size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
   }
@@ -6973,12 +6987,14 @@ pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(read
   msg
 }
 pub impl @lib.Write for GeneratedCodeInfo_Annotation with fn write(self: GeneratedCodeInfo_Annotation, writer : &@lib.Writer) -> Unit raise {
-  writer |> @lib.write_varint(10UL)
-  let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.write_uint32(size)
-  for item in self.path {
-      writer |> @lib.write_int32(item)
+  if !self.path.is_empty() {
+    writer |> @lib.write_varint(10UL)
+    let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.write_uint32(size)
+    for item in self.path {
+        writer |> @lib.write_int32(item)
 
+    }
   }
   if self.source_file is Some(v) {
     writer |> @lib.write_varint(18UL);
@@ -7063,12 +7079,14 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit
   msg
 }
 pub impl @lib.AsyncWrite for GeneratedCodeInfo_Annotation with fn write(self: GeneratedCodeInfo_Annotation, writer : &@lib.AsyncWriter) -> Unit raise {
-  writer |> @lib.async_write_varint(10UL)
-  let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-  writer |> @lib.async_write_uint32(size)
-  for item in self.path {
-      writer |> @lib.async_write_int32(item)
+  if !self.path.is_empty() {
+    writer |> @lib.async_write_varint(10UL)
+    let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
+    writer |> @lib.async_write_uint32(size)
+    for item in self.path {
+        writer |> @lib.async_write_int32(item)
 
+    }
   }
   if self.source_file is Some(v) {
     writer |> @lib.async_write_varint(18UL);


### PR DESCRIPTION
## Summary
- Resolve protobuf feature enums into local behavior decisions after field/file syntax defaults and overrides are considered.
- Keep message and oneof fields presence-aware even under implicit scalar presence.
- Skip default-valued implicit fields and empty packed repeated fields in generated writers and `Sized` implementations.
- Refresh plugin, reader, snapshot, and generated-code harness outputs.

## Verification
- `python3 scripts/workflow.py generated-code-test`
- `python3 scripts/workflow.py generate-plugin`
- `python3 scripts/workflow.py snapshot-test --update`
- `python3 scripts/workflow.py reader-test`
- `moon check --target native --deny-warn`
- `moon test --target native --deny-warn`
- `git diff --check`