### PR TITLE
refactor: centralize protobuf feature resolution

### DIFF
--- a/cli/enum_template.mbt
+++ b/cli/enum_template.mbt
@@ -25,12 +25,13 @@ fn CodeGenerator::gen_enum(
   let derive_list = self.derive_list().join(", ")
   let enum_name = enum_.import_path.path() |> to_camel_case
   let unknown_variant_name = enum_.unknown_value_variant_name()
+  let is_open = enum_.is_open()
   file.write_string("pub(all) enum \{enum_name} {\n")
   for value in enum_.value {
     let value_name = to_camel_case(value.name.unwrap())
     file.write_string("  \{value_name}\n")
   }
-  if enum_.is_open() {
+  if is_open {
     file.write_string("  \{unknown_variant_name}(@lib.Enum)\n")
   }
   file.write_string("} derive(\{derive_list})\n")
@@ -49,7 +50,7 @@ fn CodeGenerator::gen_enum(
       "    \{enum_name}::\{value_name} => \{value.number.unwrap()}\n",
     )
   }
-  if enum_.is_open() {
+  if is_open {
     file.write_string(
       "    \{enum_name}::\{unknown_variant_name}(value) => value\n",
     )
@@ -70,7 +71,7 @@ fn CodeGenerator::gen_enum(
       "    \{value.number.unwrap()} => \{enum_name}::\{value_name}\n",
     )
   }
-  if enum_.is_open() {
+  if is_open {
     file.write_string("    _ => \{enum_name}::\{unknown_variant_name}(i)\n")
   } else {
     file.write_string("    _ => Default::default()\n")
@@ -118,7 +119,7 @@ fn CodeGenerator::gen_enum(
         "    Number(\{value.number.unwrap()}, ..) => \{enum_name}::\{value_name}\n",
       )
     }
-    if enum_.is_open() {
+    if is_open {
       file.write_string(
         (
           $|    Number(value, ..) =>
@@ -149,7 +150,7 @@ fn CodeGenerator::gen_enum(
         "    \{enum_name}::\{value_name} => \"\{value_name}\"\n",
       )
     }
-    if enum_.is_open() {
+    if is_open {
       file.write_string(
         "    \{enum_name}::\{unknown_variant_name}(value) => value.0.to_json()\n",
       )

--- a/cli/model/features.mbt
+++ b/cli/model/features.mbt
@@ -1,0 +1,240 @@
+///|
+fn known_feature_field_presence(
+  features : @protobuf.FeatureSet?,
+) -> @protobuf.FeatureSet_FieldPresence? {
+  match features {
+    Some(
+      { field_presence: Some(@protobuf.FeatureSet_FieldPresence::EXPLICIT), .. }
+    ) => Some(@protobuf.FeatureSet_FieldPresence::EXPLICIT)
+    Some(
+      { field_presence: Some(@protobuf.FeatureSet_FieldPresence::IMPLICIT), .. }
+    ) => Some(@protobuf.FeatureSet_FieldPresence::IMPLICIT)
+    Some(
+      {
+        field_presence: Some(
+          @protobuf.FeatureSet_FieldPresence::LEGACY_REQUIRED
+        ),
+        ..,
+      }
+    ) => Some(@protobuf.FeatureSet_FieldPresence::LEGACY_REQUIRED)
+    _ => None
+  }
+}
+
+///|
+fn known_feature_repeated_field_encoding(
+  features : @protobuf.FeatureSet?,
+) -> @protobuf.FeatureSet_RepeatedFieldEncoding? {
+  match features {
+    Some(
+      {
+        repeated_field_encoding: Some(
+          @protobuf.FeatureSet_RepeatedFieldEncoding::PACKED
+        ),
+        ..,
+      }
+    ) => Some(@protobuf.FeatureSet_RepeatedFieldEncoding::PACKED)
+    Some(
+      {
+        repeated_field_encoding: Some(
+          @protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED
+        ),
+        ..,
+      }
+    ) => Some(@protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED)
+    _ => None
+  }
+}
+
+///|
+fn known_feature_enum_type(
+  features : @protobuf.FeatureSet?,
+) -> @protobuf.FeatureSet_EnumType? {
+  match features {
+    Some({ enum_type: Some(@protobuf.FeatureSet_EnumType::OPEN), .. }) =>
+      Some(@protobuf.FeatureSet_EnumType::OPEN)
+    Some({ enum_type: Some(@protobuf.FeatureSet_EnumType::CLOSED), .. }) =>
+      Some(@protobuf.FeatureSet_EnumType::CLOSED)
+    _ => None
+  }
+}
+
+///|
+fn Field::field_presence_feature_behavior(
+  self : Field,
+) -> @protobuf.FeatureSet_FieldPresence {
+  if self.desc.label is Some(LABEL_REQUIRED) {
+    return @protobuf.FeatureSet_FieldPresence::LEGACY_REQUIRED
+  }
+  if self.desc.proto3_optional is Some(true) {
+    return @protobuf.FeatureSet_FieldPresence::EXPLICIT
+  }
+  if self.options is Some({ features, .. }) {
+    if known_feature_field_presence(features) is Some(presence) {
+      return presence
+    }
+  }
+  if self.parent.file is Some(file) {
+    file.field_presence_feature_behavior()
+  } else if self.desc.label is Some(LABEL_OPTIONAL) {
+    @protobuf.FeatureSet_FieldPresence::EXPLICIT
+  } else {
+    @protobuf.FeatureSet_FieldPresence::IMPLICIT
+  }
+}
+
+///|
+fn Field::presence_behavior(self : Field) -> @protobuf.FeatureSet_FieldPresence {
+  if self.is_list() {
+    return @protobuf.FeatureSet_FieldPresence::IMPLICIT
+  }
+  let presence = self.field_presence_feature_behavior()
+  if presence == @protobuf.FeatureSet_FieldPresence::LEGACY_REQUIRED {
+    return @protobuf.FeatureSet_FieldPresence::LEGACY_REQUIRED
+  }
+  if self.is_message() || self.is_oneof() {
+    return @protobuf.FeatureSet_FieldPresence::EXPLICIT
+  }
+  presence
+}
+
+///|
+fn Field::repeated_field_encoding_feature_behavior(
+  self : Field,
+) -> @protobuf.FeatureSet_RepeatedFieldEncoding {
+  if self.options is Some({ features, .. }) {
+    if known_feature_repeated_field_encoding(features) is Some(encoding) {
+      return encoding
+    }
+  }
+  match self.desc.options {
+    Some({ packed: Some(true), .. }) =>
+      return @protobuf.FeatureSet_RepeatedFieldEncoding::PACKED
+    Some({ packed: Some(false), .. }) =>
+      return @protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED
+    _ => ()
+  }
+  if self.parent.file is Some(file) {
+    file.repeated_field_encoding_feature_behavior()
+  } else {
+    @protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED
+  }
+}
+
+///|
+fn Field::repeated_field_encoding_behavior(
+  self : Field,
+) -> @protobuf.FeatureSet_RepeatedFieldEncoding {
+  if !self.is_list() || !self.is_packable_scalar() {
+    return @protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED
+  }
+  self.repeated_field_encoding_feature_behavior()
+}
+
+///|
+pub fn Field::is_pack(self : Field) -> Bool {
+  self.repeated_field_encoding_behavior() ==
+  @protobuf.FeatureSet_RepeatedFieldEncoding::PACKED
+}
+
+///|
+pub fn Field::is_optional(self : Field) -> Bool {
+  self.presence_behavior() == @protobuf.FeatureSet_FieldPresence::EXPLICIT
+}
+
+///|
+pub fn Field::has_implicit_presence(self : Field) -> Bool {
+  self.presence_behavior() == @protobuf.FeatureSet_FieldPresence::IMPLICIT
+}
+
+///|
+fn Package::field_presence_feature_behavior(
+  self : Package,
+) -> @protobuf.FeatureSet_FieldPresence {
+  if self.options is Some({ features, .. }) {
+    if known_feature_field_presence(features) is Some(presence) {
+      return presence
+    }
+  }
+  match self.syntax {
+    Proto3 => @protobuf.FeatureSet_FieldPresence::IMPLICIT
+    Proto2 | Editions => @protobuf.FeatureSet_FieldPresence::EXPLICIT
+  }
+}
+
+///|
+fn Package::repeated_field_encoding_feature_behavior(
+  self : Package,
+) -> @protobuf.FeatureSet_RepeatedFieldEncoding {
+  if self.options is Some({ features, .. }) {
+    if known_feature_repeated_field_encoding(features) is Some(encoding) {
+      return encoding
+    }
+  }
+  match self.syntax {
+    Proto3 | Editions => @protobuf.FeatureSet_RepeatedFieldEncoding::PACKED
+    Proto2 => @protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED
+  }
+}
+
+///|
+fn Package::feature_enum_type(self : Package) -> @protobuf.FeatureSet_EnumType? {
+  if self.options is Some({ features, .. }) {
+    known_feature_enum_type(features)
+  } else {
+    None
+  }
+}
+
+///|
+fn Enum::own_feature_enum_type(self : Enum) -> @protobuf.FeatureSet_EnumType? {
+  if self.options is Some({ features, .. }) {
+    known_feature_enum_type(features)
+  } else {
+    None
+  }
+}
+
+///|
+fn Enum::file_package(self : Enum) -> Package? {
+  if self.file is Some(file) {
+    Some(file)
+  } else if self.parent is Some(parent) {
+    parent.file
+  } else {
+    None
+  }
+}
+
+///|
+fn Enum::feature_enum_type(self : Enum) -> @protobuf.FeatureSet_EnumType? {
+  if self.own_feature_enum_type() is Some(enum_type) {
+    Some(enum_type)
+  } else if self.file_package() is Some(file) {
+    file.feature_enum_type()
+  } else {
+    None
+  }
+}
+
+///|
+fn Enum::openness(self : Enum) -> @protobuf.FeatureSet_EnumType {
+  match self.feature_enum_type() {
+    Some(@protobuf.FeatureSet_EnumType::OPEN) =>
+      @protobuf.FeatureSet_EnumType::OPEN
+    Some(@protobuf.FeatureSet_EnumType::CLOSED) =>
+      @protobuf.FeatureSet_EnumType::CLOSED
+    _ =>
+      match self.file_package() {
+        Some({ syntax: Proto2, .. }) => @protobuf.FeatureSet_EnumType::CLOSED
+        Some({ syntax: Proto3 | Editions, .. }) =>
+          @protobuf.FeatureSet_EnumType::OPEN
+        None => @protobuf.FeatureSet_EnumType::CLOSED
+      }
+  }
+}
+
+///|
+pub fn Enum::is_open(self : Enum) -> Bool {
+  self.openness() == @protobuf.FeatureSet_EnumType::OPEN
+}

--- a/cli/model/pkg.generated.mbti
+++ b/cli/model/pkg.generated.mbti
@@ -40,6 +40,7 @@ pub(all) struct Field {
   proto3optional : Bool?
 } derive(Eq, @debug.Debug)
 pub fn Field::default_value(Self) -> String?
+pub fn Field::has_implicit_presence(Self) -> Bool
 pub fn Field::is_enum(Self) -> Bool
 pub fn Field::is_list(Self) -> Bool
 pub fn Field::is_map(Self) -> Bool
@@ -50,7 +51,6 @@ pub fn Field::is_pack(Self) -> Bool
 pub fn Field::is_packable_scalar(Self) -> Bool
 pub fn Field::is_synthetic_oneof(Self) -> Bool
 pub fn Field::map_key_value(Self) -> Message?
-pub fn Field::omits_default_value(Self) -> Bool
 
 pub(all) struct ImportPath {
   path : Array[String]

--- a/cli/model/types.mbt
+++ b/cli/model/types.mbt
@@ -77,86 +77,6 @@ pub(all) enum Syntax {
 } derive(Eq, Debug)
 
 ///|
-priv enum FieldPresence {
-  PresenceImplicit
-  PresenceExplicit
-  PresenceRequired
-} derive(Eq)
-
-///|
-priv enum RepeatedFieldEncoding {
-  RepeatedPacked
-  RepeatedExpanded
-} derive(Eq)
-
-///|
-priv enum EnumOpenness {
-  EnumOpen
-  EnumClosed
-} derive(Eq)
-
-///|
-fn known_feature_field_presence(
-  features : @protobuf.FeatureSet?,
-) -> FieldPresence? {
-  match features {
-    Some(
-      { field_presence: Some(@protobuf.FeatureSet_FieldPresence::EXPLICIT), .. }
-    ) => Some(PresenceExplicit)
-    Some(
-      { field_presence: Some(@protobuf.FeatureSet_FieldPresence::IMPLICIT), .. }
-    ) => Some(PresenceImplicit)
-    Some(
-      {
-        field_presence: Some(
-          @protobuf.FeatureSet_FieldPresence::LEGACY_REQUIRED
-        ),
-        ..,
-      }
-    ) => Some(PresenceRequired)
-    _ => None
-  }
-}
-
-///|
-fn known_feature_repeated_field_encoding(
-  features : @protobuf.FeatureSet?,
-) -> RepeatedFieldEncoding? {
-  match features {
-    Some(
-      {
-        repeated_field_encoding: Some(
-          @protobuf.FeatureSet_RepeatedFieldEncoding::PACKED
-        ),
-        ..,
-      }
-    ) => Some(RepeatedPacked)
-    Some(
-      {
-        repeated_field_encoding: Some(
-          @protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED
-        ),
-        ..,
-      }
-    ) => Some(RepeatedExpanded)
-    _ => None
-  }
-}
-
-///|
-fn known_feature_enum_type(
-  features : @protobuf.FeatureSet?,
-) -> @protobuf.FeatureSet_EnumType? {
-  match features {
-    Some({ enum_type: Some(@protobuf.FeatureSet_EnumType::OPEN), .. }) =>
-      Some(@protobuf.FeatureSet_EnumType::OPEN)
-    Some({ enum_type: Some(@protobuf.FeatureSet_EnumType::CLOSED), .. }) =>
-      Some(@protobuf.FeatureSet_EnumType::CLOSED)
-    _ => None
-  }
-}
-
-///|
 pub(all) struct Field {
   desc : @protobuf.FieldDescriptorProto
   import_path : ImportPath
@@ -189,77 +109,6 @@ fn Field::from(
     number: desc.number,
     proto3optional: desc.proto3_optional,
   }
-}
-
-///|
-pub fn Field::is_pack(self : Field) -> Bool {
-  self.repeated_field_encoding() == RepeatedPacked
-}
-
-///|
-fn Field::feature_field_presence(self : Field) -> FieldPresence {
-  if self.desc.label is Some(LABEL_REQUIRED) {
-    return PresenceRequired
-  }
-  if self.desc.proto3_optional is Some(true) {
-    return PresenceExplicit
-  }
-  if self.options is Some({ features, .. }) {
-    if known_feature_field_presence(features) is Some(presence) {
-      return presence
-    }
-  }
-  if self.parent.file is Some(file) {
-    file.feature_field_presence()
-  } else if self.desc.label is Some(LABEL_OPTIONAL) {
-    PresenceExplicit
-  } else {
-    PresenceImplicit
-  }
-}
-
-///|
-fn Field::feature_repeated_field_encoding(
-  self : Field,
-) -> RepeatedFieldEncoding {
-  if self.options is Some({ features, .. }) {
-    if known_feature_repeated_field_encoding(features) is Some(encoding) {
-      return encoding
-    }
-  }
-  match self.desc.options {
-    Some({ packed: Some(true), .. }) => return RepeatedPacked
-    Some({ packed: Some(false), .. }) => return RepeatedExpanded
-    _ => ()
-  }
-  if self.parent.file is Some(file) {
-    file.feature_repeated_field_encoding()
-  } else {
-    RepeatedExpanded
-  }
-}
-
-///|
-fn Field::field_presence(self : Field) -> FieldPresence {
-  if self.is_list() {
-    return PresenceImplicit
-  }
-  let presence = self.feature_field_presence()
-  if presence == PresenceRequired {
-    return PresenceRequired
-  }
-  if self.is_message() || self.is_oneof() {
-    return PresenceExplicit
-  }
-  presence
-}
-
-///|
-fn Field::repeated_field_encoding(self : Field) -> RepeatedFieldEncoding {
-  if !self.is_list() || !self.is_packable_scalar() {
-    return RepeatedExpanded
-  }
-  self.feature_repeated_field_encoding()
 }
 
 ///|
@@ -302,16 +151,6 @@ pub fn Field::is_message(self : Field) -> Bool {
 ///|
 pub fn Field::is_enum(self : Field) -> Bool {
   return self.desc.type_ is Some(FieldDescriptorProto_Type::TYPE_ENUM)
-}
-
-///|
-pub fn Field::is_optional(self : Field) -> Bool {
-  self.field_presence() == PresenceExplicit
-}
-
-///|
-pub fn Field::omits_default_value(self : Field) -> Bool {
-  self.field_presence() == PresenceImplicit
 }
 
 ///|
@@ -377,42 +216,6 @@ pub fn Package::from(
     }
   }
   package_
-}
-
-///|
-fn Package::feature_field_presence(self : Package) -> FieldPresence {
-  if self.options is Some({ features, .. }) {
-    if known_feature_field_presence(features) is Some(presence) {
-      return presence
-    }
-  }
-  match self.syntax {
-    Proto3 => PresenceImplicit
-    Proto2 | Editions => PresenceExplicit
-  }
-}
-
-///|
-fn Package::feature_repeated_field_encoding(
-  self : Package,
-) -> RepeatedFieldEncoding {
-  if self.options is Some({ features, .. }) {
-    if known_feature_repeated_field_encoding(features) is Some(encoding) {
-      return encoding
-    }
-  }
-  match self.syntax {
-    Proto3 | Editions => RepeatedPacked
-    Proto2 => RepeatedExpanded
-  }
-}
-
-///|
-fn Package::feature_enum_type(self : Package) -> @protobuf.FeatureSet_EnumType? {
-  match self.options {
-    Some({ features, .. }) => known_feature_enum_type(features)
-    _ => None
-  }
 }
 
 ///|
@@ -487,57 +290,6 @@ fn Enum::from_message(
     options: desc.options,
     value: desc.value,
   }
-}
-
-///|
-fn Enum::own_feature_enum_type(self : Enum) -> @protobuf.FeatureSet_EnumType? {
-  match self.options {
-    Some({ features, .. }) => known_feature_enum_type(features)
-    _ => None
-  }
-}
-
-///|
-fn Enum::file_package(self : Enum) -> Package? {
-  match self.file {
-    Some(file) => Some(file)
-    None =>
-      match self.parent {
-        Some(parent) => parent.file
-        None => None
-      }
-  }
-}
-
-///|
-fn Enum::feature_enum_type(self : Enum) -> @protobuf.FeatureSet_EnumType? {
-  match self.own_feature_enum_type() {
-    Some(enum_type) => Some(enum_type)
-    None =>
-      match self.file_package() {
-        Some(file) => file.feature_enum_type()
-        None => None
-      }
-  }
-}
-
-///|
-fn Enum::openness(self : Enum) -> EnumOpenness {
-  match self.feature_enum_type() {
-    Some(@protobuf.FeatureSet_EnumType::OPEN) => EnumOpen
-    Some(@protobuf.FeatureSet_EnumType::CLOSED) => EnumClosed
-    _ =>
-      match self.file_package() {
-        Some({ syntax: Proto2, .. }) => EnumClosed
-        Some({ syntax: Proto3 | Editions, .. }) => EnumOpen
-        None => EnumClosed
-      }
-  }
-}
-
-///|
-pub fn Enum::is_open(self : Enum) -> Bool {
-  self.openness() == EnumOpen
 }
 
 ///|

--- a/cli/size_template.mbt
+++ b/cli/size_template.mbt
@@ -163,7 +163,7 @@ fn CodeGenerator::gen_message_size(
         "self.\{field_name}",
         size_tag(field_number),
       )
-      if field.omits_default_value() {
+      if field.has_implicit_presence() {
         content.write_string(
           (
             $|  if self.\{field_name} != Default::default() {

--- a/cli/writer_template.mbt
+++ b/cli/writer_template.mbt
@@ -203,7 +203,7 @@ fn CodeGenerator::gen_message_writer(
       let field_write =
         $|  writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL);
         $|  \{field_write_type}
-      if field.omits_default_value() {
+      if field.has_implicit_presence() {
         content.write_string(
           "  if self.\{field_name} != Default::default() {\n",
         )


### PR DESCRIPTION
## Summary
- Move protobuf feature-resolution logic into `cli/model/features.mbt` so field presence, repeated-field encoding, and enum openness are resolved in one model-layer place.
- Keep the model API predicate-focused: templates use `is_pack()`, `is_optional()`, `has_implicit_presence()`, and `is_open()` instead of reinterpreting descriptor syntax/options.
- Use the generated protobuf `FeatureSet` enums internally instead of defining parallel behavior enums.
- Replace `omits_default_value()` with `has_implicit_presence()` so the public predicate names the relevant presence behavior directly without exporting the full raw accessor.

## Verification
- `moon fmt`
- `moon info --target native`
- `moon check --target native --deny-warn`
- `moon test --target native --deny-warn`
- `python3 scripts/workflow.py generated-code-test`
- `git diff --check`