### PR TITLE
Add buffered reader adapter

### DIFF
--- a/lib/buffered_reader_test.mbt
+++ b/lib/buffered_reader_test.mbt
@@ -1,0 +1,102 @@
+///|
+struct ChunkedReader {
+  data : Bytes
+  max_chunk : Int
+  read_calls : Array[Int]
+  mut start : Int
+}
+
+///|
+fn ChunkedReader::from_bytes(
+  data : Bytes,
+  max_chunk~ : Int,
+  read_calls~ : Array[Int],
+) -> ChunkedReader {
+  { data, max_chunk, read_calls, start: 0 }
+}
+
+///|
+pub impl @protobuf.Reader for ChunkedReader with fn read(
+  self,
+  bytes : FixedArray[Byte],
+  offset~ : Int,
+  max_length~ : Int,
+) -> Int? {
+  if offset >= bytes.length() ||
+    max_length <= 0 ||
+    self.start >= self.data.length() {
+    return None
+  }
+  self.read_calls[0] = self.read_calls[0] + 1
+  let read_length = @cmp.minimum(
+    self.max_chunk,
+    @cmp.minimum(
+      bytes.length() - offset,
+      @cmp.minimum(max_length, self.data.length() - self.start),
+    ),
+  )
+  bytes.blit_from_bytes(offset, self.data, self.start, read_length)
+  self.start += read_length
+  Some(read_length)
+}
+
+///|
+test "BufferedReader batches upstream reads for varints" {
+  let writer = Buffer()
+  for i in 0..<32 {
+    writer |> @protobuf.write_varint(i.to_uint64())
+  }
+  let read_calls = [0]
+  let source = ChunkedReader::from_bytes(
+    writer.to_bytes(),
+    max_chunk=16,
+    read_calls~,
+  )
+  let reader = @protobuf.BufferedReader::new(source, capacity=16)
+    as &@protobuf.Reader
+  for i in 0..<32 {
+    @test.assert_eq(
+      reader |> @protobuf.read_varint32(),
+      i.reinterpret_as_uint(),
+    )
+  }
+  @test.assert_eq(read_calls[0], 2)
+}
+
+///|
+test "BufferedReader preserves bytes read past a limited reader" {
+  let packed_writer = Buffer()
+  packed_writer |> @protobuf.write_sint32(1)
+  packed_writer |> @protobuf.write_sint32(2)
+  packed_writer |> @protobuf.write_sint32(3)
+  let writer = Buffer()
+  writer |> @protobuf.write_tag((1U, 2U))
+  writer |> @protobuf.write_bytes(packed_writer.to_bytes())
+  writer |> @protobuf.write_tag((2U, 0U))
+  writer |> @protobuf.write_int32(150)
+  let read_calls = [0]
+  let source = ChunkedReader::from_bytes(
+    writer.to_bytes(),
+    max_chunk=16,
+    read_calls~,
+  )
+  let reader = @protobuf.BufferedReader::new(source, capacity=16)
+    as &@protobuf.Reader
+  let (tag, wire_type) = reader |> @protobuf.read_tag()
+  @test.assert_eq(tag, 1U)
+  @test.assert_eq(wire_type, 2U)
+  let packed = @protobuf.read_packed(
+    reader,
+    fn(reader) raise { reader |> @protobuf.read_sint32() },
+    None,
+  )
+  let values : Array[Int] = []
+  for value in packed {
+    values.push(value.0)
+  }
+  @test.assert_eq(values, [1, 2, 3])
+  let (tag, wire_type) = reader |> @protobuf.read_tag()
+  @test.assert_eq(tag, 2U)
+  @test.assert_eq(wire_type, 0U)
+  @test.assert_eq(reader |> @protobuf.read_int32(), 150)
+}

--- a/lib/moon.pkg
+++ b/lib/moon.pkg
@@ -5,3 +5,7 @@ import {
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/quickcheck",
 }
