### PR TITLE
Introduce oneof shape IR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,5 +10,6 @@
 - **Field storage shape**: The first Field shape semantics slice that resolves a generated field's MoonBit storage declaration: field name, base MoonBit type, optional/list/map wrapping, and default expression when it follows directly from storage.
 - **Field codec shape**: The Field shape semantics slice that resolves generated binary read/write/size categories for normal fields, including singular, optional, repeated, packed repeated, and map field handling.
 - **Field JSON shape**: The Field shape semantics slice that resolves generated JSON categories for normal fields, including JSON names, default comparison expressions, optional/list/map handling, and scalar JSON adapters.
+- **Oneof shape**: Generator-side decisions that turn protobuf oneof descriptors into generated enum names, message storage fields, enum variants, field numbers, value types, and oneof read/write/size/JSON cases.
 - **Generated-code harness**: a test workflow that builds the Generator, generates MoonBit code from focused proto fixtures, and verifies the generated code through its public Runtime interfaces.
 - **Harness case**: a self-contained Generated-code harness input with proto fixtures, a runner test, and `case.toml` metadata.

--- a/cli/json_template.mbt
+++ b/cli/json_template.mbt
@@ -42,22 +42,8 @@ fn CodeGenerator::gen_message_json(
     self.gen_field_json_to(shape, content)
   }
   for oneof in message.oneofs {
-    let oneof_field = oneof.import_path.name() |> pascal_to_snake
-    content.write_string(
-      (
-        $|  match self.\{oneof_field} {
-        $|    NotSet => ()
-        $|
-      ),
-    )
-    for field in oneof.field {
-      let json_name = field.json_name.unwrap()
-      let field_type = field.import_path.name() |> to_camel_case
-      content.write_string(
-        "    \{field_type}(v) => json[\"\{json_name}\"] = v.to_json()\n",
-      )
-    }
-    content.write_string("  }\n")
+    let shape = self.oneof_shape(message, oneof)
+    self.gen_oneof_json_to(shape, content)
   }
   // From JSON
   content.write_string(
@@ -79,13 +65,8 @@ fn CodeGenerator::gen_message_json(
     self.gen_field_json_from(shape, content)
   }
   for oneof in message.oneofs {
-    let oneof_field = oneof.import_path.name() |> pascal_to_snake
-    for field in oneof.field {
-      let json_name = field.json_name.unwrap()
-      content.write_string(
-        "      (\"\{json_name}\", value) => message.\{oneof_field} = @json.from_json(value, path~)\n",
-      )
-    }
+    let shape = self.oneof_shape(message, oneof)
+    self.gen_oneof_json_from(shape, content)
   }
   content.write_string(
     (

--- a/cli/message_template.mbt
+++ b/cli/message_template.mbt
@@ -80,13 +80,13 @@ fn CodeGenerator::gen_message(
   }
   let derive_list = self.derive_list().join(", ")
   for oneof in message.oneofs {
-    let oneof_name = self.get_oneof_enum_name(message, oneof.import_path.name())
-    let field_name = oneof.import_path.name() |> pascal_to_snake
-    file.write_string("  mut \{field_name} : \{oneof_name}\n")
+    let shape = self.oneof_shape(message, oneof)
+    file.write_string("  mut \{shape.field_name} : \{shape.enum_name}\n")
   }
   file.write_string("} derive(\{derive_list})\n")
   for oneof in message.oneofs {
-    self.gen_oneof_enum(message, oneof, file)
+    let shape = self.oneof_shape(message, oneof)
+    self.gen_oneof_enum(shape, file)
   }
   self.gen_message_size(message, file)
   self.gen_message_default(message, file)
@@ -121,9 +121,9 @@ fn CodeGenerator::gen_message_default(
     content.write_string("    \{shape.field_name} : \{shape.default_expr},\n")
   }
   for oneof in message.oneofs {
-    let oneof_name = self.get_oneof_enum_name(message, oneof.import_path.name())
+    let shape = self.oneof_shape(message, oneof)
     content.write_string(
-      "    \{oneof.import_path.name()} : \{oneof_name}::NotSet,\n",
+      "    \{shape.field_name} : \{shape.enum_name}::NotSet,\n",
     )
   }
   content.write_string(
@@ -150,10 +150,9 @@ fn CodeGenerator::gen_message_new(
     )
   }
   for oneof in message.oneofs {
-    let oneof_name = self.get_oneof_enum_name(message, oneof.import_path.name())
-    let oneof_field_name = oneof.import_path.name() |> pascal_to_snake
+    let shape = self.oneof_shape(message, oneof)
     constructor_arguments.push(
-      "\{oneof_field_name}?: \{oneof_name} = \{oneof_name}::NotSet",
+      "\{shape.field_name}?: \{shape.enum_name} = \{shape.enum_name}::NotSet",
     )
   }
   let constructor_arguments_string = constructor_arguments.join(", ")
@@ -169,8 +168,8 @@ fn CodeGenerator::gen_message_new(
     content.write_string("    \{shape.field_name},\n")
   }
   for oneof in message.oneofs {
-    let oneof_field_name = oneof.import_path.name() |> pascal_to_snake
-    content.write_string("    \{oneof_field_name},\n")
+    let shape = self.oneof_shape(message, oneof)
+    content.write_string("    \{shape.field_name},\n")
   }
   content.write_string(
     (

--- a/cli/model/pkg.generated.mbti
+++ b/cli/model/pkg.generated.mbti
@@ -137,6 +137,20 @@ pub(all) struct OneOf {
   name : String
 } derive(Eq, @debug.Debug)
 
+pub(all) struct OneofFieldShape {
+  constructor_name : String
+  field_number : Int
+  json_name : String
+  value_type : String
+  value : FieldCodecValue
+} derive(Eq, @debug.Debug)
+
+pub(all) struct OneofShape {
+  field_name : String
+  enum_name : String
+  fields : Array[OneofFieldShape]
+} derive(Eq, @debug.Debug)
+
 pub(all) struct Package {
   desc : @protobuf.FileDescriptorProto
   message_type : Array[Message]

--- a/cli/model/types.mbt
+++ b/cli/model/types.mbt
@@ -149,6 +149,22 @@ pub(all) struct FieldJsonShape {
 } derive(Eq, Debug)
 
 ///|
+pub(all) struct OneofFieldShape {
+  constructor_name : String
+  field_number : Int
+  json_name : String
+  value_type : String
+  value : FieldCodecValue
+} derive(Eq, Debug)
+
+///|
+pub(all) struct OneofShape {
+  field_name : String
+  enum_name : String
+  fields : Array[OneofFieldShape]
+} derive(Eq, Debug)
+
+///|
 fn Field::from(
   desc : @protobuf.FieldDescriptorProto,
   parent : Message,

--- a/cli/model_imports.mbt
+++ b/cli/model_imports.mbt
@@ -14,5 +14,7 @@ using @model {
   type ImportPath,
   type Message,
   type OneOf,
+  type OneofFieldShape,
+  type OneofShape,
   type Package,
 }

--- a/cli/oneof_shape.mbt
+++ b/cli/oneof_shape.mbt
@@ -1,0 +1,137 @@
+///|
+fn CodeGenerator::oneof_shape(
+  self : CodeGenerator,
+  message : Message,
+  oneof : OneOf,
+) -> OneofShape raise {
+  let message_name = message.import_path.path() |> to_camel_case
+  let fields = []
+  for field in oneof.field {
+    let field_shape : OneofFieldShape = {
+      constructor_name: field.import_path.name() |> to_camel_case,
+      field_number: field.number.unwrap(),
+      json_name: field.json_name.unwrap(),
+      value_type: self.get_moonbit_type(field, parent_path=message.import_path),
+      value: self.field_codec_value(field, message.import_path),
+    }
+    fields.push(field_shape)
+  }
+  {
+    field_name: oneof.import_path.name() |> pascal_to_snake,
+    enum_name: "\{message_name}_\{to_camel_case(oneof.import_path.name())}",
+    fields,
+  }
+}
+
+///|
+fn OneofFieldShape::tag_value(self : OneofFieldShape) -> UInt64 {
+  tag(self.value.type_, self.field_number, false)
+}
+
+///|
+fn CodeGenerator::gen_oneof_codec_read(
+  _ : CodeGenerator,
+  shape : OneofShape,
+  content : StringBuilder,
+  is_async? : Bool = false,
+) -> Unit raise {
+  for field in shape.fields {
+    content.write_string(
+      "        (\{field.field_number}, _) => msg.\{shape.field_name} = \{field.value.read_expr(is_async~)} |> \{shape.enum_name}::\{field.constructor_name}\n",
+    )
+  }
+}
+
+///|
+fn CodeGenerator::gen_oneof_codec_write(
+  _ : CodeGenerator,
+  shape : OneofShape,
+  content : StringBuilder,
+  is_async? : Bool = false,
+) -> Unit raise {
+  let async_keyword = if is_async { "async" } else { "" }
+  let async_keyword_to_snake = async_keyword |> pascal_to_snake
+  content.write_string("  match self.\{shape.field_name} {\n")
+  for field in shape.fields {
+    let field_write = field.value.write_expr("v", is_async~)
+    content.write_string(
+      (
+        $|    \{shape.enum_name}::\{field.constructor_name}(v) => {
+        $|      writer |> @lib.\{async_keyword_to_snake}write_varint(\{field.tag_value()}UL)
+        $|      \{field_write}
+        $|     }
+        $|
+      ),
+    )
+  }
+  content.write_string(
+    (
+      $|    \{shape.enum_name}::NotSet => ()
+      $|  }
+      $|
+    ),
+  )
+}
+
+///|
+fn CodeGenerator::gen_oneof_codec_size(
+  _ : CodeGenerator,
+  shape : OneofShape,
+  content : StringBuilder,
+) -> Unit {
+  content.write_string("  match self.\{shape.field_name} {\n")
+  for field in shape.fields {
+    let (delta_size, need_v) = field.value.unpacked_size_expr(
+      "v",
+      size_tag(field.field_number),
+    )
+    let value_binding = if need_v { "v" } else { "_" }
+    content.write_string(
+      (
+        $|    \{field.constructor_name}(\{value_binding}) => { size += \{delta_size} }
+        $|
+      ),
+    )
+  }
+  content.write_string(
+    (
+      #|    NotSet => ()
+      #|  }
+      #|
+    ),
+  )
+}
+
+///|
+fn CodeGenerator::gen_oneof_json_to(
+  _ : CodeGenerator,
+  shape : OneofShape,
+  content : StringBuilder,
+) -> Unit {
+  content.write_string(
+    (
+      $|  match self.\{shape.field_name} {
+      $|    NotSet => ()
+      $|
+    ),
+  )
+  for field in shape.fields {
+    content.write_string(
+      "    \{field.constructor_name}(v) => json[\"\{field.json_name}\"] = v.to_json()\n",
+    )
+  }
+  content.write_string("  }\n")
+}
+
+///|
+fn CodeGenerator::gen_oneof_json_from(
+  _ : CodeGenerator,
+  shape : OneofShape,
+  content : StringBuilder,
+) -> Unit {
+  for field in shape.fields {
+    content.write_string(
+      "      (\"\{field.json_name}\", value) => message.\{shape.field_name} = @json.from_json(value, path~)\n",
+    )
+  }
+}

--- a/cli/oneof_template.mbt
+++ b/cli/oneof_template.mbt
@@ -1,36 +1,19 @@
 ///|
-fn CodeGenerator::get_oneof_enum_name(
-  _ : CodeGenerator,
-  message : Message,
-  oneof_name : String,
-) -> String {
-  let message_name = message.import_path.path() |> to_camel_case
-  return "\{message_name}_\{to_camel_case(oneof_name)}"
-}
-
-///|
 fn CodeGenerator::gen_oneof_enum(
   self : CodeGenerator,
-  message : Message,
-  oneof : OneOf,
+  shape : OneofShape,
   content : StringBuilder,
-) -> Unit raise {
-  let enum_name = self.get_oneof_enum_name(message, oneof.import_path.name())
-  content.write_string("pub(all) enum \{enum_name} {\n")
-  for field in oneof.field {
-    let field_type = self.get_moonbit_type(
-      field,
-      parent_path=message.import_path,
-    )
-    let field_name = field.import_path.name() |> to_camel_case
-    content.write_string("  \{field_name}(\{field_type})\n")
+) -> Unit {
+  content.write_string("pub(all) enum \{shape.enum_name} {\n")
+  for field in shape.fields {
+    content.write_string("  \{field.constructor_name}(\{field.value_type})\n")
   }
   let derive_list = self.derive_list().join(", ")
   content.write_string(
     (
       $|  NotSet
       $|} derive(\{derive_list})
-      $|pub impl Default for \{enum_name} with fn default() -> \{enum_name} {
+      $|pub impl Default for \{shape.enum_name} with fn default() -> \{shape.enum_name} {
       $|  NotSet
       $|}
       $|
@@ -39,13 +22,12 @@ fn CodeGenerator::gen_oneof_enum(
   if self.support_json() {
     // From Json
     content.write_string(
-      "pub impl @json.FromJson for \{enum_name} with fn from_json(json: Json, path: @json.JsonPath) -> \{enum_name} raise {\n",
+      "pub impl @json.FromJson for \{shape.enum_name} with fn from_json(json: Json, path: @json.JsonPath) -> \{shape.enum_name} raise {\n",
     )
-    for field in oneof.field {
-      let field_name = field.import_path.name() |> to_camel_case
+    for field in shape.fields {
       content.write_string(
         (
-          $|  try { \{enum_name}::\{field_name}(json |> @json.from_json(path~)) } catch {
+          $|  try { \{shape.enum_name}::\{field.constructor_name}(json |> @json.from_json(path~)) } catch {
           $|    _ => ()
           $|  } noraise {
           $|    v => return v
@@ -56,23 +38,22 @@ fn CodeGenerator::gen_oneof_enum(
     }
     content.write_string(
       (
-        $|\{enum_name}::NotSet
+        $|\{shape.enum_name}::NotSet
         $|}
-        $|pub impl ToJson for \{enum_name} with fn to_json(self : \{enum_name}) -> Json {
+        $|pub impl ToJson for \{shape.enum_name} with fn to_json(self : \{shape.enum_name}) -> Json {
         $|  match self {
         // To Json
         $|
       ),
     )
-    for field in oneof.field {
-      let field_name = field.import_path.name() |> to_camel_case
+    for field in shape.fields {
       content.write_string(
-        "    \{enum_name}::\{field_name}(v) => v.to_json()\n",
+        "    \{shape.enum_name}::\{field.constructor_name}(v) => v.to_json()\n",
       )
     }
     content.write_string(
       (
-        $|    \{enum_name}::NotSet => Json::null()
+        $|    \{shape.enum_name}::NotSet => Json::null()
         $|  }
         $|}
         $|

--- a/cli/reader_template.mbt
+++ b/cli/reader_template.mbt
@@ -40,19 +40,8 @@ fn CodeGenerator::gen_message_reader(
     self.gen_field_codec_read(shape, content, is_async~)
   }
   for oneof in message.oneofs {
-    let oneof_name = self.get_oneof_enum_name(message, oneof.import_path.name())
-    let oneof_field_name = oneof.import_path.name() |> pascal_to_snake
-    for field in oneof.field {
-      let field_name = field.import_path.name() |> to_camel_case
-      let field_number = field.number.unwrap()
-      let type_name = self.get_moonbit_type(
-        field,
-        parent_path=message.import_path,
-      )
-      content.write_string(
-        "        (\{field_number}, _) => msg.\{oneof_field_name} = \{gen_kind_read(field.type_.unwrap(), type_name, is_async~)} |> \{oneof_name}::\{field_name}\n",
-      )
-    }
+    let shape = self.oneof_shape(message, oneof)
+    self.gen_oneof_codec_read(shape, content, is_async~)
   }
   content.write_string(
     (
@@ -100,40 +89,6 @@ fn kind_read_func(
       raise @model.UnsupportedType("enum type")
     FieldDescriptorProto_Type::TYPE_MESSAGE =>
       raise @model.UnexpectedType("message type")
-    FieldDescriptorProto_Type::TYPE_GROUP =>
-      raise @model.UnsupportedType("Group")
-  }
-}
-
-///|
-fn gen_kind_read(
-  field_type : FieldDescriptorProto_Type,
-  type_name : String,
-  is_async? : Bool = false,
-) -> String raise {
-  let async_keyword = if is_async { "async_" } else { "" }
-  match field_type {
-    FieldDescriptorProto_Type::TYPE_BOOL
-    | FieldDescriptorProto_Type::TYPE_INT32
-    | FieldDescriptorProto_Type::TYPE_INT64
-    | FieldDescriptorProto_Type::TYPE_UINT32
-    | FieldDescriptorProto_Type::TYPE_UINT64
-    | FieldDescriptorProto_Type::TYPE_FIXED32
-    | FieldDescriptorProto_Type::TYPE_FIXED64
-    | FieldDescriptorProto_Type::TYPE_SFIXED32
-    | FieldDescriptorProto_Type::TYPE_SFIXED64
-    | FieldDescriptorProto_Type::TYPE_FLOAT
-    | FieldDescriptorProto_Type::TYPE_DOUBLE
-    | FieldDescriptorProto_Type::TYPE_STRING
-    | FieldDescriptorProto_Type::TYPE_BYTES =>
-      "reader |> \{kind_read_func(field_type, is_async~)}()"
-    FieldDescriptorProto_Type::TYPE_SINT32
-    | FieldDescriptorProto_Type::TYPE_SINT64 =>
-      "(reader |> \{kind_read_func(field_type, is_async~)}()).0"
-    FieldDescriptorProto_Type::TYPE_ENUM =>
-      "reader |> @lib.\{async_keyword}read_enum() |> \{type_name}::from_enum"
-    FieldDescriptorProto_Type::TYPE_MESSAGE =>
-      "(reader |> @lib.\{async_keyword}read_message() : \{type_name})"
     FieldDescriptorProto_Type::TYPE_GROUP =>
       raise @model.UnsupportedType("Group")
   }

--- a/cli/size_template.mbt
+++ b/cli/size_template.mbt
@@ -28,39 +28,8 @@ fn CodeGenerator::gen_message_size(
     self.gen_field_codec_size(shape, content)
   }
   for oneof in message.oneofs {
-    let field_name = oneof.import_path.name() |> pascal_to_snake
-    content.write_string("  match self.\{field_name} {\n")
-    for field in oneof.field {
-      let field_name = field.import_path.name() |> to_camel_case
-      let field_number = field.number.unwrap()
-      let (delta_size, value_binding) = if field.type_ is Some(typ) {
-        let value : FieldCodecValue = {
-          type_: typ,
-          type_name: "",
-          number: field_number,
-        }
-        let (value_size, need_v) = value.unpacked_size_expr(
-          "v",
-          size_tag(field_number),
-        )
-        (value_size, if need_v { "v" } else { "_" })
-      } else {
-        ("0", "_")
-      }
-      content.write_string(
-        (
-          $|    \{field_name}(\{value_binding}) => { size += \{delta_size} }
-          $|
-        ),
-      )
-    }
-    content.write_string(
-      (
-        #|    NotSet => ()
-        #|  }
-        #|
-      ),
-    )
+    let shape = self.oneof_shape(message, oneof)
+    self.gen_oneof_codec_size(shape, content)
   }
   content.write_string(
     (

--- a/cli/writer_template.mbt
+++ b/cli/writer_template.mbt
@@ -7,7 +7,6 @@ fn CodeGenerator::gen_message_writer(
 ) -> Unit raise {
   let message_name = message.import_path.path() |> to_camel_case
   let async_keyword = if is_async { "async" } else { "" }
-  let async_keyword_to_snake = async_keyword |> pascal_to_snake
   let async_keyword_to_title = async_keyword |> title
   if message.fields.is_empty() && message.oneofs.is_empty() {
     content.write_string(
@@ -27,47 +26,8 @@ fn CodeGenerator::gen_message_writer(
     self.gen_field_codec_write(shape, content, is_async~)
   }
   for oneof in message.oneofs {
-    let oneof_name = self.get_oneof_enum_name(message, oneof.import_path.name())
-    let oneof_field_name = oneof.import_path.name() |> pascal_to_snake
-    content.write_string("  match self.\{oneof_field_name} {\n")
-    for field in oneof.field {
-      let field_name = field.import_path.name() |> to_camel_case
-      let field_number = field.number.unwrap()
-      let tag_val = tag(field.type_.unwrap(), field_number, false)
-      let field_write_type = self.gen_kind_write(field, "v", is_async~)
-      content.write_string(
-        (
-          $|    \{oneof_name}::\{field_name}(v) => {
-          $|      writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL)
-          $|      \{field_write_type}
-          $|     }
-          $|
-        ),
-      )
-    }
-    content.write_string(
-      (
-        $|    \{oneof_name}::NotSet => ()
-        $|  }
-        $|
-      ),
-    )
+    let shape = self.oneof_shape(message, oneof)
+    self.gen_oneof_codec_write(shape, content, is_async~)
   }
   content.write_string("}\n")
-}
-
-///|
-fn CodeGenerator::gen_kind_write(
-  _ : CodeGenerator,
-  field : Field,
-  variable : String,
-  is_async? : Bool = false,
-) -> String raise {
-  guard field.type_ is Some(type_) else {
-    raise @model.UnexpectedType(
-      "Field type is not set: \{field.import_path.name()}",
-    )
-  }
-  let value : FieldCodecValue = { type_, type_name: "", number: 0 }
-  value.write_expr(variable, is_async~)
 }


### PR DESCRIPTION
## Why
Oneof generation still recomputed the same descriptor decisions across multiple templates: generated enum names, message storage field names, enum variant names, field numbers, value types, JSON names, binary tags, and read/write/size cases. That made oneof behavior the next repeated generator surface after normal Field shape semantics.

## What
- Add `OneofShape` and `OneofFieldShape` to the generator model.
- Add a `oneof_shape` builder plus oneof read/write/size/JSON emitters.
- Route message storage/default/new, oneof enum generation, binary codec generation, size generation, and JSON generation through the oneof shape.
- Remove the old ad hoc oneof read/write helper paths that duplicated `FieldCodecValue` behavior.
- Document Oneof shape in the project context glossary.

## Why This Is Correct
The new shape stores the same names, numbers, JSON names, value types, and codec values that each template previously derived inline. The oneof emitters reuse `FieldCodecValue` for binary value read/write/size expressions, so oneof scalar, enum, and message handling follows the same codec value semantics as normal fields while preserving the generated cases.

## Scope
This PR is limited to concentrating oneof shape decisions. It does not change protobuf semantics, generated snapshot output, or the normal field storage/codec/JSON shape interfaces.