### PR TITLE
perf: batch scalar writer output

### DIFF
--- a/lib/async_writer.mbt
+++ b/lib/async_writer.mbt
@@ -8,12 +8,21 @@ pub async fn[T : AsyncWriter] async_write_varint(
   writer : T,
   input : UInt64,
 ) -> Unit {
-  let mut v = input
-  while v >= 0x80 {
-    writer.write([(v.to_byte() & 0x7F) | 0x80])
+  let mut v = input >> 7
+  let mut length = 0
+  while v > 0 {
     v = v >> 7
+    length += 1
   }
-  writer.write([v.to_byte()])
+  let bytes = Bytes::makei(length + 1, fn(i) {
+    let byte = ((input >> (i * 7)) & 0x7F).to_byte()
+    if i == length {
+      byte
+    } else {
+      byte | 0x80
+    }
+  })
+  writer.write(bytes)
 }
 
 ///|
@@ -62,11 +71,7 @@ pub async fn[T : AsyncWriter] async_write_sint64(writer : T, v : Int64) -> Unit 
 
 ///|
 pub async fn[T : AsyncWriter] async_write_fixed32(writer : T, v : UInt) -> Unit {
-  let mut v = v
-  for _ in 0..<4 {
-    writer.write([(v & 0xFF) |> UInt::to_byte()])
-    v = v >> 8
-  }
+  writer.write(Bytes::makei(4, fn(i) { ((v >> (i * 8)) & 0xFF).to_byte() }))
 }
 
 ///|
@@ -74,11 +79,7 @@ pub async fn[T : AsyncWriter] async_write_fixed64(
   writer : T,
   v : UInt64,
 ) -> Unit {
-  let mut v = v
-  for _ in 0..<8 {
-    writer.write([(v & 0xFF) |> UInt64::to_byte()])
-    v = v >> 8
-  }
+  writer.write(Bytes::makei(8, fn(i) { ((v >> (i * 8)) & 0xFF).to_byte() }))
 }
 
 ///|

--- a/lib/writer.mbt
+++ b/lib/writer.mbt
@@ -20,12 +20,21 @@ pub(open) trait Writer {
 
 ///|
 pub fn[T : Writer] write_varint(writer : T, input : UInt64) -> Unit raise {
-  let mut v = input
-  while v >= 0x80 {
-    writer.write([(v.to_byte() & 0x7F) | 0x80])
+  let mut v = input >> 7
+  let mut length = 0
+  while v > 0 {
     v = v >> 7
+    length += 1
   }
-  writer.write([v.to_byte()])
+  let bytes = Bytes::makei(length + 1, fn(i) {
+    let byte = ((input >> (i * 7)) & 0x7F).to_byte()
+    if i == length {
+      byte
+    } else {
+      byte | 0x80
+    }
+  })
+  writer.write(bytes)
 }
 
 ///|
@@ -67,20 +76,12 @@ pub fn[T : Writer] write_sint64(writer : T, v : Int64) -> Unit raise {
 
 ///|
 pub fn[T : Writer] write_fixed32(writer : T, v : UInt) -> Unit raise {
-  let mut v = v
-  for _ in 0..<4 {
-    writer.write([(v & 0xFF) |> UInt::to_byte()])
-    v = v >> 8
-  }
+  writer.write(Bytes::makei(4, fn(i) { ((v >> (i * 8)) & 0xFF).to_byte() }))
 }
 
 ///|
 pub fn[T : Writer] write_fixed64(writer : T, v : UInt64) -> Unit raise {
-  let mut v = v
-  for _ in 0..<8 {
-    writer.write([(v & 0xFF) |> UInt64::to_byte()])
-    v = v >> 8
-  }
+  writer.write(Bytes::makei(8, fn(i) { ((v >> (i * 8)) & 0xFF).to_byte() }))
 }
 
 ///|


### PR DESCRIPTION
## Why
Profiling a representative binary runtime workload showed scalar writer paths spending significant time in repeated one-byte `Writer.write` calls, especially through `write_varint`, `write_fixed32`, and `write_fixed64`.

## What changed
- Build each varint into one exact `Bytes` value before calling `Writer.write`.
- Build fixed32 and fixed64 outputs as one exact `Bytes` value instead of four or eight one-byte writes.
- Apply the same batching to sync and async writer helpers.

## Why this is correct and minimal
The protobuf wire bytes are unchanged; only the number of calls into the writer changes. The public writer API remains unchanged, and the optimization is limited to scalar writer helpers that showed up in profiling.