### PR TITLE
test: add syntax default feature harness

### DIFF
--- a/test/harness/cases/syntax-defaults/case.toml
+++ b/test/harness/cases/syntax-defaults/case.toml
@@ -1,0 +1,3 @@
+generated_project = "harness_syntax_defaults"
+proto_files = ["proto2_defaults.proto", "proto3_defaults.proto"]
+test_args = ["test", "src", "--target", "native", "--deny-warn"]

--- a/test/harness/cases/syntax-defaults/moon.work
+++ b/test/harness/cases/syntax-defaults/moon.work
@@ -1,0 +1,5 @@
+members = [
+  "../../../../lib",
+  "../../__gen/harness_syntax_defaults",
+  "runner",
+]

--- a/test/harness/cases/syntax-defaults/proto/proto2_defaults.proto
+++ b/test/harness/cases/syntax-defaults/proto/proto2_defaults.proto
@@ -1,0 +1,15 @@
+syntax = "proto2";
+
+package harness.syntax.proto2;
+
+enum Proto2State {
+  PROTO2_STATE_UNSPECIFIED = 0;
+  PROTO2_STATE_READY = 1;
+}
+
+message Proto2Presence {
+  required int32 required_value = 1;
+  optional int32 optional_value = 2;
+  repeated int32 values = 3;
+  optional Proto2State state = 4;
+}

--- a/test/harness/cases/syntax-defaults/proto/proto3_defaults.proto
+++ b/test/harness/cases/syntax-defaults/proto/proto3_defaults.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package harness.syntax.proto3;
+
+enum Proto3State {
+  PROTO3_STATE_UNSPECIFIED = 0;
+  PROTO3_STATE_READY = 1;
+}
+
+message Proto3Defaults {
+  int32 implicit_value = 1;
+  optional int32 explicit_value = 2;
+  repeated int32 values = 3;
+  Proto3State state = 4;
+}

--- a/test/harness/cases/syntax-defaults/runner/moon.mod
+++ b/test/harness/cases/syntax-defaults/runner/moon.mod
@@ -1,0 +1,18 @@
+name = "username/harness_syntax_defaults_runner"
+
+version = "0.1.0"
+
+import {
+  "moonbitlang/protobuf@0.1.2",
+  "username/harness_syntax_defaults@0.1.0",
+}
+
+readme = ""
+
+repository = ""
+
+license = ""
+
+keywords = []
+
+description = ""

--- a/test/harness/cases/syntax-defaults/runner/src/moon.pkg
+++ b/test/harness/cases/syntax-defaults/runner/src/moon.pkg
@@ -1,0 +1,10 @@
+import {
+}
+
+import {
+  "username/harness_syntax_defaults/harness/syntax/proto2" @proto2,
+  "username/harness_syntax_defaults/harness/syntax/proto3" @proto3,
+  "moonbitlang/protobuf",
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
+} for "test"

--- a/test/harness/cases/syntax-defaults/runner/src/syntax_defaults_test.mbt
+++ b/test/harness/cases/syntax-defaults/runner/src/syntax_defaults_test.mbt
@@ -1,0 +1,76 @@
+///|
+/// Proto2 required and optional field labels should keep distinct generated shapes.
+test "proto2 field labels control generated presence" {
+  let message = @proto2.Proto2Presence::new(
+    7,
+    [],
+    optional_value=9,
+    state=@proto2.Proto2State::PROTO2_STATE_READY,
+  )
+  @debug.assert_eq(message.required_value, 7)
+  @debug.assert_eq(message.optional_value, Some(9))
+  @debug.assert_eq(message.state, Some(@proto2.Proto2State::PROTO2_STATE_READY))
+}
+
+///|
+/// Proto2 required fields have explicit presence, so even a default value is emitted.
+test "proto2 required default value still writes" {
+  let message = @proto2.Proto2Presence::new(0, [])
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x08\x00")
+  @debug.assert_eq(@protobuf.size_of(message), 2U)
+}
+
+///|
+/// Proto2 repeated scalar fields default to expanded encoding.
+test "proto2 repeated scalar writes expanded values by default" {
+  let message = @proto2.Proto2Presence::new(7, [1, 150])
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x08\x07\x18\x01\x18\x96\x01")
+}
+
+///|
+/// Proto2 enums are closed by default and reject unknown numeric values.
+test "proto2 enum is closed by default" {
+  @debug.assert_eq(
+    @proto2.Proto2State::from_enum(@protobuf.Enum(7)),
+    @proto2.Proto2State::PROTO2_STATE_UNSPECIFIED,
+  )
+}
+
+///|
+/// Proto3 optional and implicit fields should keep distinct generated shapes.
+test "proto3 optional field controls generated presence" {
+  let message = @proto3.Proto3Defaults::new(
+    0,
+    [],
+    @proto3.Proto3State::PROTO3_STATE_UNSPECIFIED,
+    explicit_value=9,
+  )
+  @debug.assert_eq(message.implicit_value, 0)
+  @debug.assert_eq(message.explicit_value, Some(9))
+}
+
+///|
+/// Proto3 repeated scalar fields default to packed encoding.
+test "proto3 repeated scalar writes packed values by default" {
+  let message = @proto3.Proto3Defaults::new(
+    0,
+    [1, 150],
+    @proto3.Proto3State::PROTO3_STATE_UNSPECIFIED,
+  )
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x1a\x03\x01\x96\x01")
+}
+
+///|
+/// Proto3 enums are open by default and preserve unknown numeric values.
+test "proto3 enum is open by default" {
+  @debug.assert_eq(
+    @proto3.Proto3State::from_enum(@protobuf.Enum(7)),
+    @proto3.Proto3State::Unknown(@protobuf.Enum(7)),
+  )
+}


### PR DESCRIPTION
## Summary
- Add a generated-code harness case for proto2/proto3 syntax defaults after centralizing feature resolution.
- Cover proto2 required vs optional presence, required default-value emission, expanded repeated scalar encoding, and closed enum defaults.
- Cover proto3 optional vs implicit presence, packed repeated scalar encoding, and open enum defaults.

## Verification
- `python3 scripts/workflow.py generated-code-test`
- `moon fmt`
- `moon check --target native --deny-warn`
- `moon test --target native --deny-warn`
- `git diff --check`