### PR TITLE
Introduce field JSON shape IR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,5 +9,6 @@
 - **Field shape semantics**: Generator-side decisions that turn protobuf field descriptors and Feature resolver answers into generated MoonBit shape decisions, such as presence, packing, maps, defaults, names, and per-field read/write/size/JSON categories.
 - **Field storage shape**: The first Field shape semantics slice that resolves a generated field's MoonBit storage declaration: field name, base MoonBit type, optional/list/map wrapping, and default expression when it follows directly from storage.
 - **Field codec shape**: The Field shape semantics slice that resolves generated binary read/write/size categories for normal fields, including singular, optional, repeated, packed repeated, and map field handling.
+- **Field JSON shape**: The Field shape semantics slice that resolves generated JSON categories for normal fields, including JSON names, default comparison expressions, optional/list/map handling, and scalar JSON adapters.
 - **Generated-code harness**: a test workflow that builds the Generator, generates MoonBit code from focused proto fixtures, and verifies the generated code through its public Runtime interfaces.
 - **Harness case**: a self-contained Generated-code harness input with proto fixtures, a runner test, and `case.toml` metadata.

--- a/cli/field_json_shape.mbt
+++ b/cli/field_json_shape.mbt
@@ -1,0 +1,148 @@
+///|
+fn CodeGenerator::field_json_shape(
+  self : CodeGenerator,
+  field : Field,
+  parent_path : ImportPath,
+) -> FieldJsonShape raise {
+  guard field.type_ is Some(type_) else {
+    raise @model.UnexpectedType(
+      "Field type is not set: \{field.import_path.name()}",
+    )
+  }
+  let field_name = field.import_path.name() |> pascal_to_snake
+  let field_type = self.get_moonbit_type(field, parent_path~)
+  let has_default_value = field.default_value() is Some(_)
+  let default_expr = if field.default_value() is Some(default_value) {
+    if field.type_ is Some(TYPE_STRING) {
+      "\"\{default_value}\""
+    } else if field.is_enum() {
+      "\{field_type}::\{default_value}"
+    } else {
+      "\{default_value}"
+    }
+  } else {
+    "Default::default()"
+  }
+  let cardinality = if field.map_key_value() is Some(_) {
+    FieldJsonCardinality::MapJsonField
+  } else if field.is_list() {
+    FieldJsonCardinality::RepeatedJsonField
+  } else if field.is_optional() {
+    FieldJsonCardinality::OptionalJsonField
+  } else {
+    FieldJsonCardinality::SingularJsonField
+  }
+  {
+    field_name,
+    self_expr: "self.\{field_name}",
+    to_json_name: field.json_name.unwrap_or(field.name),
+    from_json_name: field.json_name.unwrap(),
+    type_,
+    default_expr,
+    has_default_value,
+    cardinality,
+  }
+}
+
+///|
+fn FieldJsonShape::to_json_expr(
+  self : FieldJsonShape,
+  value_expr : String,
+) -> String {
+  if self.type_ is TYPE_BYTES {
+    "@lib.base64_encode(\{value_expr}).to_json()"
+  } else {
+    "\{value_expr}.to_json()"
+  }
+}
+
+///|
+fn CodeGenerator::gen_field_json_to(
+  _ : CodeGenerator,
+  shape : FieldJsonShape,
+  content : StringBuilder,
+) -> Unit {
+  match shape.cardinality {
+    OptionalJsonField => {
+      content.write_string("  match \{shape.self_expr} {\n")
+      let optional_match = if shape.has_default_value {
+        "Some(v) if v != \{shape.default_expr}"
+      } else {
+        "Some(v)"
+      }
+      content.write_string(
+        "      \{optional_match} => json[\"\{shape.to_json_name}\"] = \{shape.to_json_expr("v")}\n",
+      )
+      content.write_string(
+        (
+          #|      _ => ()
+          #|    }
+          #|
+        ),
+      )
+    }
+    SingularJsonField | RepeatedJsonField | MapJsonField => {
+      content.write_string(
+        "  if \{shape.self_expr} != \{shape.default_expr} {\n",
+      )
+      content.write_string(
+        "  json[\"\{shape.to_json_name}\"] = \{shape.to_json_expr(shape.self_expr)}\n",
+      )
+      content.write_string("  }\n")
+    }
+  }
+}
+
+///|
+fn CodeGenerator::gen_field_json_from(
+  _ : CodeGenerator,
+  shape : FieldJsonShape,
+  content : StringBuilder,
+) -> Unit {
+  match shape.cardinality {
+    OptionalJsonField =>
+      match shape.type_ {
+        TYPE_BYTES =>
+          content.write_string(
+            "      (\"\{shape.from_json_name}\", String(value)) => message.\{shape.field_name} = Some(try @lib.base64_decode(value) catch { _ => raise @json.JsonDecodeError((path, \"Invalid base64 encoding\")) })\n",
+          )
+        TYPE_FLOAT =>
+          content.write_string(
+            "      (\"\{shape.from_json_name}\", Number(value, ..)) => message.\{shape.field_name} = Some(Float::from_double(value))\n",
+          )
+        _ =>
+          content.write_string(
+            "      (\"\{shape.from_json_name}\", value) => message.\{shape.field_name} = Some(@json.from_json(value, path~))\n",
+          )
+      }
+    MapJsonField =>
+      content.write_string(
+        "      (\"\{shape.from_json_name}\", _) => message.\{shape.field_name} = @json.from_json(value, path~)\n",
+      )
+    RepeatedJsonField => {
+      content.write_string(
+        "      (\"\{shape.from_json_name}\", Array(value)) => message.\{shape.field_name} = value.map(v => \n",
+      )
+      if shape.type_ is TYPE_FLOAT {
+        content.write_string("Float::from_double(@json.from_json(v, path~)))\n")
+      } else {
+        content.write_string("@json.from_json(v, path~))\n")
+      }
+    }
+    SingularJsonField =>
+      match shape.type_ {
+        TYPE_FLOAT =>
+          content.write_string(
+            "      (\"\{shape.from_json_name}\", Number(value, ..)) => message.\{shape.field_name} = Float::from_double(value)\n",
+          )
+        TYPE_BYTES =>
+          content.write_string(
+            "      (\"\{shape.from_json_name}\", String(value)) => message.\{shape.field_name} = try @lib.base64_decode(value) catch { _ => raise @json.JsonDecodeError((path, \"Invalid base64 encoding\")) }\n",
+          )
+        _ =>
+          content.write_string(
+            "      (\"\{shape.from_json_name}\", value) => message.\{shape.field_name} = @json.from_json(value, path~)\n",
+          )
+      }
+  }
+}

