### PR TITLE
fix: read protobuf strings as complete UTF-8 payloads

### DIFF
--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -183,70 +183,7 @@ pub async fn[T : AsyncReader] async_read_bytes(reader : T) -> Bytes {
 
 ///|
 pub async fn[T : AsyncReader] async_read_string(reader : T) -> String {
-  let length = reader |> async_read_int32()
-  if length < 0 {
-    raise ReaderError::InvalidLength
-  }
-  let string = StringBuilder::new()
-  for i = 0; i < length; {
-    let b = reader |> async_read_byte() |> Byte::to_int()
-    if b < 0x80 {
-      string.write_char(b.unsafe_to_char())
-      continue i + 1
-    } else if b < 0xE0 {
-      if i + 1 == length {
-        raise ReaderError::InvalidString
-      }
-      let b2 = reader |> async_read_byte() |> Byte::to_int()
-      if (b2 & 0xC0) != 0x80 {
-        raise ReaderError::InvalidString
-      }
-      let ch = ((b & 0x1F) << 6) | (b2 & 0x3F)
-      if ch < 0x80 {
-        raise ReaderError::InvalidString
-      }
-      string.write_char(ch.unsafe_to_char())
-      continue i + 2
-    } else if b < 0xF0 {
-      if i + 2 >= length {
-        raise ReaderError::InvalidString
-      }
-      let b2 = reader |> async_read_byte() |> Byte::to_int()
-      let b3 = reader |> async_read_byte() |> Byte::to_int()
-      if (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80 {
-        raise ReaderError::InvalidString
-      }
-      let ch = ((b & 0x0F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F)
-      if ch < 0x800 || (ch >= 0xD800 && ch <= 0xDFFF) {
-        raise ReaderError::InvalidString
-      }
-      string.write_char(ch.unsafe_to_char())
-      continue i + 3
-    } else if b < 0xF8 {
-      if i + 3 >= length {
-        raise ReaderError::InvalidString
-      }
-      let varint_bytes : FixedArray[Byte] = FixedArray::make(3, 0)
-      reader |> async_read_exactly(varint_bytes, offset=0, length=3)
-      if (varint_bytes[0].to_int() & 0xC0) != 0x80 ||
-        (varint_bytes[1].to_int() & 0xC0) != 0x80 ||
-        (varint_bytes[2].to_int() & 0xC0) != 0x80 {
-        raise ReaderError::InvalidString
-      }
-      let ch = ((b & 0x07) << 18) |
-        ((varint_bytes[0].to_int() & 0x3F) << 12) |
-        ((varint_bytes[1].to_int() & 0x3F) << 6) |
-        (varint_bytes[2].to_int() & 0x3F)
-      if ch < 0x10000 || ch > 0x10FFFF {
-        raise ReaderError::InvalidString
-      }
-      string.write_char(ch.unsafe_to_char())
-      continue i + 4
-    } else {
-      raise ReaderError::InvalidString
-    }
-  }
-  string.to_string()
+  reader |> async_read_bytes() |> decode_utf8_string()
 }
 
 ///|

--- a/lib/async_writer.mbt
+++ b/lib/async_writer.mbt
@@ -129,26 +129,7 @@ pub async fn[T : AsyncWriter] async_write_string(
   writer : T,
   v : String,
 ) -> Unit {
-  let utf8_string = Buffer()
-  for ch in v {
-    let ch = ch.to_int()
-    if ch < 0x80 {
-      utf8_string.write_byte(ch.to_byte())
-    } else if ch < 0x800 {
-      utf8_string.write_byte((0xC0 | (ch >> 6)).to_byte())
-      utf8_string.write_byte((0x80 | (ch & 0x3F)).to_byte())
-    } else if ch < 0x10000 {
-      utf8_string.write_byte((0xE0 | (ch >> 12)).to_byte())
-      utf8_string.write_byte((0x80 | ((ch >> 6) & 0x3F)).to_byte())
-      utf8_string.write_byte((0x80 | (ch & 0x3F)).to_byte())
-    } else {
-      utf8_string.write_byte((0xF0 | (ch >> 18)).to_byte())
-      utf8_string.write_byte((0x80 | ((ch >> 12) & 0x3F)).to_byte())
-      utf8_string.write_byte((0x80 | ((ch >> 6) & 0x3F)).to_byte())
-      utf8_string.write_byte((0x80 | (ch & 0x3F)).to_byte())
-    }
-  }
-  let utf8_string = utf8_string.to_bytes()
+  let utf8_string = encode_utf8_string(v)
   writer
   |> async_write_varint(utf8_string.length().reinterpret_as_uint().to_uint64())
   writer.write(utf8_string)

--- a/lib/moon.pkg
+++ b/lib/moon.pkg
@@ -2,5 +2,6 @@ import {
   "moonbitlang/core/buffer",
   "moonbitlang/core/cmp",
   "moonbitlang/core/debug",
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/quickcheck",
 }

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -198,69 +198,7 @@ pub fn[T : Reader] read_bytes(reader : T) -> Bytes raise {
 
 ///|
 pub fn[T : Reader] read_string(reader : T) -> String raise {
-  let length = reader |> read_int32()
-  if length < 0 {
-    raise ReaderError::InvalidLength
-  }
-  let string = StringBuilder::new()
-  for i = 0; i < length; {
-    let b = reader |> read_byte() |> Byte::to_int()
-    if b < 0x80 {
-      string.write_char(b.unsafe_to_char())
-      continue i + 1
-    } else if b < 0xE0 {
-      if i + 1 == length {
-        raise ReaderError::InvalidString
-      }
-      let b2 = reader |> read_byte() |> Byte::to_int()
-      if (b2 & 0xC0) != 0x80 {
-        raise ReaderError::InvalidString
-      }
-      let ch = ((b & 0x1F) << 6) | (b2 & 0x3F)
-      if ch < 0x80 {
-        raise ReaderError::InvalidString
-      }
-      string.write_char(ch.unsafe_to_char())
-      continue i + 2
-    } else if b < 0xF0 {
-      if i + 2 >= length {
-        raise ReaderError::InvalidString
-      }
-      let b2 = reader |> read_byte() |> Byte::to_int()
-      let b3 = reader |> read_byte() |> Byte::to_int()
-      if (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80 {
-        raise ReaderError::InvalidString
-      }
-      let ch = ((b & 0x0F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F)
-      if ch < 0x800 || (ch >= 0xD800 && ch <= 0xDFFF) {
-        raise ReaderError::InvalidString
-      }
-      string.write_char(ch.unsafe_to_char())
-      continue i + 3
-    } else if b < 0xF8 {
-      if i + 3 >= length {
-        raise ReaderError::InvalidString
-      }
-      read_exactly(reader, varint_bytes, offset=0, length=3)
-      if (varint_bytes[0].to_int() & 0xC0) != 0x80 ||
-        (varint_bytes[1].to_int() & 0xC0) != 0x80 ||
-        (varint_bytes[2].to_int() & 0xC0) != 0x80 {
-        raise ReaderError::InvalidString
-      }
-      let ch = ((b & 0x07) << 18) |
-        ((varint_bytes[0].to_int() & 0x3F) << 12) |
-        ((varint_bytes[1].to_int() & 0x3F) << 6) |
-        (varint_bytes[2].to_int() & 0x3F)
-      if ch < 0x10000 || ch > 0x10FFFF {
-        raise ReaderError::InvalidString
-      }
-      string.write_char(ch.unsafe_to_char())
-      continue i + 4
-    } else {
-      raise ReaderError::InvalidString
-    }
-  }
-  string.to_string()
+  reader |> read_bytes() |> decode_utf8_string()
 }
 
 ///|

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -150,6 +150,20 @@ test "read_string/codepoint_too_large" {
 }
 
 ///|
+test "read_string/invalid_payload_is_consumed" {
+  let r = @protobuf.BytesReader::from_bytes(b"\x03\xFF\x61\x62\x96\x01")
+    as &@protobuf.Reader
+  try {
+    let _ = r |> @protobuf.read_string()
+    fail("expected InvalidString")
+  } catch {
+    @protobuf.InvalidString => ()
+    err => raise err
+  }
+  @debug.assert_eq(r |> @protobuf.read_varint32(), 150)
+}
+
+///|
 test "error" {
   let r = @protobuf.BytesReader::from_bytes(b"") as &@protobuf.Reader
   try {

--- a/lib/utf8.mbt
+++ b/lib/utf8.mbt
@@ -1,0 +1,11 @@
+///|
+fn decode_utf8_string(bytes : BytesView) -> String raise {
+  @utf8.decode(bytes) catch {
+    @utf8.Malformed(_) => raise ReaderError::InvalidString
+  }
+}
+
+///|
+fn encode_utf8_string(string : String) -> Bytes {
+  @utf8.encode(string)
+}

--- a/lib/writer.mbt
+++ b/lib/writer.mbt
@@ -122,26 +122,7 @@ pub fn[T : Writer] write_bytes(writer : T, v : Bytes) -> Unit raise {
 
 ///|
 pub fn[T : Writer] write_string(writer : T, v : String) -> Unit raise {
-  let utf8_string = Buffer()
-  for ch in v {
-    let ch = ch.to_int()
-    if ch < 0x80 {
-      utf8_string.write_byte(ch.to_byte())
-    } else if ch < 0x800 {
-      utf8_string.write_byte((0xC0 | (ch >> 6)).to_byte())
-      utf8_string.write_byte((0x80 | (ch & 0x3F)).to_byte())
-    } else if ch < 0x10000 {
-      utf8_string.write_byte((0xE0 | (ch >> 12)).to_byte())
-      utf8_string.write_byte((0x80 | ((ch >> 6) & 0x3F)).to_byte())
-      utf8_string.write_byte((0x80 | (ch & 0x3F)).to_byte())
-    } else {
-      utf8_string.write_byte((0xF0 | (ch >> 18)).to_byte())
-      utf8_string.write_byte((0x80 | ((ch >> 12) & 0x3F)).to_byte())
-      utf8_string.write_byte((0x80 | ((ch >> 6) & 0x3F)).to_byte())
-      utf8_string.write_byte((0x80 | (ch & 0x3F)).to_byte())
-    }
-  }
-  let utf8_string = utf8_string.to_bytes()
+  let utf8_string = encode_utf8_string(v)
   writer |> write_varint(utf8_string.length().reinterpret_as_uint().to_uint64())
   writer.write(utf8_string)
 }


### PR DESCRIPTION
## Why
Protobuf string fields are length-delimited. Reading and validating UTF-8 incrementally can leave the reader positioned inside a malformed string payload, and it duplicates the standard library UTF-8 implementation.

## What changed
- Read the complete length-delimited string payload before decoding.
- Encode and decode protobuf strings through the core UTF-8 API.
- Add a regression that malformed strings consume their declared payload before raising `InvalidString`.

## Why this is correct and minimal
The existing `InvalidString` error surface is preserved, valid string wire encoding is unchanged, and the sync/async paths share private helpers instead of carrying separate UTF-8 state machines.