+
+import {
+  "moonbitlang/core/test",
+} for "test"

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -183,6 +183,11 @@ pub(all) suberror ReaderError {
 pub impl Show for ReaderError
 
 // Types and methods
+type BufferedReader[T]
+pub fn[T] BufferedReader::new(T, capacity? : Int) -> Self[T]
+pub impl[T : AsyncReader] AsyncReader for BufferedReader[T]
+pub impl[T : Reader] Reader for BufferedReader[T]
+
 type BytesReader
 pub fn BytesReader::from_bytes(Bytes) -> Self
 pub impl Show for BytesReader

--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -65,6 +65,50 @@ pub fn BytesReader::from_bytes(data : Bytes) -> BytesReader {
 }
 
 ///|
+/// Wraps another reader and serves small reads from an internal buffer.
+struct BufferedReader[T] {
+  reader : T
+  buffer : FixedArray[Byte]
+  mut start : Int
+  mut end : Int
+}
+
+///|
+pub fn[T] BufferedReader::new(
+  reader : T,
+  capacity? : Int = 4096,
+) -> BufferedReader[T] {
+  let capacity = if capacity <= 0 { 4096 } else { capacity }
+  { reader, buffer: FixedArray::make(capacity, 0), start: 0, end: 0 }
+}
+
+///|
+fn[T] BufferedReader::read_from_buffer(
+  self : BufferedReader[T],
+  bytes : FixedArray[Byte],
+  offset~ : Int,
+  max_length~ : Int,
+) -> Int {
+  let read_length = @cmp.minimum(max_length, self.end - self.start)
+  if read_length == 1 {
+    bytes[offset] = self.buffer[self.start]
+  } else {
+    self.buffer.blit_to(
+      bytes,
+      len=read_length,
+      src_offset=self.start,
+      dst_offset=offset,
+    )
+  }
+  self.start += read_length
+  if self.start == self.end {
+    self.start = 0
+    self.end = 0
+  }
+  read_length
+}
+
+///|
 pub impl Reader for BytesReader with fn read(
   self,
   bytes : FixedArray[Byte],
@@ -108,6 +152,70 @@ pub impl AsyncReader for BytesReader with fn read(
   }
   self.start += read_length
   Some(read_length)
+}
+
+///|
+pub impl[T : Reader] Reader for BufferedReader[T] with fn read(
+  self,
+  bytes : FixedArray[Byte],
+  offset~ : Int,
+  max_length~ : Int,
+) -> Int? {
+  if offset >= bytes.length() || max_length <= 0 {
+    return None
+  }
+  let max_length = @cmp.minimum(bytes.length() - offset, max_length)
+  if self.start < self.end {
+    return Some(self.read_from_buffer(bytes, offset~, max_length~))
+  }
+  if max_length >= self.buffer.length() {
+    self.reader.read(bytes, offset~, max_length~)
+  } else {
+    match
+      self.reader.read(self.buffer, offset=0, max_length=self.buffer.length()) {
+      Some(read_length) => {
+        if read_length <= 0 {
+          return Some(read_length)
+        }
+        self.start = 0
+        self.end = read_length
+        Some(self.read_from_buffer(bytes, offset~, max_length~))
+      }
+      None => None
+    }
+  }
+}
+
+///|
+pub impl[T : AsyncReader] AsyncReader for BufferedReader[T] with fn read(
+  self,
+  bytes : FixedArray[Byte],
+  offset~ : Int,
+  max_length~ : Int,
+) -> Int? {
+  if offset >= bytes.length() || max_length <= 0 {
+    return None
+  }
+  let max_length = @cmp.minimum(bytes.length() - offset, max_length)
+  if self.start < self.end {
+    return Some(self.read_from_buffer(bytes, offset~, max_length~))
+  }
+  if max_length >= self.buffer.length() {
+    self.reader.read(bytes, offset~, max_length~)
+  } else {
+    match
+      self.reader.read(self.buffer, offset=0, max_length=self.buffer.length()) {
+      Some(read_length) => {
+        if read_length <= 0 {
+          return Some(read_length)
+        }
+        self.start = 0
+        self.end = read_length
+        Some(self.read_from_buffer(bytes, offset~, max_length~))
+      }
+      None => None
+    }
+  }
 }
 
 ///|


### PR DESCRIPTION
## Why
Varint-heavy decoding currently drives many one-byte reads through Reader.read. Stream-like readers that can provide larger chunks pay avoidable per-call overhead.

## What
- Add an opt-in BufferedReader runtime adapter with configurable capacity.
- Serve small reads from buffered upstream chunks while passing large destination reads through.
- Add black-box regressions for varint batching and preserving read-ahead across limited nested reads.

## Correctness
The change is opt-in and leaves the existing Reader trait and generated code unchanged. Buffered bytes stay attached to the same reader instance, so bytes read ahead while decoding a length-limited field remain available to the next top-level read.

## Scope
This is limited to the runtime reader implementation, tests, and generated package interface.