--- a/cli/json_template.mbt
+++ b/cli/json_template.mbt
@@ -38,61 +38,8 @@ fn CodeGenerator::gen_message_json(
     ),
   )
   for field in message.fields {
-    let field_name = "self.\{field.import_path.name() |> pascal_to_snake}"
-    let json_name = field.json_name.unwrap_or(field.name)
-    let field_type = self.get_moonbit_type(
-      field,
-      parent_path=message.import_path,
-    )
-    let has_default_value = field.default_value() is Some(_)
-    let default_value = if field.default_value() is Some(default_value) {
-      if field.type_ is Some(TYPE_STRING) {
-        "\"\{default_value}\""
-      } else if field.is_enum() {
-        "\{field_type}::\{default_value}"
-      } else {
-        "\{default_value}"
-      }
-    } else {
-      "Default::default()"
-    }
-    if field.is_optional() {
-      content.write_string("  match \{field_name} {\n")
-      let optional_match = if has_default_value {
-        "Some(v) if v != \{default_value}"
-      } else {
-        "Some(v)"
-      }
-      if field.type_ is Some(TYPE_BYTES) {
-        content.write_string(
-          "      \{optional_match} => json[\"\{json_name}\"] = @lib.base64_encode(v).to_json()\n",
-        )
-      } else {
-        content.write_string(
-          "      \{optional_match} => json[\"\{json_name}\"] = v.to_json()\n",
-        )
-      }
-      content.write_string(
-        (
-          #|      _ => ()
-          #|    }
-          #|
-        ),
-      )
-    } else {
-      content.write_string("  if \{field_name} != \{default_value} {\n")
-      match field.type_ {
-        Some(TYPE_BYTES) =>
-          content.write_string(
-            "  json[\"\{json_name}\"] = @lib.base64_encode(\{field_name}).to_json()\n",
-          )
-        _ =>
-          content.write_string(
-            "  json[\"\{json_name}\"] = \{field_name}.to_json()\n",
-          )
-      }
-      content.write_string("  }\n")
-    }
+    let shape = self.field_json_shape(field, message.import_path)
+    self.gen_field_json_to(shape, content)
   }
   for oneof in message.oneofs {
     let oneof_field = oneof.import_path.name() |> pascal_to_snake
@@ -128,52 +75,8 @@ fn CodeGenerator::gen_message_json(
     ),
   )
   for field in message.fields {
-    let field_name = field.import_path.name() |> pascal_to_snake
-    let json_name = field.json_name.unwrap()
-    if field.is_optional() {
-      match field.type_ {
-        Some(TYPE_BYTES) =>
-          content.write_string(
-            "      (\"\{json_name}\", String(value)) => message.\{field_name} = Some(try @lib.base64_decode(value) catch { _ => raise @json.JsonDecodeError((path, \"Invalid base64 encoding\")) })\n",
-          )
-        Some(TYPE_FLOAT) =>
-          content.write_string(
-            "      (\"\{json_name}\", Number(value, ..)) => message.\{field_name} = Some(Float::from_double(value))\n",
-          )
-        _ =>
-          content.write_string(
-            "      (\"\{json_name}\", value) => message.\{field_name} = Some(@json.from_json(value, path~))\n",
-          )
-      }
-    } else if field.map_key_value() is Some(_) {
-      content.write_string(
-        "      (\"\{json_name}\", _) => message.\{field_name} = @json.from_json(value, path~)\n",
-      )
-    } else if field.is_list() {
-      content.write_string(
-        "      (\"\{json_name}\", Array(value)) => message.\{field_name} = value.map(v => \n",
-      )
-      if field.type_ is Some(TYPE_FLOAT) {
-        content.write_string("Float::from_double(@json.from_json(v, path~)))\n")
-      } else {
-        content.write_string("@json.from_json(v, path~))\n")
-      }
-    } else {
-      match field.type_ {
-        Some(TYPE_FLOAT) =>
-          content.write_string(
-            "      (\"\{json_name}\", Number(value, ..)) => message.\{field_name} = Float::from_double(value)\n",
-          )
-        Some(TYPE_BYTES) =>
-          content.write_string(
-            "      (\"\{json_name}\", String(value)) => message.\{field_name} = try @lib.base64_decode(value) catch { _ => raise @json.JsonDecodeError((path, \"Invalid base64 encoding\")) }\n",
-          )
-        _ =>
-          content.write_string(
-            "      (\"\{json_name}\", value) => message.\{field_name} = @json.from_json(value, path~)\n",
-          )
-      }
-    }
+    let shape = self.field_json_shape(field, message.import_path)
+    self.gen_field_json_from(shape, content)
   }
   for oneof in message.oneofs {
     let oneof_field = oneof.import_path.name() |> pascal_to_snake

--- a/cli/model/pkg.generated.mbti
+++ b/cli/model/pkg.generated.mbti
@@ -77,6 +77,24 @@ pub(all) struct FieldCodecValue {
   number : Int
 } derive(Eq, @debug.Debug)
 
+pub(all) enum FieldJsonCardinality {
+  SingularJsonField
+  OptionalJsonField
+  RepeatedJsonField
+  MapJsonField
+} derive(Eq, @debug.Debug)
+
+pub(all) struct FieldJsonShape {
+  field_name : String
+  self_expr : String
+  to_json_name : String
+  from_json_name : String
+  type_ : @protobuf.FieldDescriptorProto_Type
+  default_expr : String
+  has_default_value : Bool
+  cardinality : FieldJsonCardinality
+} derive(Eq, @debug.Debug)
+
 pub(all) struct FieldStorageShape {
   field_name : String
   declaration_type : String

--- a/cli/model/types.mbt
+++ b/cli/model/types.mbt
@@ -129,6 +129,26 @@ pub(all) struct FieldCodecShape {
 } derive(Eq, Debug)
 
 ///|
+pub(all) enum FieldJsonCardinality {
+  SingularJsonField
+  OptionalJsonField
+  RepeatedJsonField
+  MapJsonField
+} derive(Eq, Debug)
+
+///|
+pub(all) struct FieldJsonShape {
+  field_name : String
+  self_expr : String
+  to_json_name : String
+  from_json_name : String
+  type_ : FieldDescriptorProto_Type
+  default_expr : String
+  has_default_value : Bool
+  cardinality : FieldJsonCardinality
+} derive(Eq, Debug)
+
+///|
 fn Field::from(
   desc : @protobuf.FieldDescriptorProto,
   parent : Message,

--- a/cli/model_imports.mbt
+++ b/cli/model_imports.mbt
@@ -8,6 +8,8 @@ using @model {
   type FieldCodecCardinality,
   type FieldCodecShape,
   type FieldCodecValue,
+  type FieldJsonCardinality,
+  type FieldJsonShape,
   type FieldStorageShape,
   type ImportPath,
   type Message,


### PR DESCRIPTION
## Why
JSON generation still repeated normal-field descriptor decisions directly in the template: JSON names, default comparisons, optional/list/map branching, and scalar adapters. That made the JSON path the remaining normal-field generator surface outside the Field shape semantics vocabulary.

## What
- Add `FieldJsonShape` and `FieldJsonCardinality` to the generator model.
- Add a `field_json_shape` builder plus to/from JSON emitters for normal fields.
- Route normal-field JSON generation through that shape while leaving oneof JSON handling in the oneof-specific path.
- Document Field JSON shape in the project context glossary.

## Why This Is Correct
The new shape computes the same field name, JSON names, default expression, cardinality, and bytes/float JSON adapters that the template previously computed inline. The emitters preserve the existing generated to/from JSON cases; the change concentrates those decisions behind the Field shape semantics seam.

## Scope
This is intentionally limited to normal-field JSON semantics. Storage, binary codec generation, oneof generation, and generated output format stay out of this slice.