### PR TITLE
Introduce field storage shape IR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,5 +6,7 @@
 - **Runtime**: the MoonBit protobuf library used by generated code for read, write, size, and JSON behavior.
 - **Standard protobuf package**: Runtime-owned generated MoonBit packages for Google protobuf descriptor, compiler, and well-known types under `google/protobuf`.
 - **Feature resolver**: Generator logic that turns protobuf Editions feature options, inheritance, and syntax defaults into semantic questions used by templates.
+- **Field shape semantics**: Generator-side decisions that turn protobuf field descriptors and Feature resolver answers into generated MoonBit shape decisions, such as presence, packing, maps, defaults, names, and per-field read/write/size/JSON categories.
+- **Field storage shape**: The first Field shape semantics slice that resolves a generated field's MoonBit storage declaration: field name, base MoonBit type, optional/list/map wrapping, and default expression when it follows directly from storage.
 - **Generated-code harness**: a test workflow that builds the Generator, generates MoonBit code from focused proto fixtures, and verifies the generated code through its public Runtime interfaces.
 - **Harness case**: a self-contained Generated-code harness input with proto fixtures, a runner test, and `case.toml` metadata.

--- a/cli/field_storage_shape.mbt
+++ b/cli/field_storage_shape.mbt
@@ -1,0 +1,51 @@
+///|
+fn CodeGenerator::field_storage_shape(
+  self : CodeGenerator,
+  field : Field,
+  parent_path : ImportPath,
+) -> FieldStorageShape raise {
+  let field_name = field.import_path.name() |> pascal_to_snake
+  let field_type = self.get_moonbit_type(field, parent_path~)
+  let mut declaration_type = field_type
+  let mut constructor_name = field_name
+  let mut constructor_type = field_type
+  let mut default_expr = "\{field_type}::default()"
+  if field.map_key_value() is Some(map_entry) {
+    let key_type = self.get_moonbit_type(map_entry.fields[0], parent_path~)
+    let value_type = self.get_moonbit_type(map_entry.fields[1], parent_path~)
+    let map_type = "Map[\{key_type}, \{value_type}]"
+    declaration_type = map_type
+    constructor_type = map_type
+    default_expr = "{}"
+  } else if field.is_list() {
+    let array_type = "Array[\{field_type}]"
+    declaration_type = array_type
+    constructor_type = array_type
+    default_expr = "[]"
+  } else if field.is_optional() {
+    declaration_type = "\{field_type}?"
+    constructor_name = "\{field_name}?"
+    default_expr = "None"
+  } else if field.is_message() || field.is_enum() {
+    declaration_type = "\{field_type} "
+  }
+  if field.default_value() is Some(default_value) {
+    let mut field_default_value = default_value
+    if field.type_ is Some(TYPE_STRING) {
+      field_default_value = "\"\{field_default_value}\""
+    } else if field.is_enum() {
+      field_default_value = "\{field_type}::\{default_value}"
+    }
+    if field.is_optional() {
+      field_default_value = "Some(\{field_default_value})"
+    }
+    default_expr = field_default_value
+  }
+  {
+    field_name,
+    declaration_type,
+    constructor_name,
+    constructor_type,
+    default_expr,
+  }
+}

