### PR TITLE
Introduce message shape IR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,5 +11,6 @@
 - **Field codec shape**: The Field shape semantics slice that resolves generated binary read/write/size categories for normal fields, including singular, optional, repeated, packed repeated, and map field handling.
 - **Field JSON shape**: The Field shape semantics slice that resolves generated JSON categories for normal fields, including JSON names, default comparison expressions, optional/list/map handling, and scalar JSON adapters.
 - **Oneof shape**: Generator-side decisions that turn protobuf oneof descriptors into generated enum names, message storage fields, enum variants, field numbers, value types, and oneof read/write/size/JSON cases.
+- **Message shape**: Generator-side decisions that collect a message's generated MoonBit name, normal Field shape slices, Oneof shapes, and Runtime-owned JSON implementation status for template emission.
 - **Generated-code harness**: a test workflow that builds the Generator, generates MoonBit code from focused proto fixtures, and verifies the generated code through its public Runtime interfaces.
 - **Harness case**: a self-contained Generated-code harness input with proto fixtures, a runner test, and `case.toml` metadata.

--- a/cli/json_template.mbt
+++ b/cli/json_template.mbt
@@ -1,27 +1,20 @@
 ///|
-fn Message::has_runtime_json_impl(self : Message) -> Bool {
-  self.import_path.package_name == "google.protobuf" &&
-  (self.name == "Timestamp" || self.name == "Duration")
-}
-
-///|
 fn CodeGenerator::gen_message_json(
   self : CodeGenerator,
-  message : Message,
+  shape : MessageShape,
   content : StringBuilder,
-) -> Unit raise {
-  if message.has_runtime_json_impl() {
+) -> Unit {
+  if shape.has_runtime_json_impl {
     return
   }
-  let message_name = message.import_path.path() |> to_camel_case
-  if message.fields.is_empty() && message.oneofs.is_empty() {
+  if shape.is_empty() {
     content.write_string(
       (
-        $|pub impl ToJson for \{message_name} with fn to_json(_) {
+        $|pub impl ToJson for \{shape.message_name} with fn to_json(_) {
         $|  {}
         $|}
-        $|pub impl @json.FromJson for \{message_name} with fn from_json(_, _) -> \{message_name} noraise {
-        $|  \{message_name}::default()
+        $|pub impl @json.FromJson for \{shape.message_name} with fn from_json(_, _) -> \{shape.message_name} noraise {
+        $|  \{shape.message_name}::default()
         $|}
         $|
       ),
@@ -32,41 +25,37 @@ fn CodeGenerator::gen_message_json(
   // To JSON
   content.write_string(
     (
-      $|pub impl ToJson for \{message_name} with fn to_json(self) {
+      $|pub impl ToJson for \{shape.message_name} with fn to_json(self) {
       $|  let json: Map[String, Json] = {}
       $|
     ),
   )
-  for field in message.fields {
-    let shape = self.field_json_shape(field, message.import_path)
-    self.gen_field_json_to(shape, content)
+  for field in shape.json_fields {
+    self.gen_field_json_to(field, content)
   }
-  for oneof in message.oneofs {
-    let shape = self.oneof_shape(message, oneof)
-    self.gen_oneof_json_to(shape, content)
+  for oneof in shape.oneofs {
+    self.gen_oneof_json_to(oneof, content)
   }
   // From JSON
   content.write_string(
     (
       $|  Json::object(json)
       $|}
-      $|pub impl @json.FromJson for \{message_name} with fn from_json(json: Json, path: @json.JsonPath) -> \{message_name} raise {
+      $|pub impl @json.FromJson for \{shape.message_name} with fn from_json(json: Json, path: @json.JsonPath) -> \{shape.message_name} raise {
       $|  guard json is Object(obj) else {
-      $|    raise @json.JsonDecodeError((path, "Expected an object for \{message_name}"))
+      $|    raise @json.JsonDecodeError((path, "Expected an object for \{shape.message_name}"))
       $|  }
-      $|  let message = \{message_name}::default()
+      $|  let message = \{shape.message_name}::default()
       $|  for key, value in obj {
       $|    match (key, value) {
       $|
     ),
   )
-  for field in message.fields {
-    let shape = self.field_json_shape(field, message.import_path)
-    self.gen_field_json_from(shape, content)
+  for field in shape.json_fields {
+    self.gen_field_json_from(field, content)
   }
-  for oneof in message.oneofs {
-    let shape = self.oneof_shape(message, oneof)
-    self.gen_oneof_json_from(shape, content)
+  for oneof in shape.oneofs {
+    self.gen_oneof_json_from(oneof, content)
   }
   content.write_string(
     (

--- a/cli/message_shape.mbt
+++ b/cli/message_shape.mbt
@@ -1,0 +1,40 @@
+///|
+fn Message::has_runtime_json_impl(self : Message) -> Bool {
+  self.import_path.package_name == "google.protobuf" &&
+  (self.name == "Timestamp" || self.name == "Duration")
+}
+
+///|
+fn CodeGenerator::message_shape(
+  self : CodeGenerator,
+  message : Message,
+) -> MessageShape raise {
+  let storage_fields = []
+  let codec_fields = []
+  let json_fields = []
+  let oneofs = []
+  let has_runtime_json_impl = message.has_runtime_json_impl()
+  for field in message.fields {
+    storage_fields.push(self.field_storage_shape(field, message.import_path))
+    codec_fields.push(self.field_codec_shape(field, message.import_path))
+    if self.support_json() && !has_runtime_json_impl {
+      json_fields.push(self.field_json_shape(field, message.import_path))
+    }
+  }
+  for oneof in message.oneofs {
+    oneofs.push(self.oneof_shape(message, oneof))
+  }
+  {
+    message_name: message.import_path.path() |> to_camel_case,
+    storage_fields,
+    codec_fields,
+    json_fields,
+    oneofs,
+    has_runtime_json_impl,
+  }
+}
+
+///|
+fn MessageShape::is_empty(self : MessageShape) -> Bool {
+  self.storage_fields.is_empty() && self.oneofs.is_empty()
+}

--- a/cli/message_template.mbt
+++ b/cli/message_template.mbt
@@ -71,59 +71,52 @@ fn CodeGenerator::gen_message(
   message : Message,
   file : StringBuilder,
 ) -> Unit raise {
-  let message_name = message.import_path.path() |> to_camel_case
-  let message_path = message.import_path
-  file.write_string("pub(all) struct \{message_name} {\n")
-  for field in message.fields {
-    let shape = self.field_storage_shape(field, message_path)
-    file.write_string("  mut \{shape.field_name} : \{shape.declaration_type}\n")
+  let shape = self.message_shape(message)
+  file.write_string("pub(all) struct \{shape.message_name} {\n")
+  for field in shape.storage_fields {
+    file.write_string("  mut \{field.field_name} : \{field.declaration_type}\n")
   }
   let derive_list = self.derive_list().join(", ")
-  for oneof in message.oneofs {
-    let shape = self.oneof_shape(message, oneof)
-    file.write_string("  mut \{shape.field_name} : \{shape.enum_name}\n")
+  for oneof in shape.oneofs {
+    file.write_string("  mut \{oneof.field_name} : \{oneof.enum_name}\n")
   }
   file.write_string("} derive(\{derive_list})\n")
-  for oneof in message.oneofs {
-    let shape = self.oneof_shape(message, oneof)
-    self.gen_oneof_enum(shape, file)
+  for oneof in shape.oneofs {
+    self.gen_oneof_enum(oneof, file)
   }
-  self.gen_message_size(message, file)
-  self.gen_message_default(message, file)
-  self.gen_message_new(message, file)
-  self.gen_message_reader(message, file)
-  self.gen_message_writer(message, file)
+  self.gen_message_size(shape, file)
+  self.gen_message_default(shape, file)
+  self.gen_message_new(shape, file)
+  self.gen_message_reader(shape, file)
+  self.gen_message_writer(shape, file)
   if self.support_json() {
-    self.gen_message_json(message, file)
+    self.gen_message_json(shape, file)
   }
   if self.support_async() {
-    self.gen_message_reader(message, file, is_async=true)
-    self.gen_message_writer(message, file, is_async=true)
+    self.gen_message_reader(shape, file, is_async=true)
+    self.gen_message_writer(shape, file, is_async=true)
   }
 }
 
 ///|
 fn CodeGenerator::gen_message_default(
-  self : CodeGenerator,
-  message : Message,
+  _ : CodeGenerator,
+  shape : MessageShape,
   content : StringBuilder,
-) -> Unit raise {
-  let message_name = message.import_path.path() |> to_camel_case
+) -> Unit {
   content.write_string(
     (
-      $|pub impl Default for \{message_name} with fn default() -> \{message_name} {
-      $|  \{message_name}::{
+      $|pub impl Default for \{shape.message_name} with fn default() -> \{shape.message_name} {
+      $|  \{shape.message_name}::{
       $|
     ),
   )
-  for field in message.fields {
-    let shape = self.field_storage_shape(field, message.import_path)
-    content.write_string("    \{shape.field_name} : \{shape.default_expr},\n")
+  for field in shape.storage_fields {
+    content.write_string("    \{field.field_name} : \{field.default_expr},\n")
   }
-  for oneof in message.oneofs {
-    let shape = self.oneof_shape(message, oneof)
+  for oneof in shape.oneofs {
     content.write_string(
-      "    \{shape.field_name} : \{shape.enum_name}::NotSet,\n",
+      "    \{oneof.field_name} : \{oneof.enum_name}::NotSet,\n",
     )
   }
   content.write_string(
@@ -137,39 +130,34 @@ fn CodeGenerator::gen_message_default(
 
 ///|
 fn CodeGenerator::gen_message_new(
-  self : CodeGenerator,
-  message : Message,
+  _ : CodeGenerator,
+  shape : MessageShape,
   content : StringBuilder,
-) -> Unit raise {
-  let message_name = message.import_path.path() |> to_camel_case
+) -> Unit {
   let constructor_arguments = []
-  for field in message.fields {
-    let shape = self.field_storage_shape(field, message.import_path)
+  for field in shape.storage_fields {
     constructor_arguments.push(
-      "\{shape.constructor_name} : \{shape.constructor_type}",
+      "\{field.constructor_name} : \{field.constructor_type}",
     )
   }
-  for oneof in message.oneofs {
-    let shape = self.oneof_shape(message, oneof)
+  for oneof in shape.oneofs {
     constructor_arguments.push(
-      "\{shape.field_name}?: \{shape.enum_name} = \{shape.enum_name}::NotSet",
+      "\{oneof.field_name}?: \{oneof.enum_name} = \{oneof.enum_name}::NotSet",
     )
   }
   let constructor_arguments_string = constructor_arguments.join(", ")
   content.write_string(
     (
-      $|pub fn \{message_name}::new(\{constructor_arguments_string}) -> \{message_name} {
-      $|  \{message_name}::{
+      $|pub fn \{shape.message_name}::new(\{constructor_arguments_string}) -> \{shape.message_name} {
+      $|  \{shape.message_name}::{
       $|
     ),
   )
-  for field in message.fields {
-    let shape = self.field_storage_shape(field, message.import_path)
-    content.write_string("    \{shape.field_name},\n")
+  for field in shape.storage_fields {
+    content.write_string("    \{field.field_name},\n")
   }
-  for oneof in message.oneofs {
-    let shape = self.oneof_shape(message, oneof)
-    content.write_string("    \{shape.field_name},\n")
+  for oneof in shape.oneofs {
+    content.write_string("    \{oneof.field_name},\n")
   }
   content.write_string(
     (

--- a/cli/model/pkg.generated.mbti
+++ b/cli/model/pkg.generated.mbti
@@ -127,6 +127,15 @@ pub(all) struct Message {
 } derive(Eq, @debug.Debug)
 pub fn Message::is_map(Self) -> Bool
 
+pub(all) struct MessageShape {
+  message_name : String
+  storage_fields : Array[FieldStorageShape]
+  codec_fields : Array[FieldCodecShape]
+  json_fields : Array[FieldJsonShape]
+  oneofs : Array[OneofShape]
+  has_runtime_json_impl : Bool
+} derive(Eq, @debug.Debug)
+
 pub(all) struct OneOf {
   desc : @protobuf.OneofDescriptorProto
   import_path : ImportPath

--- a/cli/model/types.mbt
+++ b/cli/model/types.mbt
@@ -165,6 +165,16 @@ pub(all) struct OneofShape {
 } derive(Eq, Debug)
 
 ///|
+pub(all) struct MessageShape {
+  message_name : String
+  storage_fields : Array[FieldStorageShape]
+  codec_fields : Array[FieldCodecShape]
+  json_fields : Array[FieldJsonShape]
+  oneofs : Array[OneofShape]
+  has_runtime_json_impl : Bool
+} derive(Eq, Debug)
+
+///|
 fn Field::from(
   desc : @protobuf.FieldDescriptorProto,
   parent : Message,

--- a/cli/model_imports.mbt
+++ b/cli/model_imports.mbt
@@ -13,6 +13,7 @@ using @model {
   type FieldStorageShape,
   type ImportPath,
   type Message,
+  type MessageShape,
   type OneOf,
   type OneofFieldShape,
   type OneofShape,

--- a/cli/reader_template.mbt
+++ b/cli/reader_template.mbt
@@ -1,19 +1,18 @@
 ///|
 fn CodeGenerator::gen_message_reader(
   self : CodeGenerator,
-  message : Message,
+  shape : MessageShape,
   content : StringBuilder,
   is_async? : Bool = false,
 ) -> Unit raise {
-  let message_name = message.import_path.path() |> to_camel_case
   let async_keyword = if is_async { "async" } else { "" }
   let async_keyword_to_snake = async_keyword |> pascal_to_snake
   let async_keyword_to_title = async_keyword |> title
-  if message.fields.is_empty() && message.oneofs.is_empty() {
+  if shape.is_empty() {
     content.write_string(
       (
-        $|pub impl @lib.\{async_keyword_to_title}Read for \{message_name} with fn read_with_limit(_) -> \{message_name} noraise {
-        $|  \{message_name}::default()
+        $|pub impl @lib.\{async_keyword_to_title}Read for \{shape.message_name} with fn read_with_limit(_) -> \{shape.message_name} noraise {
+        $|  \{shape.message_name}::default()
         $|}
         $|
       ),
@@ -22,8 +21,8 @@ fn CodeGenerator::gen_message_reader(
   }
   content.write_string(
     (
-      $|pub impl @lib.\{async_keyword_to_title}Read for \{message_name} with fn read_with_limit(reader : @lib.LimitedReader[&@lib.\{async_keyword_to_title}Reader]) -> \{message_name} raise {
-      $|  let msg = \{message_name}::default()
+      $|pub impl @lib.\{async_keyword_to_title}Read for \{shape.message_name} with fn read_with_limit(reader : @lib.LimitedReader[&@lib.\{async_keyword_to_title}Reader]) -> \{shape.message_name} raise {
+      $|  let msg = \{shape.message_name}::default()
       $|
     ),
   )
@@ -35,13 +34,11 @@ fn CodeGenerator::gen_message_reader(
       $|
     ),
   )
-  for field in message.fields {
-    let shape = self.field_codec_shape(field, message.import_path)
-    self.gen_field_codec_read(shape, content, is_async~)
+  for field in shape.codec_fields {
+    self.gen_field_codec_read(field, content, is_async~)
   }
-  for oneof in message.oneofs {
-    let shape = self.oneof_shape(message, oneof)
-    self.gen_oneof_codec_read(shape, content, is_async~)
+  for oneof in shape.oneofs {
+    self.gen_oneof_codec_read(oneof, content, is_async~)
   }
   content.write_string(
     (

--- a/cli/size_template.mbt
+++ b/cli/size_template.mbt
@@ -1,14 +1,13 @@
 ///|
 fn CodeGenerator::gen_message_size(
   self : CodeGenerator,
-  message : Message,
+  shape : MessageShape,
   content : StringBuilder,
 ) -> Unit raise {
-  let message_name = message.import_path.path() |> to_camel_case
-  if message.fields.is_empty() && message.oneofs.is_empty() {
+  if shape.is_empty() {
     content.write_string(
       (
-        $|pub impl @lib.Sized for \{message_name} with fn size_of(_) {
+        $|pub impl @lib.Sized for \{shape.message_name} with fn size_of(_) {
         $|  0
         $|}
         $|
@@ -18,18 +17,16 @@ fn CodeGenerator::gen_message_size(
   }
   content.write_string(
     (
-      $|pub impl @lib.Sized for \{message_name} with fn size_of(self) {
+      $|pub impl @lib.Sized for \{shape.message_name} with fn size_of(self) {
       $|  let mut size = 0U
       $|
     ),
   )
-  for field in message.fields {
-    let shape = self.field_codec_shape(field, message.import_path)
-    self.gen_field_codec_size(shape, content)
+  for field in shape.codec_fields {
+    self.gen_field_codec_size(field, content)
   }
-  for oneof in message.oneofs {
-    let shape = self.oneof_shape(message, oneof)
-    self.gen_oneof_codec_size(shape, content)
+  for oneof in shape.oneofs {
+    self.gen_oneof_codec_size(oneof, content)
   }
   content.write_string(
     (

--- a/cli/writer_template.mbt
+++ b/cli/writer_template.mbt
@@ -1,17 +1,16 @@
 ///|
 fn CodeGenerator::gen_message_writer(
   self : CodeGenerator,
-  message : Message,
+  shape : MessageShape,
   content : StringBuilder,
   is_async? : Bool = false,
 ) -> Unit raise {
-  let message_name = message.import_path.path() |> to_camel_case
   let async_keyword = if is_async { "async" } else { "" }
   let async_keyword_to_title = async_keyword |> title
-  if message.fields.is_empty() && message.oneofs.is_empty() {
+  if shape.is_empty() {
     content.write_string(
       (
-        $|pub impl @lib.\{async_keyword_to_title}Write for \{message_name} with fn write(_, _) -> Unit noraise {
+        $|pub impl @lib.\{async_keyword_to_title}Write for \{shape.message_name} with fn write(_, _) -> Unit noraise {
         $|}
         $|
       ),
@@ -19,15 +18,13 @@ fn CodeGenerator::gen_message_writer(
     return
   }
   content.write_string(
-    "pub impl @lib.\{async_keyword_to_title}Write for \{message_name} with fn write(self: \{message_name}, writer : &@lib.\{async_keyword_to_title}Writer) -> Unit raise {\n",
+    "pub impl @lib.\{async_keyword_to_title}Write for \{shape.message_name} with fn write(self: \{shape.message_name}, writer : &@lib.\{async_keyword_to_title}Writer) -> Unit raise {\n",
   )
-  for field in message.fields {
-    let shape = self.field_codec_shape(field, message.import_path)
-    self.gen_field_codec_write(shape, content, is_async~)
+  for field in shape.codec_fields {
+    self.gen_field_codec_write(field, content, is_async~)
   }
-  for oneof in message.oneofs {
-    let shape = self.oneof_shape(message, oneof)
-    self.gen_oneof_codec_write(shape, content, is_async~)
+  for oneof in shape.oneofs {
+    self.gen_oneof_codec_write(oneof, content, is_async~)
   }
   content.write_string("}\n")
 }


### PR DESCRIPTION
## Why
After the field and oneof shape slices, message templates still rebuilt the same per-message context in each emission path: generated message name, normal field storage/codec/JSON shapes, oneof shapes, empty-message checks, and Runtime-owned JSON implementation status. That kept the message-level template seam shallow even though the lower-level shapes were now centralized.

## What
- Add `MessageShape` to collect the generated message name, storage field shapes, codec field shapes, JSON field shapes, oneof shapes, and Runtime-owned JSON status.
- Add a `message_shape` resolver that builds the lower-level shapes once per message.
- Route struct/default/new, size, read/write, and JSON templates through `MessageShape` instead of recomputing field and oneof shapes in each template.
- Keep JSON field shape construction conditional on JSON support and non-runtime-owned JSON implementations.
- Document Message shape in the project context glossary.

## Why This Is Correct
The resolver preserves the same ordering and uses the same lower-level shape builders that each template previously called inline. Templates now consume precomputed arrays but still emit the same storage, constructor, codec, size, and JSON cases. Runtime-owned JSON messages continue to skip generated JSON implementations.

## Scope
This PR is limited to message-level shape aggregation. It does not change the lower-level field or oneof shape interfaces, protobuf semantics, or generated snapshot output.