### PR TITLE
perf: avoid blit for single-byte reads

### DIFF
--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -78,7 +78,11 @@ pub impl Reader for BytesReader with fn read(
     @cmp.minimum(bytes.length() - offset, max_length),
     self.len - self.start,
   )
-  bytes.blit_from_bytes(offset, self.data, self.start, read_length)
+  if read_length == 1 {
+    bytes[offset] = self.data[self.start]
+  } else {
+    bytes.blit_from_bytes(offset, self.data, self.start, read_length)
+  }
   self.start += read_length
   Some(read_length)
 }
@@ -97,7 +101,11 @@ pub impl AsyncReader for BytesReader with fn read(
     @cmp.minimum(bytes.length() - offset, max_length),
     self.len - self.start,
   )
-  bytes.blit_from_bytes(offset, self.data, self.start, read_length)
+  if read_length == 1 {
+    bytes[offset] = self.data[self.start]
+  } else {
+    bytes.blit_from_bytes(offset, self.data, self.start, read_length)
+  }
   self.start += read_length
   Some(read_length)
 }


### PR DESCRIPTION
## Why
After batching scalar writer output, profiling showed read-side varints spending time in one-byte `BytesReader.read` calls that still routed through `blit_from_bytes`.

## What changed
- Add a one-byte fast path in the sync `BytesReader.read` implementation.
- Mirror the same fast path in the async `BytesReader.read` implementation.

## Why this is correct and minimal
The public `Reader` and `AsyncReader` traits stay unchanged. Multi-byte reads still use the existing blit path, while one-byte reads copy exactly the same byte and advance the cursor by one. This targets varint-heavy decoding without changing generated code or stream-reader behavior.