--- a/cli/message_template.mbt
+++ b/cli/message_template.mbt
@@ -75,31 +75,8 @@ fn CodeGenerator::gen_message(
   let message_path = message.import_path
   file.write_string("pub(all) struct \{message_name} {\n")
   for field in message.fields {
-    let field_type = self.get_moonbit_type(field, parent_path=message_path)
-    let field_name = field.import_path.name() |> pascal_to_snake
-    if field.is_optional() {
-      file.write_string("  mut \{field_name} : \{field_type}?\n")
-    } else if field.map_key_value() is Some(map_entry) {
-      let key_type = self.get_moonbit_type(
-        map_entry.fields[0],
-        parent_path=message_path,
-      )
-      let value_type = self.get_moonbit_type(
-        map_entry.fields[1],
-        parent_path=message_path,
-      )
-      file.write_string(
-        "  mut \{field_name} : Map[\{key_type}, \{value_type}]\n",
-      )
-    } else if field.is_list() {
-      file.write_string("  mut \{field_name} : Array[\{field_type}]\n")
-    } else if field.is_message() {
-      file.write_string("  mut \{field_name} : \{field_type} \n")
-    } else if field.is_enum() {
-      file.write_string("  mut \{field_name} : \{field_type} \n")
-    } else {
-      file.write_string("  mut \{field_name} : \{field_type}\n")
-    }
+    let shape = self.field_storage_shape(field, message_path)
+    file.write_string("  mut \{shape.field_name} : \{shape.declaration_type}\n")
   }
   let derive_list = self.derive_list().join(", ")
   for oneof in message.oneofs {
@@ -140,31 +117,8 @@ fn CodeGenerator::gen_message_default(
     ),
   )
   for field in message.fields {
-    let field_type = self.get_moonbit_type(
-      field,
-      parent_path=message.import_path,
-    )
-    let field_name = field.import_path.name() |> pascal_to_snake
-    if field.default_value() is Some(default_value) {
-      let mut field_default_value = default_value
-      if field.type_ is Some(TYPE_STRING) {
-        field_default_value = "\"\{field_default_value}\""
-      } else if field.is_enum() {
-        field_default_value = "\{field_type}::\{default_value}"
-      }
-      if field.is_optional() {
-        field_default_value = "Some(\{field_default_value})"
-      }
-      content.write_string("    \{field_name} : \{field_default_value},\n")
-    } else if field.is_optional() {
-      content.write_string("    \{field_name} : None,\n")
-    } else if field.map_key_value() is Some(_) {
-      content.write_string("    \{field_name} : {},\n")
-    } else if field.is_list() {
-      content.write_string("    \{field_name} : [],\n")
-    } else {
-      content.write_string("    \{field_name} : \{field_type}::default(),\n")
-    }
+    let shape = self.field_storage_shape(field, message.import_path)
+    content.write_string("    \{shape.field_name} : \{shape.default_expr},\n")
   }
   for oneof in message.oneofs {
     let oneof_name = self.get_oneof_enum_name(message, oneof.import_path.name())
@@ -190,27 +144,10 @@ fn CodeGenerator::gen_message_new(
   let message_name = message.import_path.path() |> to_camel_case
   let constructor_arguments = []
   for field in message.fields {
-    let mut field_name = field.import_path.name() |> pascal_to_snake
-    let mut field_type = self.get_moonbit_type(
-      field,
-      parent_path=message.import_path,
+    let shape = self.field_storage_shape(field, message.import_path)
+    constructor_arguments.push(
+      "\{shape.constructor_name} : \{shape.constructor_type}",
     )
-    if field.map_key_value() is Some(map_entry) {
-      let key_type = self.get_moonbit_type(
-        map_entry.fields[0],
-        parent_path=message.import_path,
-      )
-      let value_type = self.get_moonbit_type(
-        map_entry.fields[1],
-        parent_path=message.import_path,
-      )
-      field_type = "Map[\{key_type}, \{value_type}]"
-    } else if field.is_pack() || field.is_list() {
-      field_type = "Array[\{field_type}]"
-    } else if field.is_optional() {
-      field_name = "\{field_name}?"
-    }
-    constructor_arguments.push("\{field_name} : \{field_type}")
   }
   for oneof in message.oneofs {
     let oneof_name = self.get_oneof_enum_name(message, oneof.import_path.name())
@@ -228,8 +165,8 @@ fn CodeGenerator::gen_message_new(
     ),
   )
   for field in message.fields {
-    let field_name = field.import_path.name() |> pascal_to_snake
-    content.write_string("    \{field_name},\n")
+    let shape = self.field_storage_shape(field, message.import_path)
+    content.write_string("    \{shape.field_name},\n")
   }
   for oneof in message.oneofs {
     let oneof_field_name = oneof.import_path.name() |> pascal_to_snake

--- a/cli/model/pkg.generated.mbti
+++ b/cli/model/pkg.generated.mbti
@@ -52,6 +52,14 @@ pub fn Field::is_packable_scalar(Self) -> Bool
 pub fn Field::is_synthetic_oneof(Self) -> Bool
 pub fn Field::map_key_value(Self) -> Message?
 
+pub(all) struct FieldStorageShape {
+  field_name : String
+  declaration_type : String
+  constructor_name : String
+  constructor_type : String
+  default_expr : String
+} derive(Eq, @debug.Debug)
+
 pub(all) struct ImportPath {
   path : Array[String]
   package_name : String

--- a/cli/model/types.mbt
+++ b/cli/model/types.mbt
@@ -92,6 +92,15 @@ pub(all) struct Field {
 } derive(Eq, Debug)
 
 ///|
+pub(all) struct FieldStorageShape {
+  field_name : String
+  declaration_type : String
+  constructor_name : String
+  constructor_type : String
+  default_expr : String
+} derive(Eq, Debug)
+
+///|
 fn Field::from(
   desc : @protobuf.FieldDescriptorProto,
   parent : Message,

--- a/cli/model_imports.mbt
+++ b/cli/model_imports.mbt
@@ -5,6 +5,7 @@ using @protobuf {type FieldDescriptorProto_Type}
 using @model {
   type Enum,
   type Field,
+  type FieldStorageShape,
   type ImportPath,
   type Message,
   type OneOf,


### PR DESCRIPTION
## Why

Generated message storage decisions were spread through `message_template`: field declaration shape, constructor argument shape, and default expression generation each had to know optional/list/map/default rules. That made the template seam shallow and reduced locality for future Field shape semantics work.

## What changed

This PR introduces a small `FieldStorageShape` IR in the Generator model and resolves it from `CodeGenerator::field_storage_shape`. Message struct generation, defaults, and constructor argument generation now consume that storage shape instead of reinterpreting field descriptors directly.

## Why this is correct

The new resolver centralizes the same storage decisions that `message_template` previously made: generated field name, declaration type, constructor argument name/type, and default expression. Templates still emit the same message-level structure, while the descriptor-to-storage-shape behavior now has one Generator-side module.

## Why this is minimal

The change is limited to the first storage-shape slice. It does not move reader, writer, size, JSON, packed wire, or Runtime behavior into the new seam; those remain follow-up candidates.