### PR TITLE
Move message framing into runtime

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,5 +12,6 @@
 - **Field JSON shape**: The Field shape semantics slice that resolves generated JSON categories for normal fields, including JSON names, default comparison expressions, optional/list/map handling, and scalar JSON adapters.
 - **Oneof shape**: Generator-side decisions that turn protobuf oneof descriptors into generated enum names, message storage fields, enum variants, field numbers, value types, and oneof read/write/size/JSON cases.
 - **Message shape**: Generator-side decisions that collect a message's generated MoonBit name, normal Field shape slices, Oneof shapes, and Runtime-owned JSON implementation status for template emission.
+- **Message framing**: Runtime-owned handling of protobuf message frame mechanics, including length-delimited message writes, tag-loop reads, normal `EndOfStream` completion, and unknown-field skipping.
 - **Generated-code harness**: a test workflow that builds the Generator, generates MoonBit code from focused proto fixtures, and verifies the generated code through its public Runtime interfaces.
 - **Harness case**: a self-contained Generated-code harness input with proto fixtures, a runner test, and `case.toml` metadata.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,6 @@
 - **Field JSON shape**: The Field shape semantics slice that resolves generated JSON categories for normal fields, including JSON names, default comparison expressions, optional/list/map handling, and scalar JSON adapters.
 - **Oneof shape**: Generator-side decisions that turn protobuf oneof descriptors into generated enum names, message storage fields, enum variants, field numbers, value types, and oneof read/write/size/JSON cases.
 - **Message shape**: Generator-side decisions that collect a message's generated MoonBit name, normal Field shape slices, Oneof shapes, and Runtime-owned JSON implementation status for template emission.
-- **Message framing**: Runtime-owned handling of protobuf message frame mechanics, including length-delimited message writes, tag-loop reads, normal `EndOfStream` completion, and unknown-field skipping.
+- **Message framing**: Runtime-owned handling of protobuf message frame mechanics, including length-delimited message writes, message-field tag reads, normal `EndOfStream` completion, and unknown-field skipping.
 - **Generated-code harness**: a test workflow that builds the Generator, generates MoonBit code from focused proto fixtures, and verifies the generated code through its public Runtime interfaces.
 - **Harness case**: a self-contained Generated-code harness input with proto fixtures, a runner test, and `case.toml` metadata.

--- a/cli/field_codec_shape.mbt
+++ b/cli/field_codec_shape.mbt
@@ -276,19 +276,19 @@ fn CodeGenerator::gen_field_codec_read(
       FieldDescriptorProto_Type::TYPE_SINT32
       | FieldDescriptorProto_Type::TYPE_SINT64 =>
         content.write_string(
-          "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) }; true }\n",
+          "          (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) } }\n",
         )
       FieldDescriptorProto_Type::TYPE_ENUM =>
         content.write_string(
-          "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) }; true }\n",
+          "          (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) } }\n",
         )
       _ =>
         content.write_string(
-          "      (\{shape.field_number}, 2) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()); true }\n",
+          "          (\{shape.field_number}, 2) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()) }\n",
         )
     }
     content.write_string(
-      "      (\{shape.field_number}, \{shape.value.unpacked_wire_type()}) => { msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)}); true }\n",
+      "          (\{shape.field_number}, \{shape.value.unpacked_wire_type()}) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
     )
     return
   }
@@ -296,19 +296,19 @@ fn CodeGenerator::gen_field_codec_read(
     PackedField => raise @model.UnexpectedType("unpackable packed field")
     MapField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => { let {key, value} = \{shape.value.read_expr(is_async~)}; msg.\{shape.field_name}[key] = value; true }\n",
+        "          (\{shape.field_number}, _) => { let {key, value} = \{shape.value.read_expr(is_async~)}; msg.\{shape.field_name}[key] = value }\n",
       )
     RepeatedField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => { msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)}); true }\n",
+        "          (\{shape.field_number}, _) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
       )
     OptionalField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => { msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)} |> Some; true }\n",
+        "          (\{shape.field_number}, _) => msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)} |> Some\n",
       )
     SingularField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => { msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)}; true }\n",
+        "          (\{shape.field_number}, _) => msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)}\n",
       )
   }
 }

--- a/cli/field_codec_shape.mbt
+++ b/cli/field_codec_shape.mbt
@@ -90,14 +90,13 @@ fn FieldCodecValue::write_expr(
   is_async? : Bool = false,
 ) -> String raise {
   let async_keyword = if is_async { "async_" } else { "" }
-  let async_keyword_to_title = if is_async { "Async" } else { "" }
   match self.type_ {
     FieldDescriptorProto_Type::TYPE_STRING =>
       "writer |> @lib.\{async_keyword}write_string(\{variable})\n"
     FieldDescriptorProto_Type::TYPE_BYTES =>
       "writer |> @lib.\{async_keyword}write_bytes(\{variable})\n"
     FieldDescriptorProto_Type::TYPE_MESSAGE =>
-      "writer |> @lib.\{async_keyword}write_uint32(@lib.size_of(\{variable})); @lib.\{async_keyword_to_title}Write::write(\{variable}, writer)\n"
+      "writer |> @lib.\{async_keyword}write_message(\{variable})\n"
     FieldDescriptorProto_Type::TYPE_FIXED32 =>
       "writer |> @lib.\{async_keyword}write_fixed32(\{variable})\n"
     FieldDescriptorProto_Type::TYPE_SFIXED32 =>
@@ -277,19 +276,19 @@ fn CodeGenerator::gen_field_codec_read(
       FieldDescriptorProto_Type::TYPE_SINT32
       | FieldDescriptorProto_Type::TYPE_SINT64 =>
         content.write_string(
-          "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) } }\n",
+          "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) }; true }\n",
         )
       FieldDescriptorProto_Type::TYPE_ENUM =>
         content.write_string(
-          "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) } }\n",
+          "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) }; true }\n",
         )
       _ =>
         content.write_string(
-          "      (\{shape.field_number}, 2) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()) }\n",
+          "      (\{shape.field_number}, 2) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()); true }\n",
         )
     }
     content.write_string(
-      "      (\{shape.field_number}, \{shape.value.unpacked_wire_type()}) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
+      "      (\{shape.field_number}, \{shape.value.unpacked_wire_type()}) => { msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)}); true }\n",
     )
     return
   }
@@ -297,19 +296,19 @@ fn CodeGenerator::gen_field_codec_read(
     PackedField => raise @model.UnexpectedType("unpackable packed field")
     MapField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => { let {key, value} = \{shape.value.read_expr(is_async~)}; msg.\{shape.field_name}[key] = value }\n",
+        "      (\{shape.field_number}, _) => { let {key, value} = \{shape.value.read_expr(is_async~)}; msg.\{shape.field_name}[key] = value; true }\n",
       )
     RepeatedField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
+        "      (\{shape.field_number}, _) => { msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)}); true }\n",
       )
     OptionalField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)} |> Some\n",
+        "      (\{shape.field_number}, _) => { msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)} |> Some; true }\n",
       )
     SingularField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)}\n",
+        "      (\{shape.field_number}, _) => { msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)}; true }\n",
       )
   }
 }

--- a/cli/field_codec_shape.mbt
+++ b/cli/field_codec_shape.mbt
@@ -276,19 +276,19 @@ fn CodeGenerator::gen_field_codec_read(
       FieldDescriptorProto_Type::TYPE_SINT32
       | FieldDescriptorProto_Type::TYPE_SINT64 =>
         content.write_string(
-          "          (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) } }\n",
+          "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) } }\n",
         )
       FieldDescriptorProto_Type::TYPE_ENUM =>
         content.write_string(
-          "          (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) } }\n",
+          "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) } }\n",
         )
       _ =>
         content.write_string(
-          "          (\{shape.field_number}, 2) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()) }\n",
+          "      (\{shape.field_number}, 2) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()) }\n",
         )
     }
     content.write_string(
-      "          (\{shape.field_number}, \{shape.value.unpacked_wire_type()}) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
+      "      (\{shape.field_number}, \{shape.value.unpacked_wire_type()}) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
     )
     return
   }
@@ -296,19 +296,19 @@ fn CodeGenerator::gen_field_codec_read(
     PackedField => raise @model.UnexpectedType("unpackable packed field")
     MapField =>
       content.write_string(
-        "          (\{shape.field_number}, _) => { let {key, value} = \{shape.value.read_expr(is_async~)}; msg.\{shape.field_name}[key] = value }\n",
+        "      (\{shape.field_number}, _) => { let {key, value} = \{shape.value.read_expr(is_async~)}; msg.\{shape.field_name}[key] = value }\n",
       )
     RepeatedField =>
       content.write_string(
-        "          (\{shape.field_number}, _) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
+        "      (\{shape.field_number}, _) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
       )
     OptionalField =>
       content.write_string(
-        "          (\{shape.field_number}, _) => msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)} |> Some\n",
+        "      (\{shape.field_number}, _) => msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)} |> Some\n",
       )
     SingularField =>
       content.write_string(
-        "          (\{shape.field_number}, _) => msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)}\n",
+        "      (\{shape.field_number}, _) => msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)}\n",
       )
   }
 }

--- a/cli/oneof_shape.mbt
+++ b/cli/oneof_shape.mbt
@@ -37,7 +37,7 @@ fn CodeGenerator::gen_oneof_codec_read(
 ) -> Unit raise {
   for field in shape.fields {
     content.write_string(
-      "      (\{field.field_number}, _) => { msg.\{shape.field_name} = \{field.value.read_expr(is_async~)} |> \{shape.enum_name}::\{field.constructor_name}; true }\n",
+      "          (\{field.field_number}, _) => msg.\{shape.field_name} = \{field.value.read_expr(is_async~)} |> \{shape.enum_name}::\{field.constructor_name}\n",
     )
   }
 }

--- a/cli/oneof_shape.mbt
+++ b/cli/oneof_shape.mbt
@@ -37,7 +37,7 @@ fn CodeGenerator::gen_oneof_codec_read(
 ) -> Unit raise {
   for field in shape.fields {
     content.write_string(
-      "        (\{field.field_number}, _) => msg.\{shape.field_name} = \{field.value.read_expr(is_async~)} |> \{shape.enum_name}::\{field.constructor_name}\n",
+      "      (\{field.field_number}, _) => { msg.\{shape.field_name} = \{field.value.read_expr(is_async~)} |> \{shape.enum_name}::\{field.constructor_name}; true }\n",
     )
   }
 }

--- a/cli/oneof_shape.mbt
+++ b/cli/oneof_shape.mbt
@@ -37,7 +37,7 @@ fn CodeGenerator::gen_oneof_codec_read(
 ) -> Unit raise {
   for field in shape.fields {
     content.write_string(
-      "          (\{field.field_number}, _) => msg.\{shape.field_name} = \{field.value.read_expr(is_async~)} |> \{shape.enum_name}::\{field.constructor_name}\n",
+      "      (\{field.field_number}, _) => msg.\{shape.field_name} = \{field.value.read_expr(is_async~)} |> \{shape.enum_name}::\{field.constructor_name}\n",
     )
   }
 }

--- a/cli/reader_template.mbt
+++ b/cli/reader_template.mbt
@@ -8,8 +8,6 @@ fn CodeGenerator::gen_message_reader(
   let async_keyword = if is_async { "async" } else { "" }
   let async_keyword_to_snake = async_keyword |> pascal_to_snake
   let async_keyword_to_title = async_keyword |> title
-  let field_handler = if is_async { "async fn" } else { "fn" }
-  let field_handler_effect = if is_async { "" } else { " raise" }
   if shape.is_empty() {
     content.write_string(
       (
@@ -30,8 +28,10 @@ fn CodeGenerator::gen_message_reader(
   )
   content.write_string(
     (
-      $|  reader |> @lib.\{async_keyword_to_snake}read_message_fields(\{field_handler}(field_number, wire)\{field_handler_effect} {
-      $|    match (field_number, wire) {
+      $|  for ;; {
+      $|    match (reader |> @lib.\{async_keyword_to_snake}read_next_message_field()) {
+      $|      Some((field_number, wire)) =>
+      $|        match (field_number, wire) {
       $|
     ),
   )
@@ -43,9 +43,11 @@ fn CodeGenerator::gen_message_reader(
   }
   content.write_string(
     (
-      $|      _ => false
+      $|          _ => reader |> @lib.\{async_keyword_to_snake}skip_message_field(wire)
+      $|        }
+      $|      None => break
       $|    }
-      $|  })
+      $|  }
       $|  msg
       $|}
       $|

--- a/cli/reader_template.mbt
+++ b/cli/reader_template.mbt
@@ -28,10 +28,8 @@ fn CodeGenerator::gen_message_reader(
   )
   content.write_string(
     (
-      $|  for ;; {
-      $|    match (reader |> @lib.\{async_keyword_to_snake}read_next_message_field()) {
-      $|      Some((field_number, wire)) =>
-      $|        match (field_number, wire) {
+      $|  while (reader |> @lib.\{async_keyword_to_snake}read_next_message_field()) is Some((field_number, wire)) {
+      $|    match (field_number, wire) {
       $|
     ),
   )
@@ -43,9 +41,7 @@ fn CodeGenerator::gen_message_reader(
   }
   content.write_string(
     (
-      $|          _ => reader |> @lib.\{async_keyword_to_snake}skip_message_field(wire)
-      $|        }
-      $|      None => break
+      $|      _ => reader |> @lib.\{async_keyword_to_snake}skip_message_field(wire)
       $|    }
       $|  }
       $|  msg

--- a/cli/reader_template.mbt
+++ b/cli/reader_template.mbt
@@ -8,6 +8,8 @@ fn CodeGenerator::gen_message_reader(
   let async_keyword = if is_async { "async" } else { "" }
   let async_keyword_to_snake = async_keyword |> pascal_to_snake
   let async_keyword_to_title = async_keyword |> title
+  let field_handler = if is_async { "async fn" } else { "fn" }
+  let field_handler_effect = if is_async { "" } else { " raise" }
   if shape.is_empty() {
     content.write_string(
       (
@@ -28,9 +30,8 @@ fn CodeGenerator::gen_message_reader(
   )
   content.write_string(
     (
-      $|  try {
-      $|    for ;; {
-      $|      match (reader |> @lib.\{async_keyword_to_snake}read_tag()) {
+      $|  reader |> @lib.\{async_keyword_to_snake}read_message_fields(\{field_handler}(field_number, wire)\{field_handler_effect} {
+      $|    match (field_number, wire) {
       $|
     ),
   )
@@ -42,13 +43,9 @@ fn CodeGenerator::gen_message_reader(
   }
   content.write_string(
     (
-      $|       (_, wire) => reader |> @lib.\{async_keyword |> pascal_to_snake}read_unknown(wire)
-      $|      }
+      $|      _ => false
       $|    }
-      $|  } catch {
-      $|    @lib.EndOfStream => ()
-      $|    err => raise err
-      $|  }
+      $|  })
       $|  msg
       $|}
       $|

--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -214,6 +214,24 @@ pub async fn[M : AsyncRead + Default] async_read_message(
 }
 
 ///|
+pub async fn[R : AsyncReader] async_read_message_fields(
+  reader : LimitedReader[R],
+  handle_field : async (UInt, UInt) -> Bool,
+) -> Unit {
+  try {
+    for ;; {
+      let (field_number, wire_type) = reader |> async_read_tag()
+      if !handle_field(field_number, wire_type) {
+        reader |> async_read_unknown(wire_type)
+      }
+    }
+  } catch {
+    EndOfStream => ()
+    err => raise err
+  }
+}
+
+///|
 /// Reads packed repeated field (Array[M])
 ///
 /// Note: packed field are stored as a variable length chunk of data, while regular repeated

--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -214,19 +214,11 @@ pub async fn[M : AsyncRead + Default] async_read_message(
 }
 
 ///|
-pub async fn[R : AsyncReader] async_read_message_fields(
+pub async fn[R : AsyncReader] async_read_next_message_field(
   reader : LimitedReader[R],
-  handle_field : async (UInt, UInt) -> Bool,
-) -> Unit {
-  try {
-    for ;; {
-      let (field_number, wire_type) = reader |> async_read_tag()
-      if !handle_field(field_number, wire_type) {
-        reader |> async_read_unknown(wire_type)
-      }
-    }
-  } catch {
-    EndOfStream => ()
+) -> (UInt, UInt)? {
+  Some(reader |> async_read_tag()) catch {
+    EndOfStream => None
     err => raise err
   }
 }
@@ -276,4 +268,12 @@ pub async fn[T : AsyncReader] async_read_unknown(
     5 => reader |> async_read_fixed32() |> ignore
     _ => raise ReaderError::UnknownWireType(wire_type)
   }
+}
+
+///|
+pub async fn[T : AsyncReader] async_skip_message_field(
+  reader : T,
+  wire_type : UInt,
+) -> Unit {
+  reader |> async_read_unknown(wire_type)
 }

--- a/lib/async_writer.mbt
+++ b/lib/async_writer.mbt
@@ -135,3 +135,12 @@ pub async fn[T : AsyncWriter] async_write_string(
   |> async_write_varint(utf8_string.length().reinterpret_as_uint().to_uint64())
   writer.write(utf8_string)
 }
+
+///|
+pub async fn[M : AsyncWrite + Sized, T : AsyncWriter] async_write_message(
+  writer : T,
+  message : M,
+) -> Unit {
+  writer |> async_write_uint32(size_of(message))
+  AsyncWrite::write(message, writer)
+}

--- a/lib/google/protobuf/any.mbt
+++ b/lib/google/protobuf/any.mbt
@@ -39,17 +39,16 @@ pub impl @lib.Read for Any with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Any raise {
   let msg = Any::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.type_url = reader |> @lib.read_string()
-        (2, _) => msg.value = reader |> @lib.read_bytes()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.type_url = reader |> @lib.read_string()
+          (2, _) => msg.value = reader |> @lib.read_bytes()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -105,17 +104,16 @@ pub impl @lib.AsyncRead for Any with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Any raise {
   let msg = Any::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.type_url = reader |> @lib.async_read_string()
-        (2, _) => msg.value = reader |> @lib.async_read_bytes()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.type_url = reader |> @lib.async_read_string()
+          (2, _) => msg.value = reader |> @lib.async_read_bytes()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }

--- a/lib/google/protobuf/any.mbt
+++ b/lib/google/protobuf/any.mbt
@@ -39,15 +39,11 @@ pub impl @lib.Read for Any with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Any raise {
   let msg = Any::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.type_url = reader |> @lib.read_string()
-          (2, _) => msg.value = reader |> @lib.read_bytes()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.type_url = reader |> @lib.read_string()
+      (2, _) => msg.value = reader |> @lib.read_bytes()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -104,15 +100,12 @@ pub impl @lib.AsyncRead for Any with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Any raise {
   let msg = Any::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.type_url = reader |> @lib.async_read_string()
-          (2, _) => msg.value = reader |> @lib.async_read_bytes()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.type_url = reader |> @lib.async_read_string()
+      (2, _) => msg.value = reader |> @lib.async_read_bytes()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/lib/google/protobuf/api.mbt
+++ b/lib/google/protobuf/api.mbt
@@ -110,23 +110,19 @@ pub impl @lib.Read for Api with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Api raise {
   let msg = Api::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.methods.push((reader |> @lib.read_message() : Method))
-          (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
-          (4, _) => msg.version = reader |> @lib.read_string()
-          (5, _) =>
-            msg.source_context = (reader |> @lib.read_message() : SourceContext)
-              |> Some
-          (6, _) => msg.mixins.push((reader |> @lib.read_message() : Mixin))
-          (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
-          (8, _) => msg.edition = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.methods.push((reader |> @lib.read_message() : Method))
+      (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
+      (4, _) => msg.version = reader |> @lib.read_string()
+      (5, _) =>
+        msg.source_context = (reader |> @lib.read_message() : SourceContext)
+          |> Some
+      (6, _) => msg.mixins.push((reader |> @lib.read_message() : Mixin))
+      (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
+      (8, _) => msg.edition = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -233,28 +229,22 @@ pub impl @lib.AsyncRead for Api with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Api raise {
   let msg = Api::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) =>
-            msg.methods.push((reader |> @lib.async_read_message() : Method))
-          (3, _) =>
-            msg.options.push((reader |> @lib.async_read_message() : Option))
-          (4, _) => msg.version = reader |> @lib.async_read_string()
-          (5, _) =>
-            msg.source_context = (
-                reader |> @lib.async_read_message() : SourceContext)
-              |> Some
-          (6, _) =>
-            msg.mixins.push((reader |> @lib.async_read_message() : Mixin))
-          (7, _) =>
-            msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
-          (8, _) => msg.edition = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.methods.push((reader |> @lib.async_read_message() : Method))
+      (3, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (4, _) => msg.version = reader |> @lib.async_read_string()
+      (5, _) =>
+        msg.source_context = (
+            reader |> @lib.async_read_message() : SourceContext)
+          |> Some
+      (6, _) => msg.mixins.push((reader |> @lib.async_read_message() : Mixin))
+      (7, _) =>
+        msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
+      (8, _) => msg.edition = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -403,21 +393,17 @@ pub impl @lib.Read for Method with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Method raise {
   let msg = Method::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.request_type_url = reader |> @lib.read_string()
-          (3, _) => msg.request_streaming = reader |> @lib.read_bool()
-          (4, _) => msg.response_type_url = reader |> @lib.read_string()
-          (5, _) => msg.response_streaming = reader |> @lib.read_bool()
-          (6, _) => msg.options.push((reader |> @lib.read_message() : Option))
-          (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
-          (8, _) => msg.edition = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.request_type_url = reader |> @lib.read_string()
+      (3, _) => msg.request_streaming = reader |> @lib.read_bool()
+      (4, _) => msg.response_type_url = reader |> @lib.read_string()
+      (5, _) => msg.response_streaming = reader |> @lib.read_bool()
+      (6, _) => msg.options.push((reader |> @lib.read_message() : Option))
+      (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
+      (8, _) => msg.edition = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -527,23 +513,19 @@ pub impl @lib.AsyncRead for Method with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Method raise {
   let msg = Method::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) => msg.request_type_url = reader |> @lib.async_read_string()
-          (3, _) => msg.request_streaming = reader |> @lib.async_read_bool()
-          (4, _) => msg.response_type_url = reader |> @lib.async_read_string()
-          (5, _) => msg.response_streaming = reader |> @lib.async_read_bool()
-          (6, _) =>
-            msg.options.push((reader |> @lib.async_read_message() : Option))
-          (7, _) =>
-            msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
-          (8, _) => msg.edition = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.request_type_url = reader |> @lib.async_read_string()
+      (3, _) => msg.request_streaming = reader |> @lib.async_read_bool()
+      (4, _) => msg.response_type_url = reader |> @lib.async_read_string()
+      (5, _) => msg.response_streaming = reader |> @lib.async_read_bool()
+      (6, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (7, _) =>
+        msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
+      (8, _) => msg.edition = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -629,15 +611,11 @@ pub impl @lib.Read for Mixin with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Mixin raise {
   let msg = Mixin::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.root = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.root = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -691,15 +669,12 @@ pub impl @lib.AsyncRead for Mixin with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Mixin raise {
   let msg = Mixin::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) => msg.root = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.root = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/lib/google/protobuf/api.mbt
+++ b/lib/google/protobuf/api.mbt
@@ -110,25 +110,24 @@ pub impl @lib.Read for Api with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Api raise {
   let msg = Api::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string()
-        (2, _) => msg.methods.push((reader |> @lib.read_message() : Method))
-        (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
-        (4, _) => msg.version = reader |> @lib.read_string()
-        (5, _) =>
-          msg.source_context = (reader |> @lib.read_message() : SourceContext)
-            |> Some
-        (6, _) => msg.mixins.push((reader |> @lib.read_message() : Mixin))
-        (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
-        (8, _) => msg.edition = reader |> @lib.read_string()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.methods.push((reader |> @lib.read_message() : Method))
+          (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
+          (4, _) => msg.version = reader |> @lib.read_string()
+          (5, _) =>
+            msg.source_context = (reader |> @lib.read_message() : SourceContext)
+              |> Some
+          (6, _) => msg.mixins.push((reader |> @lib.read_message() : Mixin))
+          (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
+          (8, _) => msg.edition = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -141,13 +140,11 @@ pub impl @lib.Write for Api with fn write(self : Api, writer : &@lib.Writer) -> 
   }
   for item in self.methods {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.options {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.version != Default::default() {
     writer |> @lib.write_varint(34UL)
@@ -155,13 +152,11 @@ pub impl @lib.Write for Api with fn write(self : Api, writer : &@lib.Writer) -> 
   }
   if self.source_context is Some(v) {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   for item in self.mixins {
     writer |> @lib.write_varint(50UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.syntax != Default::default() {
     writer |> @lib.write_varint(56UL)
@@ -238,29 +233,29 @@ pub impl @lib.AsyncRead for Api with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Api raise {
   let msg = Api::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string()
-        (2, _) =>
-          msg.methods.push((reader |> @lib.async_read_message() : Method))
-        (3, _) =>
-          msg.options.push((reader |> @lib.async_read_message() : Option))
-        (4, _) => msg.version = reader |> @lib.async_read_string()
-        (5, _) =>
-          msg.source_context = (
-              reader |> @lib.async_read_message() : SourceContext)
-            |> Some
-        (6, _) => msg.mixins.push((reader |> @lib.async_read_message() : Mixin))
-        (7, _) =>
-          msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
-        (8, _) => msg.edition = reader |> @lib.async_read_string()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) =>
+            msg.methods.push((reader |> @lib.async_read_message() : Method))
+          (3, _) =>
+            msg.options.push((reader |> @lib.async_read_message() : Option))
+          (4, _) => msg.version = reader |> @lib.async_read_string()
+          (5, _) =>
+            msg.source_context = (
+                reader |> @lib.async_read_message() : SourceContext)
+              |> Some
+          (6, _) =>
+            msg.mixins.push((reader |> @lib.async_read_message() : Mixin))
+          (7, _) =>
+            msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
+          (8, _) => msg.edition = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -276,13 +271,11 @@ pub impl @lib.AsyncWrite for Api with fn write(
   }
   for item in self.methods {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.options {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.version != Default::default() {
     writer |> @lib.async_write_varint(34UL)
@@ -290,13 +283,11 @@ pub impl @lib.AsyncWrite for Api with fn write(
   }
   if self.source_context is Some(v) {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   for item in self.mixins {
     writer |> @lib.async_write_varint(50UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.syntax != Default::default() {
     writer |> @lib.async_write_varint(56UL)
@@ -412,23 +403,22 @@ pub impl @lib.Read for Method with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Method raise {
   let msg = Method::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string()
-        (2, _) => msg.request_type_url = reader |> @lib.read_string()
-        (3, _) => msg.request_streaming = reader |> @lib.read_bool()
-        (4, _) => msg.response_type_url = reader |> @lib.read_string()
-        (5, _) => msg.response_streaming = reader |> @lib.read_bool()
-        (6, _) => msg.options.push((reader |> @lib.read_message() : Option))
-        (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
-        (8, _) => msg.edition = reader |> @lib.read_string()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.request_type_url = reader |> @lib.read_string()
+          (3, _) => msg.request_streaming = reader |> @lib.read_bool()
+          (4, _) => msg.response_type_url = reader |> @lib.read_string()
+          (5, _) => msg.response_streaming = reader |> @lib.read_bool()
+          (6, _) => msg.options.push((reader |> @lib.read_message() : Option))
+          (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
+          (8, _) => msg.edition = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -460,8 +450,7 @@ pub impl @lib.Write for Method with fn write(
   }
   for item in self.options {
     writer |> @lib.write_varint(50UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.syntax != Default::default() {
     writer |> @lib.write_varint(56UL)
@@ -538,25 +527,24 @@ pub impl @lib.AsyncRead for Method with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Method raise {
   let msg = Method::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string()
-        (2, _) => msg.request_type_url = reader |> @lib.async_read_string()
-        (3, _) => msg.request_streaming = reader |> @lib.async_read_bool()
-        (4, _) => msg.response_type_url = reader |> @lib.async_read_string()
-        (5, _) => msg.response_streaming = reader |> @lib.async_read_bool()
-        (6, _) =>
-          msg.options.push((reader |> @lib.async_read_message() : Option))
-        (7, _) =>
-          msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
-        (8, _) => msg.edition = reader |> @lib.async_read_string()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) => msg.request_type_url = reader |> @lib.async_read_string()
+          (3, _) => msg.request_streaming = reader |> @lib.async_read_bool()
+          (4, _) => msg.response_type_url = reader |> @lib.async_read_string()
+          (5, _) => msg.response_streaming = reader |> @lib.async_read_bool()
+          (6, _) =>
+            msg.options.push((reader |> @lib.async_read_message() : Option))
+          (7, _) =>
+            msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
+          (8, _) => msg.edition = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -588,8 +576,7 @@ pub impl @lib.AsyncWrite for Method with fn write(
   }
   for item in self.options {
     writer |> @lib.async_write_varint(50UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.syntax != Default::default() {
     writer |> @lib.async_write_varint(56UL)
@@ -642,17 +629,16 @@ pub impl @lib.Read for Mixin with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Mixin raise {
   let msg = Mixin::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string()
-        (2, _) => msg.root = reader |> @lib.read_string()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.root = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -705,17 +691,16 @@ pub impl @lib.AsyncRead for Mixin with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Mixin raise {
   let msg = Mixin::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string()
-        (2, _) => msg.root = reader |> @lib.async_read_string()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) => msg.root = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }

--- a/lib/google/protobuf/compiler/top.mbt
+++ b/lib/google/protobuf/compiler/top.mbt
@@ -48,17 +48,13 @@ pub impl @lib.Read for Version with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Version raise {
   let msg = Version::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.major = reader |> @lib.read_int32() |> Some
-          (2, _) => msg.minor = reader |> @lib.read_int32() |> Some
-          (3, _) => msg.patch = reader |> @lib.read_int32() |> Some
-          (4, _) => msg.suffix = reader |> @lib.read_string() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.major = reader |> @lib.read_int32() |> Some
+      (2, _) => msg.minor = reader |> @lib.read_int32() |> Some
+      (3, _) => msg.patch = reader |> @lib.read_int32() |> Some
+      (4, _) => msg.suffix = reader |> @lib.read_string() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -135,17 +131,14 @@ pub impl @lib.AsyncRead for Version with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Version raise {
   let msg = Version::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.major = reader |> @lib.async_read_int32() |> Some
-          (2, _) => msg.minor = reader |> @lib.async_read_int32() |> Some
-          (3, _) => msg.patch = reader |> @lib.async_read_int32() |> Some
-          (4, _) => msg.suffix = reader |> @lib.async_read_string() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.major = reader |> @lib.async_read_int32() |> Some
+      (2, _) => msg.minor = reader |> @lib.async_read_int32() |> Some
+      (3, _) => msg.patch = reader |> @lib.async_read_int32() |> Some
+      (4, _) => msg.suffix = reader |> @lib.async_read_string() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -257,26 +250,21 @@ pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
-          (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
-          (15, _) =>
-            msg.proto_file.push(
-              (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
-            )
-          (17, _) =>
-            msg.source_file_descriptors.push(
-              (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
-            )
-          (3, _) =>
-            msg.compiler_version = (reader |> @lib.read_message() : Version)
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
+      (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
+      (15, _) =>
+        msg.proto_file.push(
+          (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
+        )
+      (17, _) =>
+        msg.source_file_descriptors.push(
+          (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
+        )
+      (3, _) =>
+        msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -368,32 +356,23 @@ pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.file_to_generate.push(reader |> @lib.async_read_string())
-          (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
-          (15, _) =>
-            msg.proto_file.push(
-              (
-                reader |> @lib.async_read_message() :
-                @protobuf.FileDescriptorProto),
-            )
-          (17, _) =>
-            msg.source_file_descriptors.push(
-              (
-                reader |> @lib.async_read_message() :
-                @protobuf.FileDescriptorProto),
-            )
-          (3, _) =>
-            msg.compiler_version = (
-                reader |> @lib.async_read_message() : Version)
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.file_to_generate.push(reader |> @lib.async_read_string())
+      (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
+      (15, _) =>
+        msg.proto_file.push(
+          (reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto),
+        )
+      (17, _) =>
+        msg.source_file_descriptors.push(
+          (reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto),
+        )
+      (3, _) =>
+        msg.compiler_version = (reader |> @lib.async_read_message() : Version)
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -574,20 +553,16 @@ pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
-          (15, _) => msg.content = reader |> @lib.read_string() |> Some
-          (16, _) =>
-            msg.generated_code_info = (
-                reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo)
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
+      (15, _) => msg.content = reader |> @lib.read_string() |> Some
+      (16, _) =>
+        msg.generated_code_info = (
+            reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo)
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -669,22 +644,17 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) =>
-            msg.insertion_point = reader |> @lib.async_read_string() |> Some
-          (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
-          (16, _) =>
-            msg.generated_code_info = (
-                reader |> @lib.async_read_message() :
-                @protobuf.GeneratedCodeInfo)
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.insertion_point = reader |> @lib.async_read_string() |> Some
+      (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
+      (16, _) =>
+        msg.generated_code_info = (
+            reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo)
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -784,22 +754,17 @@ pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.error = reader |> @lib.read_string() |> Some
-          (2, _) =>
-            msg.supported_features = reader |> @lib.read_uint64() |> Some
-          (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
-          (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
-          (15, _) =>
-            msg.file.push(
-              (reader |> @lib.read_message() : CodeGeneratorResponse_File),
-            )
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.error = reader |> @lib.read_string() |> Some
+      (2, _) => msg.supported_features = reader |> @lib.read_uint64() |> Some
+      (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
+      (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
+      (15, _) =>
+        msg.file.push(
+          (reader |> @lib.read_message() : CodeGeneratorResponse_File),
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -890,24 +855,19 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.error = reader |> @lib.async_read_string() |> Some
-          (2, _) =>
-            msg.supported_features = reader |> @lib.async_read_uint64() |> Some
-          (3, _) =>
-            msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
-          (4, _) =>
-            msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
-          (15, _) =>
-            msg.file.push(
-              (reader |> @lib.async_read_message() : CodeGeneratorResponse_File),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.error = reader |> @lib.async_read_string() |> Some
+      (2, _) =>
+        msg.supported_features = reader |> @lib.async_read_uint64() |> Some
+      (3, _) => msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
+      (4, _) => msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
+      (15, _) =>
+        msg.file.push(
+          (reader |> @lib.async_read_message() : CodeGeneratorResponse_File),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/lib/google/protobuf/compiler/top.mbt
+++ b/lib/google/protobuf/compiler/top.mbt
@@ -48,19 +48,18 @@ pub impl @lib.Read for Version with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Version raise {
   let msg = Version::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.major = reader |> @lib.read_int32() |> Some
-        (2, _) => msg.minor = reader |> @lib.read_int32() |> Some
-        (3, _) => msg.patch = reader |> @lib.read_int32() |> Some
-        (4, _) => msg.suffix = reader |> @lib.read_string() |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.major = reader |> @lib.read_int32() |> Some
+          (2, _) => msg.minor = reader |> @lib.read_int32() |> Some
+          (3, _) => msg.patch = reader |> @lib.read_int32() |> Some
+          (4, _) => msg.suffix = reader |> @lib.read_string() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -136,19 +135,18 @@ pub impl @lib.AsyncRead for Version with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Version raise {
   let msg = Version::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.major = reader |> @lib.async_read_int32() |> Some
-        (2, _) => msg.minor = reader |> @lib.async_read_int32() |> Some
-        (3, _) => msg.patch = reader |> @lib.async_read_int32() |> Some
-        (4, _) => msg.suffix = reader |> @lib.async_read_string() |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.major = reader |> @lib.async_read_int32() |> Some
+          (2, _) => msg.minor = reader |> @lib.async_read_int32() |> Some
+          (3, _) => msg.patch = reader |> @lib.async_read_int32() |> Some
+          (4, _) => msg.suffix = reader |> @lib.async_read_string() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -259,28 +257,27 @@ pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
-        (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
-        (15, _) =>
-          msg.proto_file.push(
-            (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
-          )
-        (17, _) =>
-          msg.source_file_descriptors.push(
-            (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
-          )
-        (3, _) =>
-          msg.compiler_version = (reader |> @lib.read_message() : Version)
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
+          (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
+          (15, _) =>
+            msg.proto_file.push(
+              (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
+            )
+          (17, _) =>
+            msg.source_file_descriptors.push(
+              (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
+            )
+          (3, _) =>
+            msg.compiler_version = (reader |> @lib.read_message() : Version)
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -300,18 +297,15 @@ pub impl @lib.Write for CodeGeneratorRequest with fn write(
   }
   for item in self.proto_file {
     writer |> @lib.write_varint(122UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.source_file_descriptors {
     writer |> @lib.write_varint(138UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.compiler_version is Some(v) {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -374,28 +368,33 @@ pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.file_to_generate.push(reader |> @lib.async_read_string())
-        (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
-        (15, _) =>
-          msg.proto_file.push(
-            (reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto),
-          )
-        (17, _) =>
-          msg.source_file_descriptors.push(
-            (reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto),
-          )
-        (3, _) =>
-          msg.compiler_version = (reader |> @lib.async_read_message() : Version)
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.file_to_generate.push(reader |> @lib.async_read_string())
+          (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
+          (15, _) =>
+            msg.proto_file.push(
+              (
+                reader |> @lib.async_read_message() :
+                @protobuf.FileDescriptorProto),
+            )
+          (17, _) =>
+            msg.source_file_descriptors.push(
+              (
+                reader |> @lib.async_read_message() :
+                @protobuf.FileDescriptorProto),
+            )
+          (3, _) =>
+            msg.compiler_version = (
+                reader |> @lib.async_read_message() : Version)
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -415,18 +414,15 @@ pub impl @lib.AsyncWrite for CodeGeneratorRequest with fn write(
   }
   for item in self.proto_file {
     writer |> @lib.async_write_varint(122UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.source_file_descriptors {
     writer |> @lib.async_write_varint(138UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.compiler_version is Some(v) {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }
 
@@ -578,22 +574,21 @@ pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string() |> Some
-        (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
-        (15, _) => msg.content = reader |> @lib.read_string() |> Some
-        (16, _) =>
-          msg.generated_code_info = (
-              reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo)
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
+          (15, _) => msg.content = reader |> @lib.read_string() |> Some
+          (16, _) =>
+            msg.generated_code_info = (
+                reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo)
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -617,8 +612,7 @@ pub impl @lib.Write for CodeGeneratorResponse_File with fn write(
   }
   if self.generated_code_info is Some(v) {
     writer |> @lib.write_varint(130UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -675,23 +669,23 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-        (2, _) =>
-          msg.insertion_point = reader |> @lib.async_read_string() |> Some
-        (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
-        (16, _) =>
-          msg.generated_code_info = (
-              reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo)
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) =>
+            msg.insertion_point = reader |> @lib.async_read_string() |> Some
+          (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
+          (16, _) =>
+            msg.generated_code_info = (
+                reader |> @lib.async_read_message() :
+                @protobuf.GeneratedCodeInfo)
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -715,8 +709,7 @@ pub impl @lib.AsyncWrite for CodeGeneratorResponse_File with fn write(
   }
   if self.generated_code_info is Some(v) {
     writer |> @lib.async_write_varint(130UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }
 
@@ -791,23 +784,23 @@ pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.error = reader |> @lib.read_string() |> Some
-        (2, _) => msg.supported_features = reader |> @lib.read_uint64() |> Some
-        (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
-        (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
-        (15, _) =>
-          msg.file.push(
-            (reader |> @lib.read_message() : CodeGeneratorResponse_File),
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.error = reader |> @lib.read_string() |> Some
+          (2, _) =>
+            msg.supported_features = reader |> @lib.read_uint64() |> Some
+          (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
+          (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
+          (15, _) =>
+            msg.file.push(
+              (reader |> @lib.read_message() : CodeGeneratorResponse_File),
+            )
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -835,8 +828,7 @@ pub impl @lib.Write for CodeGeneratorResponse with fn write(
   }
   for item in self.file {
     writer |> @lib.write_varint(122UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -898,26 +890,25 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.error = reader |> @lib.async_read_string() |> Some
-        (2, _) =>
-          msg.supported_features = reader |> @lib.async_read_uint64() |> Some
-        (3, _) =>
-          msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
-        (4, _) =>
-          msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
-        (15, _) =>
-          msg.file.push(
-            (reader |> @lib.async_read_message() : CodeGeneratorResponse_File),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.error = reader |> @lib.async_read_string() |> Some
+          (2, _) =>
+            msg.supported_features = reader |> @lib.async_read_uint64() |> Some
+          (3, _) =>
+            msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
+          (4, _) =>
+            msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
+          (15, _) =>
+            msg.file.push(
+              (reader |> @lib.async_read_message() : CodeGeneratorResponse_File),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -945,7 +936,6 @@ pub impl @lib.AsyncWrite for CodeGeneratorResponse with fn write(
   }
   for item in self.file {
     writer |> @lib.async_write_varint(122UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }

--- a/lib/google/protobuf/descriptor.mbt
+++ b/lib/google/protobuf/descriptor.mbt
@@ -217,17 +217,16 @@ pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -239,8 +238,7 @@ pub impl @lib.Write for FileDescriptorSet with fn write(
 ) -> Unit raise {
   for item in self.file {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -279,19 +277,18 @@ pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.file.push(
-            (reader |> @lib.async_read_message() : FileDescriptorProto),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.file.push(
+              (reader |> @lib.async_read_message() : FileDescriptorProto),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -303,8 +300,7 @@ pub impl @lib.AsyncWrite for FileDescriptorSet with fn write(
 ) -> Unit raise {
   for item in self.file {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -478,53 +474,56 @@ pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string() |> Some
-        (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
-        (3, _) => msg.dependency.push(reader |> @lib.read_string())
-        (10, 2) =>
-          msg.public_dependency.push_iter(
-            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-          )
-        (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
-        (11, 2) =>
-          msg.weak_dependency.push_iter(
-            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-          )
-        (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
-        (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
-        (4, _) =>
-          msg.message_type.push(
-            (reader |> @lib.read_message() : DescriptorProto),
-          )
-        (5, _) =>
-          msg.enum_type.push(
-            (reader |> @lib.read_message() : EnumDescriptorProto),
-          )
-        (6, _) =>
-          msg.service.push(
-            (reader |> @lib.read_message() : ServiceDescriptorProto),
-          )
-        (7, _) =>
-          msg.extension.push(
-            (reader |> @lib.read_message() : FieldDescriptorProto),
-          )
-        (8, _) =>
-          msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
-        (9, _) =>
-          msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo)
-            |> Some
-        (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
-        (14, _) =>
-          msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
+          (3, _) => msg.dependency.push(reader |> @lib.read_string())
+          (10, 2) =>
+            msg.public_dependency.push_iter(
+              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+            )
+          (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
+          (11, 2) =>
+            msg.weak_dependency.push_iter(
+              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+            )
+          (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
+          (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
+          (4, _) =>
+            msg.message_type.push(
+              (reader |> @lib.read_message() : DescriptorProto),
+            )
+          (5, _) =>
+            msg.enum_type.push(
+              (reader |> @lib.read_message() : EnumDescriptorProto),
+            )
+          (6, _) =>
+            msg.service.push(
+              (reader |> @lib.read_message() : ServiceDescriptorProto),
+            )
+          (7, _) =>
+            msg.extension.push(
+              (reader |> @lib.read_message() : FieldDescriptorProto),
+            )
+          (8, _) =>
+            msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
+          (9, _) =>
+            msg.source_code_info = (
+                reader |> @lib.read_message() : SourceCodeInfo)
+              |> Some
+          (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
+          (14, _) =>
+            msg.edition = reader
+              |> @lib.read_enum()
+              |> Edition::from_enum
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -560,33 +559,27 @@ pub impl @lib.Write for FileDescriptorProto with fn write(
   }
   for item in self.message_type {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.enum_type {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.service {
     writer |> @lib.write_varint(50UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.extension {
     writer |> @lib.write_varint(58UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(66UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.source_code_info is Some(v) {
     writer |> @lib.write_varint(74UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.syntax is Some(v) {
     writer |> @lib.write_varint(98UL)
@@ -702,59 +695,59 @@ pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-        (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
-        (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
-        (10, 2) =>
-          msg.public_dependency.push_iter(
-            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-          )
-        (10, 0) => msg.public_dependency.push(reader |> @lib.async_read_int32())
-        (11, 2) =>
-          msg.weak_dependency.push_iter(
-            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-          )
-        (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
-        (15, _) =>
-          msg.option_dependency.push(reader |> @lib.async_read_string())
-        (4, _) =>
-          msg.message_type.push(
-            (reader |> @lib.async_read_message() : DescriptorProto),
-          )
-        (5, _) =>
-          msg.enum_type.push(
-            (reader |> @lib.async_read_message() : EnumDescriptorProto),
-          )
-        (6, _) =>
-          msg.service.push(
-            (reader |> @lib.async_read_message() : ServiceDescriptorProto),
-          )
-        (7, _) =>
-          msg.extension.push(
-            (reader |> @lib.async_read_message() : FieldDescriptorProto),
-          )
-        (8, _) =>
-          msg.options = (reader |> @lib.async_read_message() : FileOptions)
-            |> Some
-        (9, _) =>
-          msg.source_code_info = (
-              reader |> @lib.async_read_message() : SourceCodeInfo)
-            |> Some
-        (12, _) => msg.syntax = reader |> @lib.async_read_string() |> Some
-        (14, _) =>
-          msg.edition = reader
-            |> @lib.async_read_enum()
-            |> Edition::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
+          (10, 2) =>
+            msg.public_dependency.push_iter(
+              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+            )
+          (10, 0) =>
+            msg.public_dependency.push(reader |> @lib.async_read_int32())
+          (11, 2) =>
+            msg.weak_dependency.push_iter(
+              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+            )
+          (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
+          (15, _) =>
+            msg.option_dependency.push(reader |> @lib.async_read_string())
+          (4, _) =>
+            msg.message_type.push(
+              (reader |> @lib.async_read_message() : DescriptorProto),
+            )
+          (5, _) =>
+            msg.enum_type.push(
+              (reader |> @lib.async_read_message() : EnumDescriptorProto),
+            )
+          (6, _) =>
+            msg.service.push(
+              (reader |> @lib.async_read_message() : ServiceDescriptorProto),
+            )
+          (7, _) =>
+            msg.extension.push(
+              (reader |> @lib.async_read_message() : FieldDescriptorProto),
+            )
+          (8, _) =>
+            msg.options = (reader |> @lib.async_read_message() : FileOptions)
+              |> Some
+          (9, _) =>
+            msg.source_code_info = (
+                reader |> @lib.async_read_message() : SourceCodeInfo)
+              |> Some
+          (12, _) => msg.syntax = reader |> @lib.async_read_string() |> Some
+          (14, _) =>
+            msg.edition = reader
+              |> @lib.async_read_enum()
+              |> Edition::from_enum
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -790,33 +783,27 @@ pub impl @lib.AsyncWrite for FileDescriptorProto with fn write(
   }
   for item in self.message_type {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.enum_type {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.service {
     writer |> @lib.async_write_varint(50UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.extension {
     writer |> @lib.async_write_varint(58UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(66UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.source_code_info is Some(v) {
     writer |> @lib.async_write_varint(74UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.syntax is Some(v) {
     writer |> @lib.async_write_varint(98UL)
@@ -873,20 +860,19 @@ pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-        (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-        (3, _) =>
-          msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions)
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+          (3, _) =>
+            msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions)
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -906,8 +892,7 @@ pub impl @lib.Write for DescriptorProto_ExtensionRange with fn write(
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -957,21 +942,20 @@ pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_lim
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-        (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-        (3, _) =>
-          msg.options = (
-              reader |> @lib.async_read_message() : ExtensionRangeOptions)
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+          (3, _) =>
+            msg.options = (
+                reader |> @lib.async_read_message() : ExtensionRangeOptions)
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -991,8 +975,7 @@ pub impl @lib.AsyncWrite for DescriptorProto_ExtensionRange with fn write(
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }
 
@@ -1032,17 +1015,16 @@ pub impl @lib.Read for DescriptorProto_ReservedRange with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-        (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1102,17 +1084,16 @@ pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with fn read_with_limi
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-        (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1277,50 +1258,52 @@ pub impl @lib.Read for DescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string() |> Some
-        (2, _) =>
-          msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
-        (6, _) =>
-          msg.extension.push(
-            (reader |> @lib.read_message() : FieldDescriptorProto),
-          )
-        (3, _) =>
-          msg.nested_type.push(
-            (reader |> @lib.read_message() : DescriptorProto),
-          )
-        (4, _) =>
-          msg.enum_type.push(
-            (reader |> @lib.read_message() : EnumDescriptorProto),
-          )
-        (5, _) =>
-          msg.extension_range.push(
-            (reader |> @lib.read_message() : DescriptorProto_ExtensionRange),
-          )
-        (8, _) =>
-          msg.oneof_decl.push(
-            (reader |> @lib.read_message() : OneofDescriptorProto),
-          )
-        (7, _) =>
-          msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
-        (9, _) =>
-          msg.reserved_range.push(
-            (reader |> @lib.read_message() : DescriptorProto_ReservedRange),
-          )
-        (10, _) => msg.reserved_name.push(reader |> @lib.read_string())
-        (11, _) =>
-          msg.visibility = reader
-            |> @lib.read_enum()
-            |> SymbolVisibility::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) =>
+            msg.field.push(
+              (reader |> @lib.read_message() : FieldDescriptorProto),
+            )
+          (6, _) =>
+            msg.extension.push(
+              (reader |> @lib.read_message() : FieldDescriptorProto),
+            )
+          (3, _) =>
+            msg.nested_type.push(
+              (reader |> @lib.read_message() : DescriptorProto),
+            )
+          (4, _) =>
+            msg.enum_type.push(
+              (reader |> @lib.read_message() : EnumDescriptorProto),
+            )
+          (5, _) =>
+            msg.extension_range.push(
+              (reader |> @lib.read_message() : DescriptorProto_ExtensionRange),
+            )
+          (8, _) =>
+            msg.oneof_decl.push(
+              (reader |> @lib.read_message() : OneofDescriptorProto),
+            )
+          (7, _) =>
+            msg.options = (reader |> @lib.read_message() : MessageOptions)
+              |> Some
+          (9, _) =>
+            msg.reserved_range.push(
+              (reader |> @lib.read_message() : DescriptorProto_ReservedRange),
+            )
+          (10, _) => msg.reserved_name.push(reader |> @lib.read_string())
+          (11, _) =>
+            msg.visibility = reader
+              |> @lib.read_enum()
+              |> SymbolVisibility::from_enum
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1336,43 +1319,35 @@ pub impl @lib.Write for DescriptorProto with fn write(
   }
   for item in self.field {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.extension {
     writer |> @lib.write_varint(50UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.nested_type {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.enum_type {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.extension_range {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.oneof_decl {
     writer |> @lib.write_varint(66UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(58UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   for item in self.reserved_range {
     writer |> @lib.write_varint(74UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.reserved_name {
     writer |> @lib.write_varint(82UL)
@@ -1471,55 +1446,56 @@ pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-        (2, _) =>
-          msg.field.push(
-            (reader |> @lib.async_read_message() : FieldDescriptorProto),
-          )
-        (6, _) =>
-          msg.extension.push(
-            (reader |> @lib.async_read_message() : FieldDescriptorProto),
-          )
-        (3, _) =>
-          msg.nested_type.push(
-            (reader |> @lib.async_read_message() : DescriptorProto),
-          )
-        (4, _) =>
-          msg.enum_type.push(
-            (reader |> @lib.async_read_message() : EnumDescriptorProto),
-          )
-        (5, _) =>
-          msg.extension_range.push(
-            (
-              reader |> @lib.async_read_message() :
-              DescriptorProto_ExtensionRange),
-          )
-        (8, _) =>
-          msg.oneof_decl.push(
-            (reader |> @lib.async_read_message() : OneofDescriptorProto),
-          )
-        (7, _) =>
-          msg.options = (reader |> @lib.async_read_message() : MessageOptions)
-            |> Some
-        (9, _) =>
-          msg.reserved_range.push(
-            (reader |> @lib.async_read_message() : DescriptorProto_ReservedRange),
-          )
-        (10, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
-        (11, _) =>
-          msg.visibility = reader
-            |> @lib.async_read_enum()
-            |> SymbolVisibility::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) =>
+            msg.field.push(
+              (reader |> @lib.async_read_message() : FieldDescriptorProto),
+            )
+          (6, _) =>
+            msg.extension.push(
+              (reader |> @lib.async_read_message() : FieldDescriptorProto),
+            )
+          (3, _) =>
+            msg.nested_type.push(
+              (reader |> @lib.async_read_message() : DescriptorProto),
+            )
+          (4, _) =>
+            msg.enum_type.push(
+              (reader |> @lib.async_read_message() : EnumDescriptorProto),
+            )
+          (5, _) =>
+            msg.extension_range.push(
+              (
+                reader |> @lib.async_read_message() :
+                DescriptorProto_ExtensionRange),
+            )
+          (8, _) =>
+            msg.oneof_decl.push(
+              (reader |> @lib.async_read_message() : OneofDescriptorProto),
+            )
+          (7, _) =>
+            msg.options = (reader |> @lib.async_read_message() : MessageOptions)
+              |> Some
+          (9, _) =>
+            msg.reserved_range.push(
+              (
+                reader |> @lib.async_read_message() :
+                DescriptorProto_ReservedRange),
+            )
+          (10, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
+          (11, _) =>
+            msg.visibility = reader
+              |> @lib.async_read_enum()
+              |> SymbolVisibility::from_enum
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1535,43 +1511,35 @@ pub impl @lib.AsyncWrite for DescriptorProto with fn write(
   }
   for item in self.field {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.extension {
     writer |> @lib.async_write_varint(50UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.nested_type {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.enum_type {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.extension_range {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.oneof_decl {
     writer |> @lib.async_write_varint(66UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(58UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   for item in self.reserved_range {
     writer |> @lib.async_write_varint(74UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.reserved_name {
     writer |> @lib.async_write_varint(82UL)
@@ -1721,20 +1689,19 @@ pub impl @lib.Read for ExtensionRangeOptions_Declaration with fn read_with_limit
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.number = reader |> @lib.read_int32() |> Some
-        (2, _) => msg.full_name = reader |> @lib.read_string() |> Some
-        (3, _) => msg.type_ = reader |> @lib.read_string() |> Some
-        (5, _) => msg.reserved = reader |> @lib.read_bool() |> Some
-        (6, _) => msg.repeated = reader |> @lib.read_bool() |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.number = reader |> @lib.read_int32() |> Some
+          (2, _) => msg.full_name = reader |> @lib.read_string() |> Some
+          (3, _) => msg.type_ = reader |> @lib.read_string() |> Some
+          (5, _) => msg.reserved = reader |> @lib.read_bool() |> Some
+          (6, _) => msg.repeated = reader |> @lib.read_bool() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1824,20 +1791,19 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with fn read_with_
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-        (2, _) => msg.full_name = reader |> @lib.async_read_string() |> Some
-        (3, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
-        (5, _) => msg.reserved = reader |> @lib.async_read_bool() |> Some
-        (6, _) => msg.repeated = reader |> @lib.async_read_bool() |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+          (2, _) => msg.full_name = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
+          (5, _) => msg.reserved = reader |> @lib.async_read_bool() |> Some
+          (6, _) => msg.repeated = reader |> @lib.async_read_bool() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1937,30 +1903,29 @@ pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.read_message() : UninterpretedOption),
-          )
-        (2, _) =>
-          msg.declaration.push(
-            (reader |> @lib.read_message() : ExtensionRangeOptions_Declaration),
-          )
-        (50, _) =>
-          msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-        (3, _) =>
-          msg.verification = reader
-            |> @lib.read_enum()
-            |> ExtensionRangeOptions_VerificationState::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.read_message() : UninterpretedOption),
+            )
+          (2, _) =>
+            msg.declaration.push(
+              (reader |> @lib.read_message() : ExtensionRangeOptions_Declaration),
+            )
+          (50, _) =>
+            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (3, _) =>
+            msg.verification = reader
+              |> @lib.read_enum()
+              |> ExtensionRangeOptions_VerificationState::from_enum
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1972,18 +1937,15 @@ pub impl @lib.Write for ExtensionRangeOptions with fn write(
 ) -> Unit raise {
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.declaration {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(402UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.verification is Some(v) {
     writer |> @lib.write_varint(24UL)
@@ -2044,33 +2006,32 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.async_read_message() : UninterpretedOption),
-          )
-        (2, _) =>
-          msg.declaration.push(
-            (
-              reader |> @lib.async_read_message() :
-              ExtensionRangeOptions_Declaration),
-          )
-        (50, _) =>
-          msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-            |> Some
-        (3, _) =>
-          msg.verification = reader
-            |> @lib.async_read_enum()
-            |> ExtensionRangeOptions_VerificationState::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.async_read_message() : UninterpretedOption),
+            )
+          (2, _) =>
+            msg.declaration.push(
+              (
+                reader |> @lib.async_read_message() :
+                ExtensionRangeOptions_Declaration),
+            )
+          (50, _) =>
+            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+              |> Some
+          (3, _) =>
+            msg.verification = reader
+              |> @lib.async_read_enum()
+              |> ExtensionRangeOptions_VerificationState::from_enum
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2082,18 +2043,15 @@ pub impl @lib.AsyncWrite for ExtensionRangeOptions with fn write(
 ) -> Unit raise {
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.declaration {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(402UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.verification is Some(v) {
     writer |> @lib.async_write_varint(24UL)
@@ -2464,35 +2422,34 @@ pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string() |> Some
-        (3, _) => msg.number = reader |> @lib.read_int32() |> Some
-        (4, _) =>
-          msg.label = reader
-            |> @lib.read_enum()
-            |> FieldDescriptorProto_Label::from_enum
-            |> Some
-        (5, _) =>
-          msg.type_ = reader
-            |> @lib.read_enum()
-            |> FieldDescriptorProto_Type::from_enum
-            |> Some
-        (6, _) => msg.type_name = reader |> @lib.read_string() |> Some
-        (2, _) => msg.extendee = reader |> @lib.read_string() |> Some
-        (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
-        (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
-        (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
-        (8, _) =>
-          msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
-        (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (3, _) => msg.number = reader |> @lib.read_int32() |> Some
+          (4, _) =>
+            msg.label = reader
+              |> @lib.read_enum()
+              |> FieldDescriptorProto_Label::from_enum
+              |> Some
+          (5, _) =>
+            msg.type_ = reader
+              |> @lib.read_enum()
+              |> FieldDescriptorProto_Type::from_enum
+              |> Some
+          (6, _) => msg.type_name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.extendee = reader |> @lib.read_string() |> Some
+          (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
+          (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
+          (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
+          (8, _) =>
+            msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
+          (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2540,8 +2497,7 @@ pub impl @lib.Write for FieldDescriptorProto with fn write(
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(66UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.proto3_optional is Some(v) {
     writer |> @lib.write_varint(136UL)
@@ -2641,37 +2597,37 @@ pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-        (3, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-        (4, _) =>
-          msg.label = reader
-            |> @lib.async_read_enum()
-            |> FieldDescriptorProto_Label::from_enum
-            |> Some
-        (5, _) =>
-          msg.type_ = reader
-            |> @lib.async_read_enum()
-            |> FieldDescriptorProto_Type::from_enum
-            |> Some
-        (6, _) => msg.type_name = reader |> @lib.async_read_string() |> Some
-        (2, _) => msg.extendee = reader |> @lib.async_read_string() |> Some
-        (7, _) => msg.default_value = reader |> @lib.async_read_string() |> Some
-        (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
-        (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
-        (8, _) =>
-          msg.options = (reader |> @lib.async_read_message() : FieldOptions)
-            |> Some
-        (17, _) =>
-          msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+          (4, _) =>
+            msg.label = reader
+              |> @lib.async_read_enum()
+              |> FieldDescriptorProto_Label::from_enum
+              |> Some
+          (5, _) =>
+            msg.type_ = reader
+              |> @lib.async_read_enum()
+              |> FieldDescriptorProto_Type::from_enum
+              |> Some
+          (6, _) => msg.type_name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.extendee = reader |> @lib.async_read_string() |> Some
+          (7, _) =>
+            msg.default_value = reader |> @lib.async_read_string() |> Some
+          (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
+          (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
+          (8, _) =>
+            msg.options = (reader |> @lib.async_read_message() : FieldOptions)
+              |> Some
+          (17, _) =>
+            msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2719,8 +2675,7 @@ pub impl @lib.AsyncWrite for FieldDescriptorProto with fn write(
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(66UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.proto3_optional is Some(v) {
     writer |> @lib.async_write_varint(136UL)
@@ -2772,18 +2727,17 @@ pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string() |> Some
-        (2, _) =>
-          msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) =>
+            msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2799,8 +2753,7 @@ pub impl @lib.Write for OneofDescriptorProto with fn write(
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -2845,19 +2798,18 @@ pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-        (2, _) =>
-          msg.options = (reader |> @lib.async_read_message() : OneofOptions)
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) =>
+            msg.options = (reader |> @lib.async_read_message() : OneofOptions)
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2873,8 +2825,7 @@ pub impl @lib.AsyncWrite for OneofDescriptorProto with fn write(
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }
 
@@ -2916,17 +2867,16 @@ pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with fn read_with_l
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-        (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2986,17 +2936,16 @@ pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with fn read_w
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-        (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -3106,34 +3055,33 @@ pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string() |> Some
-        (2, _) =>
-          msg.value.push(
-            (reader |> @lib.read_message() : EnumValueDescriptorProto),
-          )
-        (3, _) =>
-          msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
-        (4, _) =>
-          msg.reserved_range.push(
-            (
-              reader |> @lib.read_message() :
-              EnumDescriptorProto_EnumReservedRange),
-          )
-        (5, _) => msg.reserved_name.push(reader |> @lib.read_string())
-        (6, _) =>
-          msg.visibility = reader
-            |> @lib.read_enum()
-            |> SymbolVisibility::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) =>
+            msg.value.push(
+              (reader |> @lib.read_message() : EnumValueDescriptorProto),
+            )
+          (3, _) =>
+            msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
+          (4, _) =>
+            msg.reserved_range.push(
+              (
+                reader |> @lib.read_message() :
+                EnumDescriptorProto_EnumReservedRange),
+            )
+          (5, _) => msg.reserved_name.push(reader |> @lib.read_string())
+          (6, _) =>
+            msg.visibility = reader
+              |> @lib.read_enum()
+              |> SymbolVisibility::from_enum
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -3149,18 +3097,15 @@ pub impl @lib.Write for EnumDescriptorProto with fn write(
   }
   for item in self.value {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   for item in self.reserved_range {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.reserved_name {
     writer |> @lib.write_varint(42UL)
@@ -3234,35 +3179,34 @@ pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-        (2, _) =>
-          msg.value.push(
-            (reader |> @lib.async_read_message() : EnumValueDescriptorProto),
-          )
-        (3, _) =>
-          msg.options = (reader |> @lib.async_read_message() : EnumOptions)
-            |> Some
-        (4, _) =>
-          msg.reserved_range.push(
-            (
-              reader |> @lib.async_read_message() :
-              EnumDescriptorProto_EnumReservedRange),
-          )
-        (5, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
-        (6, _) =>
-          msg.visibility = reader
-            |> @lib.async_read_enum()
-            |> SymbolVisibility::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) =>
+            msg.value.push(
+              (reader |> @lib.async_read_message() : EnumValueDescriptorProto),
+            )
+          (3, _) =>
+            msg.options = (reader |> @lib.async_read_message() : EnumOptions)
+              |> Some
+          (4, _) =>
+            msg.reserved_range.push(
+              (
+                reader |> @lib.async_read_message() :
+                EnumDescriptorProto_EnumReservedRange),
+            )
+          (5, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
+          (6, _) =>
+            msg.visibility = reader
+              |> @lib.async_read_enum()
+              |> SymbolVisibility::from_enum
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -3278,18 +3222,15 @@ pub impl @lib.AsyncWrite for EnumDescriptorProto with fn write(
   }
   for item in self.value {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   for item in self.reserved_range {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.reserved_name {
     writer |> @lib.async_write_varint(42UL)
@@ -3350,20 +3291,19 @@ pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string() |> Some
-        (2, _) => msg.number = reader |> @lib.read_int32() |> Some
-        (3, _) =>
-          msg.options = (reader |> @lib.read_message() : EnumValueOptions)
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.number = reader |> @lib.read_int32() |> Some
+          (3, _) =>
+            msg.options = (reader |> @lib.read_message() : EnumValueOptions)
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -3383,8 +3323,7 @@ pub impl @lib.Write for EnumValueDescriptorProto with fn write(
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -3434,20 +3373,20 @@ pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-        (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-        (3, _) =>
-          msg.options = (reader |> @lib.async_read_message() : EnumValueOptions)
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+          (3, _) =>
+            msg.options = (
+                reader |> @lib.async_read_message() : EnumValueOptions)
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -3467,8 +3406,7 @@ pub impl @lib.AsyncWrite for EnumValueDescriptorProto with fn write(
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }
 
@@ -3525,22 +3463,22 @@ pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string() |> Some
-        (2, _) =>
-          msg.method_.push(
-            (reader |> @lib.read_message() : MethodDescriptorProto),
-          )
-        (3, _) =>
-          msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) =>
+            msg.method_.push(
+              (reader |> @lib.read_message() : MethodDescriptorProto),
+            )
+          (3, _) =>
+            msg.options = (reader |> @lib.read_message() : ServiceOptions)
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -3556,13 +3494,11 @@ pub impl @lib.Write for ServiceDescriptorProto with fn write(
   }
   for item in self.method_ {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -3612,23 +3548,22 @@ pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-        (2, _) =>
-          msg.method_.push(
-            (reader |> @lib.async_read_message() : MethodDescriptorProto),
-          )
-        (3, _) =>
-          msg.options = (reader |> @lib.async_read_message() : ServiceOptions)
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) =>
+            msg.method_.push(
+              (reader |> @lib.async_read_message() : MethodDescriptorProto),
+            )
+          (3, _) =>
+            msg.options = (reader |> @lib.async_read_message() : ServiceOptions)
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -3644,13 +3579,11 @@ pub impl @lib.AsyncWrite for ServiceDescriptorProto with fn write(
   }
   for item in self.method_ {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }
 
@@ -3740,22 +3673,22 @@ pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string() |> Some
-        (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
-        (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
-        (4, _) =>
-          msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
-        (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
-        (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
+          (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
+          (4, _) =>
+            msg.options = (reader |> @lib.read_message() : MethodOptions)
+              |> Some
+          (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
+          (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -3779,8 +3712,7 @@ pub impl @lib.Write for MethodDescriptorProto with fn write(
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.client_streaming is Some(v) {
     writer |> @lib.write_varint(40UL)
@@ -3857,25 +3789,24 @@ pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-        (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
-        (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
-        (4, _) =>
-          msg.options = (reader |> @lib.async_read_message() : MethodOptions)
-            |> Some
-        (5, _) =>
-          msg.client_streaming = reader |> @lib.async_read_bool() |> Some
-        (6, _) =>
-          msg.server_streaming = reader |> @lib.async_read_bool() |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
+          (4, _) =>
+            msg.options = (reader |> @lib.async_read_message() : MethodOptions)
+              |> Some
+          (5, _) =>
+            msg.client_streaming = reader |> @lib.async_read_bool() |> Some
+          (6, _) =>
+            msg.server_streaming = reader |> @lib.async_read_bool() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -3899,8 +3830,7 @@ pub impl @lib.AsyncWrite for MethodDescriptorProto with fn write(
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.client_streaming is Some(v) {
     writer |> @lib.async_write_varint(40UL)
@@ -4207,49 +4137,54 @@ pub impl @lib.Read for FileOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FileOptions raise {
   let msg = FileOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.java_package = reader |> @lib.read_string() |> Some
-        (8, _) =>
-          msg.java_outer_classname = reader |> @lib.read_string() |> Some
-        (10, _) => msg.java_multiple_files = reader |> @lib.read_bool() |> Some
-        (20, _) =>
-          msg.java_generate_equals_and_hash = reader |> @lib.read_bool() |> Some
-        (27, _) =>
-          msg.java_string_check_utf8 = reader |> @lib.read_bool() |> Some
-        (9, _) =>
-          msg.optimize_for = reader
-            |> @lib.read_enum()
-            |> FileOptions_OptimizeMode::from_enum
-            |> Some
-        (11, _) => msg.go_package = reader |> @lib.read_string() |> Some
-        (16, _) => msg.cc_generic_services = reader |> @lib.read_bool() |> Some
-        (17, _) =>
-          msg.java_generic_services = reader |> @lib.read_bool() |> Some
-        (18, _) => msg.py_generic_services = reader |> @lib.read_bool() |> Some
-        (23, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-        (31, _) => msg.cc_enable_arenas = reader |> @lib.read_bool() |> Some
-        (36, _) => msg.objc_class_prefix = reader |> @lib.read_string() |> Some
-        (37, _) => msg.csharp_namespace = reader |> @lib.read_string() |> Some
-        (39, _) => msg.swift_prefix = reader |> @lib.read_string() |> Some
-        (40, _) => msg.php_class_prefix = reader |> @lib.read_string() |> Some
-        (41, _) => msg.php_namespace = reader |> @lib.read_string() |> Some
-        (44, _) =>
-          msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
-        (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
-        (50, _) =>
-          msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.java_package = reader |> @lib.read_string() |> Some
+          (8, _) =>
+            msg.java_outer_classname = reader |> @lib.read_string() |> Some
+          (10, _) =>
+            msg.java_multiple_files = reader |> @lib.read_bool() |> Some
+          (20, _) =>
+            msg.java_generate_equals_and_hash = reader
+              |> @lib.read_bool()
+              |> Some
+          (27, _) =>
+            msg.java_string_check_utf8 = reader |> @lib.read_bool() |> Some
+          (9, _) =>
+            msg.optimize_for = reader
+              |> @lib.read_enum()
+              |> FileOptions_OptimizeMode::from_enum
+              |> Some
+          (11, _) => msg.go_package = reader |> @lib.read_string() |> Some
+          (16, _) =>
+            msg.cc_generic_services = reader |> @lib.read_bool() |> Some
+          (17, _) =>
+            msg.java_generic_services = reader |> @lib.read_bool() |> Some
+          (18, _) =>
+            msg.py_generic_services = reader |> @lib.read_bool() |> Some
+          (23, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (31, _) => msg.cc_enable_arenas = reader |> @lib.read_bool() |> Some
+          (36, _) =>
+            msg.objc_class_prefix = reader |> @lib.read_string() |> Some
+          (37, _) => msg.csharp_namespace = reader |> @lib.read_string() |> Some
+          (39, _) => msg.swift_prefix = reader |> @lib.read_string() |> Some
+          (40, _) => msg.php_class_prefix = reader |> @lib.read_string() |> Some
+          (41, _) => msg.php_namespace = reader |> @lib.read_string() |> Some
+          (44, _) =>
+            msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
+          (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
+          (50, _) =>
+            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -4337,13 +4272,11 @@ pub impl @lib.Write for FileOptions with fn write(
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(402UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -4503,62 +4436,68 @@ pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FileOptions raise {
   let msg = FileOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.java_package = reader |> @lib.async_read_string() |> Some
-        (8, _) =>
-          msg.java_outer_classname = reader |> @lib.async_read_string() |> Some
-        (10, _) =>
-          msg.java_multiple_files = reader |> @lib.async_read_bool() |> Some
-        (20, _) =>
-          msg.java_generate_equals_and_hash = reader
-            |> @lib.async_read_bool()
-            |> Some
-        (27, _) =>
-          msg.java_string_check_utf8 = reader |> @lib.async_read_bool() |> Some
-        (9, _) =>
-          msg.optimize_for = reader
-            |> @lib.async_read_enum()
-            |> FileOptions_OptimizeMode::from_enum
-            |> Some
-        (11, _) => msg.go_package = reader |> @lib.async_read_string() |> Some
-        (16, _) =>
-          msg.cc_generic_services = reader |> @lib.async_read_bool() |> Some
-        (17, _) =>
-          msg.java_generic_services = reader |> @lib.async_read_bool() |> Some
-        (18, _) =>
-          msg.py_generic_services = reader |> @lib.async_read_bool() |> Some
-        (23, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-        (31, _) =>
-          msg.cc_enable_arenas = reader |> @lib.async_read_bool() |> Some
-        (36, _) =>
-          msg.objc_class_prefix = reader |> @lib.async_read_string() |> Some
-        (37, _) =>
-          msg.csharp_namespace = reader |> @lib.async_read_string() |> Some
-        (39, _) => msg.swift_prefix = reader |> @lib.async_read_string() |> Some
-        (40, _) =>
-          msg.php_class_prefix = reader |> @lib.async_read_string() |> Some
-        (41, _) =>
-          msg.php_namespace = reader |> @lib.async_read_string() |> Some
-        (44, _) =>
-          msg.php_metadata_namespace = reader
-            |> @lib.async_read_string()
-            |> Some
-        (45, _) => msg.ruby_package = reader |> @lib.async_read_string() |> Some
-        (50, _) =>
-          msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-            |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.async_read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.java_package = reader |> @lib.async_read_string() |> Some
+          (8, _) =>
+            msg.java_outer_classname = reader
+              |> @lib.async_read_string()
+              |> Some
+          (10, _) =>
+            msg.java_multiple_files = reader |> @lib.async_read_bool() |> Some
+          (20, _) =>
+            msg.java_generate_equals_and_hash = reader
+              |> @lib.async_read_bool()
+              |> Some
+          (27, _) =>
+            msg.java_string_check_utf8 = reader
+              |> @lib.async_read_bool()
+              |> Some
+          (9, _) =>
+            msg.optimize_for = reader
+              |> @lib.async_read_enum()
+              |> FileOptions_OptimizeMode::from_enum
+              |> Some
+          (11, _) => msg.go_package = reader |> @lib.async_read_string() |> Some
+          (16, _) =>
+            msg.cc_generic_services = reader |> @lib.async_read_bool() |> Some
+          (17, _) =>
+            msg.java_generic_services = reader |> @lib.async_read_bool() |> Some
+          (18, _) =>
+            msg.py_generic_services = reader |> @lib.async_read_bool() |> Some
+          (23, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (31, _) =>
+            msg.cc_enable_arenas = reader |> @lib.async_read_bool() |> Some
+          (36, _) =>
+            msg.objc_class_prefix = reader |> @lib.async_read_string() |> Some
+          (37, _) =>
+            msg.csharp_namespace = reader |> @lib.async_read_string() |> Some
+          (39, _) =>
+            msg.swift_prefix = reader |> @lib.async_read_string() |> Some
+          (40, _) =>
+            msg.php_class_prefix = reader |> @lib.async_read_string() |> Some
+          (41, _) =>
+            msg.php_namespace = reader |> @lib.async_read_string() |> Some
+          (44, _) =>
+            msg.php_metadata_namespace = reader
+              |> @lib.async_read_string()
+              |> Some
+          (45, _) =>
+            msg.ruby_package = reader |> @lib.async_read_string() |> Some
+          (50, _) =>
+            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+              |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.async_read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -4646,13 +4585,11 @@ pub impl @lib.AsyncWrite for FileOptions with fn write(
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(402UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -4741,33 +4678,32 @@ pub impl @lib.Read for MessageOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MessageOptions raise {
   let msg = MessageOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.message_set_wire_format = reader |> @lib.read_bool() |> Some
-        (2, _) =>
-          msg.no_standard_descriptor_accessor = reader
-            |> @lib.read_bool()
-            |> Some
-        (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-        (7, _) => msg.map_entry = reader |> @lib.read_bool() |> Some
-        (11, _) =>
-          msg.deprecated_legacy_json_field_conflicts = reader
-            |> @lib.read_bool()
-            |> Some
-        (12, _) =>
-          msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.message_set_wire_format = reader |> @lib.read_bool() |> Some
+          (2, _) =>
+            msg.no_standard_descriptor_accessor = reader
+              |> @lib.read_bool()
+              |> Some
+          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (7, _) => msg.map_entry = reader |> @lib.read_bool() |> Some
+          (11, _) =>
+            msg.deprecated_legacy_json_field_conflicts = reader
+              |> @lib.read_bool()
+              |> Some
+          (12, _) =>
+            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -4799,13 +4735,11 @@ pub impl @lib.Write for MessageOptions with fn write(
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(98UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -4882,34 +4816,35 @@ pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MessageOptions raise {
   let msg = MessageOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.message_set_wire_format = reader |> @lib.async_read_bool() |> Some
-        (2, _) =>
-          msg.no_standard_descriptor_accessor = reader
-            |> @lib.async_read_bool()
-            |> Some
-        (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-        (7, _) => msg.map_entry = reader |> @lib.async_read_bool() |> Some
-        (11, _) =>
-          msg.deprecated_legacy_json_field_conflicts = reader
-            |> @lib.async_read_bool()
-            |> Some
-        (12, _) =>
-          msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-            |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.async_read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.message_set_wire_format = reader
+              |> @lib.async_read_bool()
+              |> Some
+          (2, _) =>
+            msg.no_standard_descriptor_accessor = reader
+              |> @lib.async_read_bool()
+              |> Some
+          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (7, _) => msg.map_entry = reader |> @lib.async_read_bool() |> Some
+          (11, _) =>
+            msg.deprecated_legacy_json_field_conflicts = reader
+              |> @lib.async_read_bool()
+              |> Some
+          (12, _) =>
+            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+              |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.async_read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -4941,13 +4876,11 @@ pub impl @lib.AsyncWrite for MessageOptions with fn write(
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(98UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -5327,18 +5260,20 @@ pub impl @lib.Read for FieldOptions_EditionDefault with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (3, _) =>
-          msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-        (2, _) => msg.value = reader |> @lib.read_string() |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (3, _) =>
+            msg.edition = reader
+              |> @lib.read_enum()
+              |> Edition::from_enum
+              |> Some
+          (2, _) => msg.value = reader |> @lib.read_string() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -5399,21 +5334,20 @@ pub impl @lib.AsyncRead for FieldOptions_EditionDefault with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (3, _) =>
-          msg.edition = reader
-            |> @lib.async_read_enum()
-            |> Edition::from_enum
-            |> Some
-        (2, _) => msg.value = reader |> @lib.async_read_string() |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (3, _) =>
+            msg.edition = reader
+              |> @lib.async_read_enum()
+              |> Edition::from_enum
+              |> Some
+          (2, _) => msg.value = reader |> @lib.async_read_string() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -5493,31 +5427,31 @@ pub impl @lib.Read for FieldOptions_FeatureSupport with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.edition_introduced = reader
-            |> @lib.read_enum()
-            |> Edition::from_enum
-            |> Some
-        (2, _) =>
-          msg.edition_deprecated = reader
-            |> @lib.read_enum()
-            |> Edition::from_enum
-            |> Some
-        (3, _) => msg.deprecation_warning = reader |> @lib.read_string() |> Some
-        (4, _) =>
-          msg.edition_removed = reader
-            |> @lib.read_enum()
-            |> Edition::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.edition_introduced = reader
+              |> @lib.read_enum()
+              |> Edition::from_enum
+              |> Some
+          (2, _) =>
+            msg.edition_deprecated = reader
+              |> @lib.read_enum()
+              |> Edition::from_enum
+              |> Some
+          (3, _) =>
+            msg.deprecation_warning = reader |> @lib.read_string() |> Some
+          (4, _) =>
+            msg.edition_removed = reader
+              |> @lib.read_enum()
+              |> Edition::from_enum
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -5599,32 +5533,31 @@ pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.edition_introduced = reader
-            |> @lib.async_read_enum()
-            |> Edition::from_enum
-            |> Some
-        (2, _) =>
-          msg.edition_deprecated = reader
-            |> @lib.async_read_enum()
-            |> Edition::from_enum
-            |> Some
-        (3, _) =>
-          msg.deprecation_warning = reader |> @lib.async_read_string() |> Some
-        (4, _) =>
-          msg.edition_removed = reader
-            |> @lib.async_read_enum()
-            |> Edition::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.edition_introduced = reader
+              |> @lib.async_read_enum()
+              |> Edition::from_enum
+              |> Some
+          (2, _) =>
+            msg.edition_deprecated = reader
+              |> @lib.async_read_enum()
+              |> Edition::from_enum
+              |> Some
+          (3, _) =>
+            msg.deprecation_warning = reader |> @lib.async_read_string() |> Some
+          (4, _) =>
+            msg.edition_removed = reader
+              |> @lib.async_read_enum()
+              |> Edition::from_enum
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -5794,62 +5727,61 @@ pub impl @lib.Read for FieldOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldOptions raise {
   let msg = FieldOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.ctype = reader
-            |> @lib.read_enum()
-            |> FieldOptions_CType::from_enum
-            |> Some
-        (2, _) => msg.packed = reader |> @lib.read_bool() |> Some
-        (6, _) =>
-          msg.jstype = reader
-            |> @lib.read_enum()
-            |> FieldOptions_JSType::from_enum
-            |> Some
-        (5, _) => msg.lazy_ = reader |> @lib.read_bool() |> Some
-        (15, _) => msg.unverified_lazy = reader |> @lib.read_bool() |> Some
-        (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-        (10, _) => msg.weak = reader |> @lib.read_bool() |> Some
-        (16, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-        (17, _) =>
-          msg.retention = reader
-            |> @lib.read_enum()
-            |> FieldOptions_OptionRetention::from_enum
-            |> Some
-        (19, 2) => {
-          let packed = reader |> @lib.read_packed(@lib.read_enum, None)
-          for item in packed {
-            msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.ctype = reader
+              |> @lib.read_enum()
+              |> FieldOptions_CType::from_enum
+              |> Some
+          (2, _) => msg.packed = reader |> @lib.read_bool() |> Some
+          (6, _) =>
+            msg.jstype = reader
+              |> @lib.read_enum()
+              |> FieldOptions_JSType::from_enum
+              |> Some
+          (5, _) => msg.lazy_ = reader |> @lib.read_bool() |> Some
+          (15, _) => msg.unverified_lazy = reader |> @lib.read_bool() |> Some
+          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (10, _) => msg.weak = reader |> @lib.read_bool() |> Some
+          (16, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
+          (17, _) =>
+            msg.retention = reader
+              |> @lib.read_enum()
+              |> FieldOptions_OptionRetention::from_enum
+              |> Some
+          (19, 2) => {
+            let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+            for item in packed {
+              msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
+            }
           }
+          (19, 0) =>
+            msg.targets.push(
+              reader
+              |> @lib.read_enum()
+              |> FieldOptions_OptionTargetType::from_enum,
+            )
+          (20, _) =>
+            msg.edition_defaults.push(
+              (reader |> @lib.read_message() : FieldOptions_EditionDefault),
+            )
+          (21, _) =>
+            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (22, _) =>
+            msg.feature_support = (
+                reader |> @lib.read_message() : FieldOptions_FeatureSupport)
+              |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.skip_message_field(wire)
         }
-        (19, 0) =>
-          msg.targets.push(
-            reader
-            |> @lib.read_enum()
-            |> FieldOptions_OptionTargetType::from_enum,
-          )
-        (20, _) =>
-          msg.edition_defaults.push(
-            (reader |> @lib.read_message() : FieldOptions_EditionDefault),
-          )
-        (21, _) =>
-          msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-        (22, _) =>
-          msg.feature_support = (
-              reader |> @lib.read_message() : FieldOptions_FeatureSupport)
-            |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -5901,23 +5833,19 @@ pub impl @lib.Write for FieldOptions with fn write(
   }
   for item in self.edition_defaults {
     writer |> @lib.write_varint(162UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(170UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.feature_support is Some(v) {
     writer |> @lib.write_varint(178UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -6026,65 +5954,65 @@ pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldOptions raise {
   let msg = FieldOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.ctype = reader
-            |> @lib.async_read_enum()
-            |> FieldOptions_CType::from_enum
-            |> Some
-        (2, _) => msg.packed = reader |> @lib.async_read_bool() |> Some
-        (6, _) =>
-          msg.jstype = reader
-            |> @lib.async_read_enum()
-            |> FieldOptions_JSType::from_enum
-            |> Some
-        (5, _) => msg.lazy_ = reader |> @lib.async_read_bool() |> Some
-        (15, _) =>
-          msg.unverified_lazy = reader |> @lib.async_read_bool() |> Some
-        (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-        (10, _) => msg.weak = reader |> @lib.async_read_bool() |> Some
-        (16, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-        (17, _) =>
-          msg.retention = reader
-            |> @lib.async_read_enum()
-            |> FieldOptions_OptionRetention::from_enum
-            |> Some
-        (19, 2) => {
-          let packed = reader
-            |> @lib.async_read_packed(@lib.async_read_enum, None)
-          for item in packed {
-            msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.ctype = reader
+              |> @lib.async_read_enum()
+              |> FieldOptions_CType::from_enum
+              |> Some
+          (2, _) => msg.packed = reader |> @lib.async_read_bool() |> Some
+          (6, _) =>
+            msg.jstype = reader
+              |> @lib.async_read_enum()
+              |> FieldOptions_JSType::from_enum
+              |> Some
+          (5, _) => msg.lazy_ = reader |> @lib.async_read_bool() |> Some
+          (15, _) =>
+            msg.unverified_lazy = reader |> @lib.async_read_bool() |> Some
+          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (10, _) => msg.weak = reader |> @lib.async_read_bool() |> Some
+          (16, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
+          (17, _) =>
+            msg.retention = reader
+              |> @lib.async_read_enum()
+              |> FieldOptions_OptionRetention::from_enum
+              |> Some
+          (19, 2) => {
+            let packed = reader
+              |> @lib.async_read_packed(@lib.async_read_enum, None)
+            for item in packed {
+              msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
+            }
           }
+          (19, 0) =>
+            msg.targets.push(
+              reader
+              |> @lib.async_read_enum()
+              |> FieldOptions_OptionTargetType::from_enum,
+            )
+          (20, _) =>
+            msg.edition_defaults.push(
+              (reader |> @lib.async_read_message() : FieldOptions_EditionDefault),
+            )
+          (21, _) =>
+            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+              |> Some
+          (22, _) =>
+            msg.feature_support = (
+                reader |> @lib.async_read_message() :
+                FieldOptions_FeatureSupport)
+              |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.async_read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
         }
-        (19, 0) =>
-          msg.targets.push(
-            reader
-            |> @lib.async_read_enum()
-            |> FieldOptions_OptionTargetType::from_enum,
-          )
-        (20, _) =>
-          msg.edition_defaults.push(
-            (reader |> @lib.async_read_message() : FieldOptions_EditionDefault),
-          )
-        (21, _) =>
-          msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-            |> Some
-        (22, _) =>
-          msg.feature_support = (
-              reader |> @lib.async_read_message() : FieldOptions_FeatureSupport)
-            |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.async_read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -6136,23 +6064,19 @@ pub impl @lib.AsyncWrite for FieldOptions with fn write(
   }
   for item in self.edition_defaults {
     writer |> @lib.async_write_varint(162UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(170UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.feature_support is Some(v) {
     writer |> @lib.async_write_varint(178UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -6200,21 +6124,20 @@ pub impl @lib.Read for OneofOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> OneofOptions raise {
   let msg = OneofOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -6226,13 +6149,11 @@ pub impl @lib.Write for OneofOptions with fn write(
 ) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -6275,22 +6196,21 @@ pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> OneofOptions raise {
   let msg = OneofOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-            |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.async_read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+              |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.async_read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -6302,13 +6222,11 @@ pub impl @lib.AsyncWrite for OneofOptions with fn write(
 ) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -6383,27 +6301,26 @@ pub impl @lib.Read for EnumOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumOptions raise {
   let msg = EnumOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (2, _) => msg.allow_alias = reader |> @lib.read_bool() |> Some
-        (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-        (6, _) =>
-          msg.deprecated_legacy_json_field_conflicts = reader
-            |> @lib.read_bool()
-            |> Some
-        (7, _) =>
-          msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (2, _) => msg.allow_alias = reader |> @lib.read_bool() |> Some
+          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (6, _) =>
+            msg.deprecated_legacy_json_field_conflicts = reader
+              |> @lib.read_bool()
+              |> Some
+          (7, _) =>
+            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -6427,13 +6344,11 @@ pub impl @lib.Write for EnumOptions with fn write(
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(58UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -6496,28 +6411,27 @@ pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumOptions raise {
   let msg = EnumOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (2, _) => msg.allow_alias = reader |> @lib.async_read_bool() |> Some
-        (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-        (6, _) =>
-          msg.deprecated_legacy_json_field_conflicts = reader
-            |> @lib.async_read_bool()
-            |> Some
-        (7, _) =>
-          msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-            |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.async_read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (2, _) => msg.allow_alias = reader |> @lib.async_read_bool() |> Some
+          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (6, _) =>
+            msg.deprecated_legacy_json_field_conflicts = reader
+              |> @lib.async_read_bool()
+              |> Some
+          (7, _) =>
+            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+              |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.async_read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -6541,13 +6455,11 @@ pub impl @lib.AsyncWrite for EnumOptions with fn write(
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(58UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -6626,27 +6538,26 @@ pub impl @lib.Read for EnumValueOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-        (2, _) =>
-          msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-        (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-        (4, _) =>
-          msg.feature_support = (
-              reader |> @lib.read_message() : FieldOptions_FeatureSupport)
-            |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (2, _) =>
+            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
+          (4, _) =>
+            msg.feature_support = (
+                reader |> @lib.read_message() : FieldOptions_FeatureSupport)
+              |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -6662,8 +6573,7 @@ pub impl @lib.Write for EnumValueOptions with fn write(
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.debug_redact is Some(v) {
     writer |> @lib.write_varint(24UL)
@@ -6671,13 +6581,11 @@ pub impl @lib.Write for EnumValueOptions with fn write(
   }
   if self.feature_support is Some(v) {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -6740,28 +6648,28 @@ pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-        (2, _) =>
-          msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-            |> Some
-        (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-        (4, _) =>
-          msg.feature_support = (
-              reader |> @lib.async_read_message() : FieldOptions_FeatureSupport)
-            |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.async_read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (2, _) =>
+            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+              |> Some
+          (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
+          (4, _) =>
+            msg.feature_support = (
+                reader |> @lib.async_read_message() :
+                FieldOptions_FeatureSupport)
+              |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.async_read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -6777,8 +6685,7 @@ pub impl @lib.AsyncWrite for EnumValueOptions with fn write(
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.debug_redact is Some(v) {
     writer |> @lib.async_write_varint(24UL)
@@ -6786,13 +6693,11 @@ pub impl @lib.AsyncWrite for EnumValueOptions with fn write(
   }
   if self.feature_support is Some(v) {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -6849,22 +6754,21 @@ pub impl @lib.Read for ServiceOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (34, _) =>
-          msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-        (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (34, _) =>
+            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -6876,8 +6780,7 @@ pub impl @lib.Write for ServiceOptions with fn write(
 ) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.write_varint(274UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(264UL)
@@ -6885,8 +6788,7 @@ pub impl @lib.Write for ServiceOptions with fn write(
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -6935,23 +6837,22 @@ pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (34, _) =>
-          msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-            |> Some
-        (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.async_read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (34, _) =>
+            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+              |> Some
+          (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.async_read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -6963,8 +6864,7 @@ pub impl @lib.AsyncWrite for ServiceOptions with fn write(
 ) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(274UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(264UL)
@@ -6972,8 +6872,7 @@ pub impl @lib.AsyncWrite for ServiceOptions with fn write(
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -7114,27 +7013,26 @@ pub impl @lib.Read for MethodOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MethodOptions raise {
   let msg = MethodOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-        (34, _) =>
-          msg.idempotency_level = reader
-            |> @lib.read_enum()
-            |> MethodOptions_IdempotencyLevel::from_enum
-            |> Some
-        (35, _) =>
-          msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (34, _) =>
+            msg.idempotency_level = reader
+              |> @lib.read_enum()
+              |> MethodOptions_IdempotencyLevel::from_enum
+              |> Some
+          (35, _) =>
+            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -7154,13 +7052,11 @@ pub impl @lib.Write for MethodOptions with fn write(
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(282UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -7216,28 +7112,27 @@ pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MethodOptions raise {
   let msg = MethodOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-        (34, _) =>
-          msg.idempotency_level = reader
-            |> @lib.async_read_enum()
-            |> MethodOptions_IdempotencyLevel::from_enum
-            |> Some
-        (35, _) =>
-          msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-            |> Some
-        (999, _) =>
-          msg.uninterpreted_option.push(
-            (reader |> @lib.async_read_message() : UninterpretedOption),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (34, _) =>
+            msg.idempotency_level = reader
+              |> @lib.async_read_enum()
+              |> MethodOptions_IdempotencyLevel::from_enum
+              |> Some
+          (35, _) =>
+            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+              |> Some
+          (999, _) =>
+            msg.uninterpreted_option.push(
+              (reader |> @lib.async_read_message() : UninterpretedOption),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -7257,13 +7152,11 @@ pub impl @lib.AsyncWrite for MethodOptions with fn write(
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(282UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -7306,17 +7199,16 @@ pub impl @lib.Read for UninterpretedOption_NamePart with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name_part = reader |> @lib.read_string()
-        (2, _) => msg.is_extension = reader |> @lib.read_bool()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name_part = reader |> @lib.read_string()
+          (2, _) => msg.is_extension = reader |> @lib.read_bool()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -7371,17 +7263,16 @@ pub impl @lib.AsyncRead for UninterpretedOption_NamePart with fn read_with_limit
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name_part = reader |> @lib.async_read_string()
-        (2, _) => msg.is_extension = reader |> @lib.async_read_bool()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name_part = reader |> @lib.async_read_string()
+          (2, _) => msg.is_extension = reader |> @lib.async_read_bool()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -7490,25 +7381,25 @@ pub impl @lib.Read for UninterpretedOption with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (2, _) =>
-          msg.name.push(
-            (reader |> @lib.read_message() : UninterpretedOption_NamePart),
-          )
-        (3, _) => msg.identifier_value = reader |> @lib.read_string() |> Some
-        (4, _) => msg.positive_int_value = reader |> @lib.read_uint64() |> Some
-        (5, _) => msg.negative_int_value = reader |> @lib.read_int64() |> Some
-        (6, _) => msg.double_value = reader |> @lib.read_double() |> Some
-        (7, _) => msg.string_value = reader |> @lib.read_bytes() |> Some
-        (8, _) => msg.aggregate_value = reader |> @lib.read_string() |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (2, _) =>
+            msg.name.push(
+              (reader |> @lib.read_message() : UninterpretedOption_NamePart),
+            )
+          (3, _) => msg.identifier_value = reader |> @lib.read_string() |> Some
+          (4, _) =>
+            msg.positive_int_value = reader |> @lib.read_uint64() |> Some
+          (5, _) => msg.negative_int_value = reader |> @lib.read_int64() |> Some
+          (6, _) => msg.double_value = reader |> @lib.read_double() |> Some
+          (7, _) => msg.string_value = reader |> @lib.read_bytes() |> Some
+          (8, _) => msg.aggregate_value = reader |> @lib.read_string() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -7520,8 +7411,7 @@ pub impl @lib.Write for UninterpretedOption with fn write(
 ) -> Unit raise {
   for item in self.name {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.identifier_value is Some(v) {
     writer |> @lib.write_varint(26UL)
@@ -7624,29 +7514,31 @@ pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (2, _) =>
-          msg.name.push(
-            (reader |> @lib.async_read_message() : UninterpretedOption_NamePart),
-          )
-        (3, _) =>
-          msg.identifier_value = reader |> @lib.async_read_string() |> Some
-        (4, _) =>
-          msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some
-        (5, _) =>
-          msg.negative_int_value = reader |> @lib.async_read_int64() |> Some
-        (6, _) => msg.double_value = reader |> @lib.async_read_double() |> Some
-        (7, _) => msg.string_value = reader |> @lib.async_read_bytes() |> Some
-        (8, _) =>
-          msg.aggregate_value = reader |> @lib.async_read_string() |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (2, _) =>
+            msg.name.push(
+              (
+                reader |> @lib.async_read_message() :
+                UninterpretedOption_NamePart),
+            )
+          (3, _) =>
+            msg.identifier_value = reader |> @lib.async_read_string() |> Some
+          (4, _) =>
+            msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some
+          (5, _) =>
+            msg.negative_int_value = reader |> @lib.async_read_int64() |> Some
+          (6, _) =>
+            msg.double_value = reader |> @lib.async_read_double() |> Some
+          (7, _) => msg.string_value = reader |> @lib.async_read_bytes() |> Some
+          (8, _) =>
+            msg.aggregate_value = reader |> @lib.async_read_string() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -7658,8 +7550,7 @@ pub impl @lib.AsyncWrite for UninterpretedOption with fn write(
 ) -> Unit raise {
   for item in self.name {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.identifier_value is Some(v) {
     writer |> @lib.async_write_varint(26UL)
@@ -8435,55 +8326,54 @@ pub impl @lib.Read for FeatureSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FeatureSet raise {
   let msg = FeatureSet::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.field_presence = reader
-            |> @lib.read_enum()
-            |> FeatureSet_FieldPresence::from_enum
-            |> Some
-        (2, _) =>
-          msg.enum_type = reader
-            |> @lib.read_enum()
-            |> FeatureSet_EnumType::from_enum
-            |> Some
-        (3, _) =>
-          msg.repeated_field_encoding = reader
-            |> @lib.read_enum()
-            |> FeatureSet_RepeatedFieldEncoding::from_enum
-            |> Some
-        (4, _) =>
-          msg.utf8_validation = reader
-            |> @lib.read_enum()
-            |> FeatureSet_Utf8Validation::from_enum
-            |> Some
-        (5, _) =>
-          msg.message_encoding = reader
-            |> @lib.read_enum()
-            |> FeatureSet_MessageEncoding::from_enum
-            |> Some
-        (6, _) =>
-          msg.json_format = reader
-            |> @lib.read_enum()
-            |> FeatureSet_JsonFormat::from_enum
-            |> Some
-        (7, _) =>
-          msg.enforce_naming_style = reader
-            |> @lib.read_enum()
-            |> FeatureSet_EnforceNamingStyle::from_enum
-            |> Some
-        (8, _) =>
-          msg.default_symbol_visibility = reader
-            |> @lib.read_enum()
-            |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.field_presence = reader
+              |> @lib.read_enum()
+              |> FeatureSet_FieldPresence::from_enum
+              |> Some
+          (2, _) =>
+            msg.enum_type = reader
+              |> @lib.read_enum()
+              |> FeatureSet_EnumType::from_enum
+              |> Some
+          (3, _) =>
+            msg.repeated_field_encoding = reader
+              |> @lib.read_enum()
+              |> FeatureSet_RepeatedFieldEncoding::from_enum
+              |> Some
+          (4, _) =>
+            msg.utf8_validation = reader
+              |> @lib.read_enum()
+              |> FeatureSet_Utf8Validation::from_enum
+              |> Some
+          (5, _) =>
+            msg.message_encoding = reader
+              |> @lib.read_enum()
+              |> FeatureSet_MessageEncoding::from_enum
+              |> Some
+          (6, _) =>
+            msg.json_format = reader
+              |> @lib.read_enum()
+              |> FeatureSet_JsonFormat::from_enum
+              |> Some
+          (7, _) =>
+            msg.enforce_naming_style = reader
+              |> @lib.read_enum()
+              |> FeatureSet_EnforceNamingStyle::from_enum
+              |> Some
+          (8, _) =>
+            msg.default_symbol_visibility = reader
+              |> @lib.read_enum()
+              |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -8603,55 +8493,54 @@ pub impl @lib.AsyncRead for FeatureSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FeatureSet raise {
   let msg = FeatureSet::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.field_presence = reader
-            |> @lib.async_read_enum()
-            |> FeatureSet_FieldPresence::from_enum
-            |> Some
-        (2, _) =>
-          msg.enum_type = reader
-            |> @lib.async_read_enum()
-            |> FeatureSet_EnumType::from_enum
-            |> Some
-        (3, _) =>
-          msg.repeated_field_encoding = reader
-            |> @lib.async_read_enum()
-            |> FeatureSet_RepeatedFieldEncoding::from_enum
-            |> Some
-        (4, _) =>
-          msg.utf8_validation = reader
-            |> @lib.async_read_enum()
-            |> FeatureSet_Utf8Validation::from_enum
-            |> Some
-        (5, _) =>
-          msg.message_encoding = reader
-            |> @lib.async_read_enum()
-            |> FeatureSet_MessageEncoding::from_enum
-            |> Some
-        (6, _) =>
-          msg.json_format = reader
-            |> @lib.async_read_enum()
-            |> FeatureSet_JsonFormat::from_enum
-            |> Some
-        (7, _) =>
-          msg.enforce_naming_style = reader
-            |> @lib.async_read_enum()
-            |> FeatureSet_EnforceNamingStyle::from_enum
-            |> Some
-        (8, _) =>
-          msg.default_symbol_visibility = reader
-            |> @lib.async_read_enum()
-            |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.field_presence = reader
+              |> @lib.async_read_enum()
+              |> FeatureSet_FieldPresence::from_enum
+              |> Some
+          (2, _) =>
+            msg.enum_type = reader
+              |> @lib.async_read_enum()
+              |> FeatureSet_EnumType::from_enum
+              |> Some
+          (3, _) =>
+            msg.repeated_field_encoding = reader
+              |> @lib.async_read_enum()
+              |> FeatureSet_RepeatedFieldEncoding::from_enum
+              |> Some
+          (4, _) =>
+            msg.utf8_validation = reader
+              |> @lib.async_read_enum()
+              |> FeatureSet_Utf8Validation::from_enum
+              |> Some
+          (5, _) =>
+            msg.message_encoding = reader
+              |> @lib.async_read_enum()
+              |> FeatureSet_MessageEncoding::from_enum
+              |> Some
+          (6, _) =>
+            msg.json_format = reader
+              |> @lib.async_read_enum()
+              |> FeatureSet_JsonFormat::from_enum
+              |> Some
+          (7, _) =>
+            msg.enforce_naming_style = reader
+              |> @lib.async_read_enum()
+              |> FeatureSet_EnforceNamingStyle::from_enum
+              |> Some
+          (8, _) =>
+            msg.default_symbol_visibility = reader
+              |> @lib.async_read_enum()
+              |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -8754,23 +8643,26 @@ pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (3, _) =>
-          msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-        (4, _) =>
-          msg.overridable_features = (reader |> @lib.read_message() : FeatureSet)
-            |> Some
-        (5, _) =>
-          msg.fixed_features = (reader |> @lib.read_message() : FeatureSet)
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (3, _) =>
+            msg.edition = reader
+              |> @lib.read_enum()
+              |> Edition::from_enum
+              |> Some
+          (4, _) =>
+            msg.overridable_features = (
+                reader |> @lib.read_message() : FeatureSet)
+              |> Some
+          (5, _) =>
+            msg.fixed_features = (reader |> @lib.read_message() : FeatureSet)
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -8786,13 +8678,11 @@ pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with fn writ
   }
   if self.overridable_features is Some(v) {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.fixed_features is Some(v) {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -8848,27 +8738,27 @@ pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn 
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (3, _) =>
-          msg.edition = reader
-            |> @lib.async_read_enum()
-            |> Edition::from_enum
-            |> Some
-        (4, _) =>
-          msg.overridable_features = (
-              reader |> @lib.async_read_message() : FeatureSet)
-            |> Some
-        (5, _) =>
-          msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet)
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (3, _) =>
+            msg.edition = reader
+              |> @lib.async_read_enum()
+              |> Edition::from_enum
+              |> Some
+          (4, _) =>
+            msg.overridable_features = (
+                reader |> @lib.async_read_message() : FeatureSet)
+              |> Some
+          (5, _) =>
+            msg.fixed_features = (
+                reader |> @lib.async_read_message() : FeatureSet)
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -8884,13 +8774,11 @@ pub impl @lib.AsyncWrite for FeatureSetDefaults_FeatureSetEditionDefault with fn
   }
   if self.overridable_features is Some(v) {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.fixed_features is Some(v) {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }
 
@@ -8943,31 +8831,30 @@ pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.defaults.push(
-            (
-              reader |> @lib.read_message() :
-              FeatureSetDefaults_FeatureSetEditionDefault),
-          )
-        (4, _) =>
-          msg.minimum_edition = reader
-            |> @lib.read_enum()
-            |> Edition::from_enum
-            |> Some
-        (5, _) =>
-          msg.maximum_edition = reader
-            |> @lib.read_enum()
-            |> Edition::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.defaults.push(
+              (
+                reader |> @lib.read_message() :
+                FeatureSetDefaults_FeatureSetEditionDefault),
+            )
+          (4, _) =>
+            msg.minimum_edition = reader
+              |> @lib.read_enum()
+              |> Edition::from_enum
+              |> Some
+          (5, _) =>
+            msg.maximum_edition = reader
+              |> @lib.read_enum()
+              |> Edition::from_enum
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -8979,8 +8866,7 @@ pub impl @lib.Write for FeatureSetDefaults with fn write(
 ) -> Unit raise {
   for item in self.defaults {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.minimum_edition is Some(v) {
     writer |> @lib.write_varint(32UL)
@@ -9039,31 +8925,30 @@ pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.defaults.push(
-            (
-              reader |> @lib.async_read_message() :
-              FeatureSetDefaults_FeatureSetEditionDefault),
-          )
-        (4, _) =>
-          msg.minimum_edition = reader
-            |> @lib.async_read_enum()
-            |> Edition::from_enum
-            |> Some
-        (5, _) =>
-          msg.maximum_edition = reader
-            |> @lib.async_read_enum()
-            |> Edition::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.defaults.push(
+              (
+                reader |> @lib.async_read_message() :
+                FeatureSetDefaults_FeatureSetEditionDefault),
+            )
+          (4, _) =>
+            msg.minimum_edition = reader
+              |> @lib.async_read_enum()
+              |> Edition::from_enum
+              |> Some
+          (5, _) =>
+            msg.maximum_edition = reader
+              |> @lib.async_read_enum()
+              |> Edition::from_enum
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -9075,8 +8960,7 @@ pub impl @lib.AsyncWrite for FeatureSetDefaults with fn write(
 ) -> Unit raise {
   for item in self.defaults {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.minimum_edition is Some(v) {
     writer |> @lib.async_write_varint(32UL)
@@ -9171,29 +9055,28 @@ pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, 2) =>
-          msg.path.push_iter(
-            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-          )
-        (1, 0) => msg.path.push(reader |> @lib.read_int32())
-        (2, 2) =>
-          msg.span.push_iter(
-            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-          )
-        (2, 0) => msg.span.push(reader |> @lib.read_int32())
-        (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
-        (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
-        (6, _) =>
-          msg.leading_detached_comments.push(reader |> @lib.read_string())
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, 2) =>
+            msg.path.push_iter(
+              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+            )
+          (1, 0) => msg.path.push(reader |> @lib.read_int32())
+          (2, 2) =>
+            msg.span.push_iter(
+              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+            )
+          (2, 0) => msg.span.push(reader |> @lib.read_int32())
+          (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
+          (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
+          (6, _) =>
+            msg.leading_detached_comments.push(reader |> @lib.read_string())
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -9292,31 +9175,32 @@ pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, 2) =>
-          msg.path.push_iter(
-            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-          )
-        (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
-        (2, 2) =>
-          msg.span.push_iter(
-            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-          )
-        (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
-        (3, _) =>
-          msg.leading_comments = reader |> @lib.async_read_string() |> Some
-        (4, _) =>
-          msg.trailing_comments = reader |> @lib.async_read_string() |> Some
-        (6, _) =>
-          msg.leading_detached_comments.push(reader |> @lib.async_read_string())
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, 2) =>
+            msg.path.push_iter(
+              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+            )
+          (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+          (2, 2) =>
+            msg.span.push_iter(
+              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+            )
+          (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
+          (3, _) =>
+            msg.leading_comments = reader |> @lib.async_read_string() |> Some
+          (4, _) =>
+            msg.trailing_comments = reader |> @lib.async_read_string() |> Some
+          (6, _) =>
+            msg.leading_detached_comments.push(
+              reader |> @lib.async_read_string(),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -9391,19 +9275,18 @@ pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.location.push(
-            (reader |> @lib.read_message() : SourceCodeInfo_Location),
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.location.push(
+              (reader |> @lib.read_message() : SourceCodeInfo_Location),
+            )
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -9415,8 +9298,7 @@ pub impl @lib.Write for SourceCodeInfo with fn write(
 ) -> Unit raise {
   for item in self.location {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -9453,19 +9335,18 @@ pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.location.push(
-            (reader |> @lib.async_read_message() : SourceCodeInfo_Location),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.location.push(
+              (reader |> @lib.async_read_message() : SourceCodeInfo_Location),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -9477,8 +9358,7 @@ pub impl @lib.AsyncWrite for SourceCodeInfo with fn write(
 ) -> Unit raise {
   for item in self.location {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -9619,28 +9499,27 @@ pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, 2) =>
-          msg.path.push_iter(
-            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-          )
-        (1, 0) => msg.path.push(reader |> @lib.read_int32())
-        (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
-        (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
-        (4, _) => msg.end = reader |> @lib.read_int32() |> Some
-        (5, _) =>
-          msg.semantic = reader
-            |> @lib.read_enum()
-            |> GeneratedCodeInfo_Annotation_Semantic::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, 2) =>
+            msg.path.push_iter(
+              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+            )
+          (1, 0) => msg.path.push(reader |> @lib.read_int32())
+          (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
+          (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
+          (4, _) => msg.end = reader |> @lib.read_int32() |> Some
+          (5, _) =>
+            msg.semantic = reader
+              |> @lib.read_enum()
+              |> GeneratedCodeInfo_Annotation_Semantic::from_enum
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -9733,28 +9612,27 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, 2) =>
-          msg.path.push_iter(
-            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-          )
-        (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
-        (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
-        (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
-        (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-        (5, _) =>
-          msg.semantic = reader
-            |> @lib.async_read_enum()
-            |> GeneratedCodeInfo_Annotation_Semantic::from_enum
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, 2) =>
+            msg.path.push_iter(
+              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+            )
+          (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+          (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
+          (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+          (5, _) =>
+            msg.semantic = reader
+              |> @lib.async_read_enum()
+              |> GeneratedCodeInfo_Annotation_Semantic::from_enum
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -9825,19 +9703,18 @@ pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.annotation.push(
-            (reader |> @lib.read_message() : GeneratedCodeInfo_Annotation),
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.annotation.push(
+              (reader |> @lib.read_message() : GeneratedCodeInfo_Annotation),
+            )
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -9849,8 +9726,7 @@ pub impl @lib.Write for GeneratedCodeInfo with fn write(
 ) -> Unit raise {
   for item in self.annotation {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -9889,19 +9765,20 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.annotation.push(
-            (reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.annotation.push(
+              (
+                reader |> @lib.async_read_message() :
+                GeneratedCodeInfo_Annotation),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -9913,7 +9790,6 @@ pub impl @lib.AsyncWrite for GeneratedCodeInfo with fn write(
 ) -> Unit raise {
   for item in self.annotation {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }

--- a/lib/google/protobuf/descriptor.mbt
+++ b/lib/google/protobuf/descriptor.mbt
@@ -217,15 +217,11 @@ pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -277,17 +273,14 @@ pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.file.push(
-              (reader |> @lib.async_read_message() : FileDescriptorProto),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.file.push(
+          (reader |> @lib.async_read_message() : FileDescriptorProto),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -474,55 +467,45 @@ pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
-          (3, _) => msg.dependency.push(reader |> @lib.read_string())
-          (10, 2) =>
-            msg.public_dependency.push_iter(
-              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-            )
-          (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
-          (11, 2) =>
-            msg.weak_dependency.push_iter(
-              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-            )
-          (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
-          (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
-          (4, _) =>
-            msg.message_type.push(
-              (reader |> @lib.read_message() : DescriptorProto),
-            )
-          (5, _) =>
-            msg.enum_type.push(
-              (reader |> @lib.read_message() : EnumDescriptorProto),
-            )
-          (6, _) =>
-            msg.service.push(
-              (reader |> @lib.read_message() : ServiceDescriptorProto),
-            )
-          (7, _) =>
-            msg.extension.push(
-              (reader |> @lib.read_message() : FieldDescriptorProto),
-            )
-          (8, _) =>
-            msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
-          (9, _) =>
-            msg.source_code_info = (
-                reader |> @lib.read_message() : SourceCodeInfo)
-              |> Some
-          (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
-          (14, _) =>
-            msg.edition = reader
-              |> @lib.read_enum()
-              |> Edition::from_enum
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
+      (3, _) => msg.dependency.push(reader |> @lib.read_string())
+      (10, 2) =>
+        msg.public_dependency.push_iter(
+          (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+        )
+      (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
+      (11, 2) =>
+        msg.weak_dependency.push_iter(
+          (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+        )
+      (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
+      (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
+      (4, _) =>
+        msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
+      (5, _) =>
+        msg.enum_type.push(
+          (reader |> @lib.read_message() : EnumDescriptorProto),
+        )
+      (6, _) =>
+        msg.service.push(
+          (reader |> @lib.read_message() : ServiceDescriptorProto),
+        )
+      (7, _) =>
+        msg.extension.push(
+          (reader |> @lib.read_message() : FieldDescriptorProto),
+        )
+      (8, _) =>
+        msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
+      (9, _) =>
+        msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo)
+          |> Some
+      (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
+      (14, _) =>
+        msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -695,58 +678,53 @@ pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
-          (10, 2) =>
-            msg.public_dependency.push_iter(
-              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-            )
-          (10, 0) =>
-            msg.public_dependency.push(reader |> @lib.async_read_int32())
-          (11, 2) =>
-            msg.weak_dependency.push_iter(
-              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-            )
-          (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
-          (15, _) =>
-            msg.option_dependency.push(reader |> @lib.async_read_string())
-          (4, _) =>
-            msg.message_type.push(
-              (reader |> @lib.async_read_message() : DescriptorProto),
-            )
-          (5, _) =>
-            msg.enum_type.push(
-              (reader |> @lib.async_read_message() : EnumDescriptorProto),
-            )
-          (6, _) =>
-            msg.service.push(
-              (reader |> @lib.async_read_message() : ServiceDescriptorProto),
-            )
-          (7, _) =>
-            msg.extension.push(
-              (reader |> @lib.async_read_message() : FieldDescriptorProto),
-            )
-          (8, _) =>
-            msg.options = (reader |> @lib.async_read_message() : FileOptions)
-              |> Some
-          (9, _) =>
-            msg.source_code_info = (
-                reader |> @lib.async_read_message() : SourceCodeInfo)
-              |> Some
-          (12, _) => msg.syntax = reader |> @lib.async_read_string() |> Some
-          (14, _) =>
-            msg.edition = reader
-              |> @lib.async_read_enum()
-              |> Edition::from_enum
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
+      (10, 2) =>
+        msg.public_dependency.push_iter(
+          (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+        )
+      (10, 0) => msg.public_dependency.push(reader |> @lib.async_read_int32())
+      (11, 2) =>
+        msg.weak_dependency.push_iter(
+          (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+        )
+      (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
+      (15, _) => msg.option_dependency.push(reader |> @lib.async_read_string())
+      (4, _) =>
+        msg.message_type.push(
+          (reader |> @lib.async_read_message() : DescriptorProto),
+        )
+      (5, _) =>
+        msg.enum_type.push(
+          (reader |> @lib.async_read_message() : EnumDescriptorProto),
+        )
+      (6, _) =>
+        msg.service.push(
+          (reader |> @lib.async_read_message() : ServiceDescriptorProto),
+        )
+      (7, _) =>
+        msg.extension.push(
+          (reader |> @lib.async_read_message() : FieldDescriptorProto),
+        )
+      (8, _) =>
+        msg.options = (reader |> @lib.async_read_message() : FileOptions)
+          |> Some
+      (9, _) =>
+        msg.source_code_info = (
+            reader |> @lib.async_read_message() : SourceCodeInfo)
+          |> Some
+      (12, _) => msg.syntax = reader |> @lib.async_read_string() |> Some
+      (14, _) =>
+        msg.edition = reader
+          |> @lib.async_read_enum()
+          |> Edition::from_enum
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -860,18 +838,14 @@ pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-          (3, _) =>
-            msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions)
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+      (3, _) =>
+        msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions)
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -942,19 +916,16 @@ pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_lim
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-          (3, _) =>
-            msg.options = (
-                reader |> @lib.async_read_message() : ExtensionRangeOptions)
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+      (3, _) =>
+        msg.options = (
+            reader |> @lib.async_read_message() : ExtensionRangeOptions)
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1015,15 +986,11 @@ pub impl @lib.Read for DescriptorProto_ReservedRange with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1084,15 +1051,12 @@ pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with fn read_with_limi
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1258,51 +1222,42 @@ pub impl @lib.Read for DescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) =>
-            msg.field.push(
-              (reader |> @lib.read_message() : FieldDescriptorProto),
-            )
-          (6, _) =>
-            msg.extension.push(
-              (reader |> @lib.read_message() : FieldDescriptorProto),
-            )
-          (3, _) =>
-            msg.nested_type.push(
-              (reader |> @lib.read_message() : DescriptorProto),
-            )
-          (4, _) =>
-            msg.enum_type.push(
-              (reader |> @lib.read_message() : EnumDescriptorProto),
-            )
-          (5, _) =>
-            msg.extension_range.push(
-              (reader |> @lib.read_message() : DescriptorProto_ExtensionRange),
-            )
-          (8, _) =>
-            msg.oneof_decl.push(
-              (reader |> @lib.read_message() : OneofDescriptorProto),
-            )
-          (7, _) =>
-            msg.options = (reader |> @lib.read_message() : MessageOptions)
-              |> Some
-          (9, _) =>
-            msg.reserved_range.push(
-              (reader |> @lib.read_message() : DescriptorProto_ReservedRange),
-            )
-          (10, _) => msg.reserved_name.push(reader |> @lib.read_string())
-          (11, _) =>
-            msg.visibility = reader
-              |> @lib.read_enum()
-              |> SymbolVisibility::from_enum
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) =>
+        msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
+      (6, _) =>
+        msg.extension.push(
+          (reader |> @lib.read_message() : FieldDescriptorProto),
+        )
+      (3, _) =>
+        msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto))
+      (4, _) =>
+        msg.enum_type.push(
+          (reader |> @lib.read_message() : EnumDescriptorProto),
+        )
+      (5, _) =>
+        msg.extension_range.push(
+          (reader |> @lib.read_message() : DescriptorProto_ExtensionRange),
+        )
+      (8, _) =>
+        msg.oneof_decl.push(
+          (reader |> @lib.read_message() : OneofDescriptorProto),
+        )
+      (7, _) =>
+        msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
+      (9, _) =>
+        msg.reserved_range.push(
+          (reader |> @lib.read_message() : DescriptorProto_ReservedRange),
+        )
+      (10, _) => msg.reserved_name.push(reader |> @lib.read_string())
+      (11, _) =>
+        msg.visibility = reader
+          |> @lib.read_enum()
+          |> SymbolVisibility::from_enum
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1446,55 +1401,48 @@ pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) =>
-            msg.field.push(
-              (reader |> @lib.async_read_message() : FieldDescriptorProto),
-            )
-          (6, _) =>
-            msg.extension.push(
-              (reader |> @lib.async_read_message() : FieldDescriptorProto),
-            )
-          (3, _) =>
-            msg.nested_type.push(
-              (reader |> @lib.async_read_message() : DescriptorProto),
-            )
-          (4, _) =>
-            msg.enum_type.push(
-              (reader |> @lib.async_read_message() : EnumDescriptorProto),
-            )
-          (5, _) =>
-            msg.extension_range.push(
-              (
-                reader |> @lib.async_read_message() :
-                DescriptorProto_ExtensionRange),
-            )
-          (8, _) =>
-            msg.oneof_decl.push(
-              (reader |> @lib.async_read_message() : OneofDescriptorProto),
-            )
-          (7, _) =>
-            msg.options = (reader |> @lib.async_read_message() : MessageOptions)
-              |> Some
-          (9, _) =>
-            msg.reserved_range.push(
-              (
-                reader |> @lib.async_read_message() :
-                DescriptorProto_ReservedRange),
-            )
-          (10, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
-          (11, _) =>
-            msg.visibility = reader
-              |> @lib.async_read_enum()
-              |> SymbolVisibility::from_enum
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) =>
+        msg.field.push(
+          (reader |> @lib.async_read_message() : FieldDescriptorProto),
+        )
+      (6, _) =>
+        msg.extension.push(
+          (reader |> @lib.async_read_message() : FieldDescriptorProto),
+        )
+      (3, _) =>
+        msg.nested_type.push(
+          (reader |> @lib.async_read_message() : DescriptorProto),
+        )
+      (4, _) =>
+        msg.enum_type.push(
+          (reader |> @lib.async_read_message() : EnumDescriptorProto),
+        )
+      (5, _) =>
+        msg.extension_range.push(
+          (reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange),
+        )
+      (8, _) =>
+        msg.oneof_decl.push(
+          (reader |> @lib.async_read_message() : OneofDescriptorProto),
+        )
+      (7, _) =>
+        msg.options = (reader |> @lib.async_read_message() : MessageOptions)
+          |> Some
+      (9, _) =>
+        msg.reserved_range.push(
+          (reader |> @lib.async_read_message() : DescriptorProto_ReservedRange),
+        )
+      (10, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
+      (11, _) =>
+        msg.visibility = reader
+          |> @lib.async_read_enum()
+          |> SymbolVisibility::from_enum
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1689,18 +1637,14 @@ pub impl @lib.Read for ExtensionRangeOptions_Declaration with fn read_with_limit
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.number = reader |> @lib.read_int32() |> Some
-          (2, _) => msg.full_name = reader |> @lib.read_string() |> Some
-          (3, _) => msg.type_ = reader |> @lib.read_string() |> Some
-          (5, _) => msg.reserved = reader |> @lib.read_bool() |> Some
-          (6, _) => msg.repeated = reader |> @lib.read_bool() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.number = reader |> @lib.read_int32() |> Some
+      (2, _) => msg.full_name = reader |> @lib.read_string() |> Some
+      (3, _) => msg.type_ = reader |> @lib.read_string() |> Some
+      (5, _) => msg.reserved = reader |> @lib.read_bool() |> Some
+      (6, _) => msg.repeated = reader |> @lib.read_bool() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1791,18 +1735,15 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with fn read_with_
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-          (2, _) => msg.full_name = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
-          (5, _) => msg.reserved = reader |> @lib.async_read_bool() |> Some
-          (6, _) => msg.repeated = reader |> @lib.async_read_bool() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+      (2, _) => msg.full_name = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
+      (5, _) => msg.reserved = reader |> @lib.async_read_bool() |> Some
+      (6, _) => msg.repeated = reader |> @lib.async_read_bool() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1903,28 +1844,24 @@ pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.read_message() : UninterpretedOption),
-            )
-          (2, _) =>
-            msg.declaration.push(
-              (reader |> @lib.read_message() : ExtensionRangeOptions_Declaration),
-            )
-          (50, _) =>
-            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (3, _) =>
-            msg.verification = reader
-              |> @lib.read_enum()
-              |> ExtensionRangeOptions_VerificationState::from_enum
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.read_message() : UninterpretedOption),
+        )
+      (2, _) =>
+        msg.declaration.push(
+          (reader |> @lib.read_message() : ExtensionRangeOptions_Declaration),
+        )
+      (50, _) =>
+        msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (3, _) =>
+        msg.verification = reader
+          |> @lib.read_enum()
+          |> ExtensionRangeOptions_VerificationState::from_enum
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2006,31 +1943,28 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.async_read_message() : UninterpretedOption),
-            )
-          (2, _) =>
-            msg.declaration.push(
-              (
-                reader |> @lib.async_read_message() :
-                ExtensionRangeOptions_Declaration),
-            )
-          (50, _) =>
-            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-              |> Some
-          (3, _) =>
-            msg.verification = reader
-              |> @lib.async_read_enum()
-              |> ExtensionRangeOptions_VerificationState::from_enum
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.async_read_message() : UninterpretedOption),
+        )
+      (2, _) =>
+        msg.declaration.push(
+          (
+            reader |> @lib.async_read_message() :
+            ExtensionRangeOptions_Declaration),
+        )
+      (50, _) =>
+        msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+          |> Some
+      (3, _) =>
+        msg.verification = reader
+          |> @lib.async_read_enum()
+          |> ExtensionRangeOptions_VerificationState::from_enum
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2422,33 +2356,29 @@ pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (3, _) => msg.number = reader |> @lib.read_int32() |> Some
-          (4, _) =>
-            msg.label = reader
-              |> @lib.read_enum()
-              |> FieldDescriptorProto_Label::from_enum
-              |> Some
-          (5, _) =>
-            msg.type_ = reader
-              |> @lib.read_enum()
-              |> FieldDescriptorProto_Type::from_enum
-              |> Some
-          (6, _) => msg.type_name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.extendee = reader |> @lib.read_string() |> Some
-          (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
-          (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
-          (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
-          (8, _) =>
-            msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
-          (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (3, _) => msg.number = reader |> @lib.read_int32() |> Some
+      (4, _) =>
+        msg.label = reader
+          |> @lib.read_enum()
+          |> FieldDescriptorProto_Label::from_enum
+          |> Some
+      (5, _) =>
+        msg.type_ = reader
+          |> @lib.read_enum()
+          |> FieldDescriptorProto_Type::from_enum
+          |> Some
+      (6, _) => msg.type_name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.extendee = reader |> @lib.read_string() |> Some
+      (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
+      (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
+      (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
+      (8, _) =>
+        msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
+      (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2597,36 +2527,31 @@ pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-          (4, _) =>
-            msg.label = reader
-              |> @lib.async_read_enum()
-              |> FieldDescriptorProto_Label::from_enum
-              |> Some
-          (5, _) =>
-            msg.type_ = reader
-              |> @lib.async_read_enum()
-              |> FieldDescriptorProto_Type::from_enum
-              |> Some
-          (6, _) => msg.type_name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.extendee = reader |> @lib.async_read_string() |> Some
-          (7, _) =>
-            msg.default_value = reader |> @lib.async_read_string() |> Some
-          (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
-          (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
-          (8, _) =>
-            msg.options = (reader |> @lib.async_read_message() : FieldOptions)
-              |> Some
-          (17, _) =>
-            msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+      (4, _) =>
+        msg.label = reader
+          |> @lib.async_read_enum()
+          |> FieldDescriptorProto_Label::from_enum
+          |> Some
+      (5, _) =>
+        msg.type_ = reader
+          |> @lib.async_read_enum()
+          |> FieldDescriptorProto_Type::from_enum
+          |> Some
+      (6, _) => msg.type_name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.extendee = reader |> @lib.async_read_string() |> Some
+      (7, _) => msg.default_value = reader |> @lib.async_read_string() |> Some
+      (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
+      (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
+      (8, _) =>
+        msg.options = (reader |> @lib.async_read_message() : FieldOptions)
+          |> Some
+      (17, _) => msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2727,16 +2652,12 @@ pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) =>
-            msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) =>
+        msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2798,17 +2719,14 @@ pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) =>
-            msg.options = (reader |> @lib.async_read_message() : OneofOptions)
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) =>
+        msg.options = (reader |> @lib.async_read_message() : OneofOptions)
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2867,15 +2785,11 @@ pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with fn read_with_l
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2936,15 +2850,12 @@ pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with fn read_w
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -3055,32 +2966,26 @@ pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) =>
-            msg.value.push(
-              (reader |> @lib.read_message() : EnumValueDescriptorProto),
-            )
-          (3, _) =>
-            msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
-          (4, _) =>
-            msg.reserved_range.push(
-              (
-                reader |> @lib.read_message() :
-                EnumDescriptorProto_EnumReservedRange),
-            )
-          (5, _) => msg.reserved_name.push(reader |> @lib.read_string())
-          (6, _) =>
-            msg.visibility = reader
-              |> @lib.read_enum()
-              |> SymbolVisibility::from_enum
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) =>
+        msg.value.push(
+          (reader |> @lib.read_message() : EnumValueDescriptorProto),
+        )
+      (3, _) =>
+        msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
+      (4, _) =>
+        msg.reserved_range.push(
+          (reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange),
+        )
+      (5, _) => msg.reserved_name.push(reader |> @lib.read_string())
+      (6, _) =>
+        msg.visibility = reader
+          |> @lib.read_enum()
+          |> SymbolVisibility::from_enum
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -3179,33 +3084,30 @@ pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) =>
-            msg.value.push(
-              (reader |> @lib.async_read_message() : EnumValueDescriptorProto),
-            )
-          (3, _) =>
-            msg.options = (reader |> @lib.async_read_message() : EnumOptions)
-              |> Some
-          (4, _) =>
-            msg.reserved_range.push(
-              (
-                reader |> @lib.async_read_message() :
-                EnumDescriptorProto_EnumReservedRange),
-            )
-          (5, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
-          (6, _) =>
-            msg.visibility = reader
-              |> @lib.async_read_enum()
-              |> SymbolVisibility::from_enum
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) =>
+        msg.value.push(
+          (reader |> @lib.async_read_message() : EnumValueDescriptorProto),
+        )
+      (3, _) =>
+        msg.options = (reader |> @lib.async_read_message() : EnumOptions)
+          |> Some
+      (4, _) =>
+        msg.reserved_range.push(
+          (
+            reader |> @lib.async_read_message() :
+            EnumDescriptorProto_EnumReservedRange),
+        )
+      (5, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
+      (6, _) =>
+        msg.visibility = reader
+          |> @lib.async_read_enum()
+          |> SymbolVisibility::from_enum
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -3291,18 +3193,13 @@ pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.number = reader |> @lib.read_int32() |> Some
-          (3, _) =>
-            msg.options = (reader |> @lib.read_message() : EnumValueOptions)
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.number = reader |> @lib.read_int32() |> Some
+      (3, _) =>
+        msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -3373,19 +3270,15 @@ pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-          (3, _) =>
-            msg.options = (
-                reader |> @lib.async_read_message() : EnumValueOptions)
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+      (3, _) =>
+        msg.options = (reader |> @lib.async_read_message() : EnumValueOptions)
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -3463,21 +3356,16 @@ pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) =>
-            msg.method_.push(
-              (reader |> @lib.read_message() : MethodDescriptorProto),
-            )
-          (3, _) =>
-            msg.options = (reader |> @lib.read_message() : ServiceOptions)
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) =>
+        msg.method_.push(
+          (reader |> @lib.read_message() : MethodDescriptorProto),
+        )
+      (3, _) =>
+        msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -3548,21 +3436,18 @@ pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) =>
-            msg.method_.push(
-              (reader |> @lib.async_read_message() : MethodDescriptorProto),
-            )
-          (3, _) =>
-            msg.options = (reader |> @lib.async_read_message() : ServiceOptions)
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) =>
+        msg.method_.push(
+          (reader |> @lib.async_read_message() : MethodDescriptorProto),
+        )
+      (3, _) =>
+        msg.options = (reader |> @lib.async_read_message() : ServiceOptions)
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -3673,21 +3558,16 @@ pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
-          (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
-          (4, _) =>
-            msg.options = (reader |> @lib.read_message() : MethodOptions)
-              |> Some
-          (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
-          (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
+      (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
+      (4, _) =>
+        msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
+      (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
+      (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -3789,23 +3669,18 @@ pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
-          (4, _) =>
-            msg.options = (reader |> @lib.async_read_message() : MethodOptions)
-              |> Some
-          (5, _) =>
-            msg.client_streaming = reader |> @lib.async_read_bool() |> Some
-          (6, _) =>
-            msg.server_streaming = reader |> @lib.async_read_bool() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
+      (4, _) =>
+        msg.options = (reader |> @lib.async_read_message() : MethodOptions)
+          |> Some
+      (5, _) => msg.client_streaming = reader |> @lib.async_read_bool() |> Some
+      (6, _) => msg.server_streaming = reader |> @lib.async_read_bool() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -4137,53 +4012,40 @@ pub impl @lib.Read for FileOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FileOptions raise {
   let msg = FileOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.java_package = reader |> @lib.read_string() |> Some
-          (8, _) =>
-            msg.java_outer_classname = reader |> @lib.read_string() |> Some
-          (10, _) =>
-            msg.java_multiple_files = reader |> @lib.read_bool() |> Some
-          (20, _) =>
-            msg.java_generate_equals_and_hash = reader
-              |> @lib.read_bool()
-              |> Some
-          (27, _) =>
-            msg.java_string_check_utf8 = reader |> @lib.read_bool() |> Some
-          (9, _) =>
-            msg.optimize_for = reader
-              |> @lib.read_enum()
-              |> FileOptions_OptimizeMode::from_enum
-              |> Some
-          (11, _) => msg.go_package = reader |> @lib.read_string() |> Some
-          (16, _) =>
-            msg.cc_generic_services = reader |> @lib.read_bool() |> Some
-          (17, _) =>
-            msg.java_generic_services = reader |> @lib.read_bool() |> Some
-          (18, _) =>
-            msg.py_generic_services = reader |> @lib.read_bool() |> Some
-          (23, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (31, _) => msg.cc_enable_arenas = reader |> @lib.read_bool() |> Some
-          (36, _) =>
-            msg.objc_class_prefix = reader |> @lib.read_string() |> Some
-          (37, _) => msg.csharp_namespace = reader |> @lib.read_string() |> Some
-          (39, _) => msg.swift_prefix = reader |> @lib.read_string() |> Some
-          (40, _) => msg.php_class_prefix = reader |> @lib.read_string() |> Some
-          (41, _) => msg.php_namespace = reader |> @lib.read_string() |> Some
-          (44, _) =>
-            msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
-          (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
-          (50, _) =>
-            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.java_package = reader |> @lib.read_string() |> Some
+      (8, _) => msg.java_outer_classname = reader |> @lib.read_string() |> Some
+      (10, _) => msg.java_multiple_files = reader |> @lib.read_bool() |> Some
+      (20, _) =>
+        msg.java_generate_equals_and_hash = reader |> @lib.read_bool() |> Some
+      (27, _) => msg.java_string_check_utf8 = reader |> @lib.read_bool() |> Some
+      (9, _) =>
+        msg.optimize_for = reader
+          |> @lib.read_enum()
+          |> FileOptions_OptimizeMode::from_enum
+          |> Some
+      (11, _) => msg.go_package = reader |> @lib.read_string() |> Some
+      (16, _) => msg.cc_generic_services = reader |> @lib.read_bool() |> Some
+      (17, _) => msg.java_generic_services = reader |> @lib.read_bool() |> Some
+      (18, _) => msg.py_generic_services = reader |> @lib.read_bool() |> Some
+      (23, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (31, _) => msg.cc_enable_arenas = reader |> @lib.read_bool() |> Some
+      (36, _) => msg.objc_class_prefix = reader |> @lib.read_string() |> Some
+      (37, _) => msg.csharp_namespace = reader |> @lib.read_string() |> Some
+      (39, _) => msg.swift_prefix = reader |> @lib.read_string() |> Some
+      (40, _) => msg.php_class_prefix = reader |> @lib.read_string() |> Some
+      (41, _) => msg.php_namespace = reader |> @lib.read_string() |> Some
+      (44, _) =>
+        msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
+      (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
+      (50, _) =>
+        msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -4436,67 +4298,53 @@ pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FileOptions raise {
   let msg = FileOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.java_package = reader |> @lib.async_read_string() |> Some
-          (8, _) =>
-            msg.java_outer_classname = reader
-              |> @lib.async_read_string()
-              |> Some
-          (10, _) =>
-            msg.java_multiple_files = reader |> @lib.async_read_bool() |> Some
-          (20, _) =>
-            msg.java_generate_equals_and_hash = reader
-              |> @lib.async_read_bool()
-              |> Some
-          (27, _) =>
-            msg.java_string_check_utf8 = reader
-              |> @lib.async_read_bool()
-              |> Some
-          (9, _) =>
-            msg.optimize_for = reader
-              |> @lib.async_read_enum()
-              |> FileOptions_OptimizeMode::from_enum
-              |> Some
-          (11, _) => msg.go_package = reader |> @lib.async_read_string() |> Some
-          (16, _) =>
-            msg.cc_generic_services = reader |> @lib.async_read_bool() |> Some
-          (17, _) =>
-            msg.java_generic_services = reader |> @lib.async_read_bool() |> Some
-          (18, _) =>
-            msg.py_generic_services = reader |> @lib.async_read_bool() |> Some
-          (23, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (31, _) =>
-            msg.cc_enable_arenas = reader |> @lib.async_read_bool() |> Some
-          (36, _) =>
-            msg.objc_class_prefix = reader |> @lib.async_read_string() |> Some
-          (37, _) =>
-            msg.csharp_namespace = reader |> @lib.async_read_string() |> Some
-          (39, _) =>
-            msg.swift_prefix = reader |> @lib.async_read_string() |> Some
-          (40, _) =>
-            msg.php_class_prefix = reader |> @lib.async_read_string() |> Some
-          (41, _) =>
-            msg.php_namespace = reader |> @lib.async_read_string() |> Some
-          (44, _) =>
-            msg.php_metadata_namespace = reader
-              |> @lib.async_read_string()
-              |> Some
-          (45, _) =>
-            msg.ruby_package = reader |> @lib.async_read_string() |> Some
-          (50, _) =>
-            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-              |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.async_read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.java_package = reader |> @lib.async_read_string() |> Some
+      (8, _) =>
+        msg.java_outer_classname = reader |> @lib.async_read_string() |> Some
+      (10, _) =>
+        msg.java_multiple_files = reader |> @lib.async_read_bool() |> Some
+      (20, _) =>
+        msg.java_generate_equals_and_hash = reader
+          |> @lib.async_read_bool()
+          |> Some
+      (27, _) =>
+        msg.java_string_check_utf8 = reader |> @lib.async_read_bool() |> Some
+      (9, _) =>
+        msg.optimize_for = reader
+          |> @lib.async_read_enum()
+          |> FileOptions_OptimizeMode::from_enum
+          |> Some
+      (11, _) => msg.go_package = reader |> @lib.async_read_string() |> Some
+      (16, _) =>
+        msg.cc_generic_services = reader |> @lib.async_read_bool() |> Some
+      (17, _) =>
+        msg.java_generic_services = reader |> @lib.async_read_bool() |> Some
+      (18, _) =>
+        msg.py_generic_services = reader |> @lib.async_read_bool() |> Some
+      (23, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (31, _) => msg.cc_enable_arenas = reader |> @lib.async_read_bool() |> Some
+      (36, _) =>
+        msg.objc_class_prefix = reader |> @lib.async_read_string() |> Some
+      (37, _) =>
+        msg.csharp_namespace = reader |> @lib.async_read_string() |> Some
+      (39, _) => msg.swift_prefix = reader |> @lib.async_read_string() |> Some
+      (40, _) =>
+        msg.php_class_prefix = reader |> @lib.async_read_string() |> Some
+      (41, _) => msg.php_namespace = reader |> @lib.async_read_string() |> Some
+      (44, _) =>
+        msg.php_metadata_namespace = reader |> @lib.async_read_string() |> Some
+      (45, _) => msg.ruby_package = reader |> @lib.async_read_string() |> Some
+      (50, _) =>
+        msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+          |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.async_read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -4678,31 +4526,24 @@ pub impl @lib.Read for MessageOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MessageOptions raise {
   let msg = MessageOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.message_set_wire_format = reader |> @lib.read_bool() |> Some
-          (2, _) =>
-            msg.no_standard_descriptor_accessor = reader
-              |> @lib.read_bool()
-              |> Some
-          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (7, _) => msg.map_entry = reader |> @lib.read_bool() |> Some
-          (11, _) =>
-            msg.deprecated_legacy_json_field_conflicts = reader
-              |> @lib.read_bool()
-              |> Some
-          (12, _) =>
-            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.message_set_wire_format = reader |> @lib.read_bool() |> Some
+      (2, _) =>
+        msg.no_standard_descriptor_accessor = reader |> @lib.read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (7, _) => msg.map_entry = reader |> @lib.read_bool() |> Some
+      (11, _) =>
+        msg.deprecated_legacy_json_field_conflicts = reader
+          |> @lib.read_bool()
+          |> Some
+      (12, _) =>
+        msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -4816,34 +4657,29 @@ pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MessageOptions raise {
   let msg = MessageOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.message_set_wire_format = reader
-              |> @lib.async_read_bool()
-              |> Some
-          (2, _) =>
-            msg.no_standard_descriptor_accessor = reader
-              |> @lib.async_read_bool()
-              |> Some
-          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (7, _) => msg.map_entry = reader |> @lib.async_read_bool() |> Some
-          (11, _) =>
-            msg.deprecated_legacy_json_field_conflicts = reader
-              |> @lib.async_read_bool()
-              |> Some
-          (12, _) =>
-            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-              |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.async_read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.message_set_wire_format = reader |> @lib.async_read_bool() |> Some
+      (2, _) =>
+        msg.no_standard_descriptor_accessor = reader
+          |> @lib.async_read_bool()
+          |> Some
+      (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (7, _) => msg.map_entry = reader |> @lib.async_read_bool() |> Some
+      (11, _) =>
+        msg.deprecated_legacy_json_field_conflicts = reader
+          |> @lib.async_read_bool()
+          |> Some
+      (12, _) =>
+        msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+          |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.async_read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -5260,19 +5096,12 @@ pub impl @lib.Read for FieldOptions_EditionDefault with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (3, _) =>
-            msg.edition = reader
-              |> @lib.read_enum()
-              |> Edition::from_enum
-              |> Some
-          (2, _) => msg.value = reader |> @lib.read_string() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (3, _) =>
+        msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+      (2, _) => msg.value = reader |> @lib.read_string() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -5334,19 +5163,16 @@ pub impl @lib.AsyncRead for FieldOptions_EditionDefault with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (3, _) =>
-            msg.edition = reader
-              |> @lib.async_read_enum()
-              |> Edition::from_enum
-              |> Some
-          (2, _) => msg.value = reader |> @lib.async_read_string() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (3, _) =>
+        msg.edition = reader
+          |> @lib.async_read_enum()
+          |> Edition::from_enum
+          |> Some
+      (2, _) => msg.value = reader |> @lib.async_read_string() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -5427,30 +5253,25 @@ pub impl @lib.Read for FieldOptions_FeatureSupport with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.edition_introduced = reader
-              |> @lib.read_enum()
-              |> Edition::from_enum
-              |> Some
-          (2, _) =>
-            msg.edition_deprecated = reader
-              |> @lib.read_enum()
-              |> Edition::from_enum
-              |> Some
-          (3, _) =>
-            msg.deprecation_warning = reader |> @lib.read_string() |> Some
-          (4, _) =>
-            msg.edition_removed = reader
-              |> @lib.read_enum()
-              |> Edition::from_enum
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.edition_introduced = reader
+          |> @lib.read_enum()
+          |> Edition::from_enum
+          |> Some
+      (2, _) =>
+        msg.edition_deprecated = reader
+          |> @lib.read_enum()
+          |> Edition::from_enum
+          |> Some
+      (3, _) => msg.deprecation_warning = reader |> @lib.read_string() |> Some
+      (4, _) =>
+        msg.edition_removed = reader
+          |> @lib.read_enum()
+          |> Edition::from_enum
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -5533,30 +5354,27 @@ pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.edition_introduced = reader
-              |> @lib.async_read_enum()
-              |> Edition::from_enum
-              |> Some
-          (2, _) =>
-            msg.edition_deprecated = reader
-              |> @lib.async_read_enum()
-              |> Edition::from_enum
-              |> Some
-          (3, _) =>
-            msg.deprecation_warning = reader |> @lib.async_read_string() |> Some
-          (4, _) =>
-            msg.edition_removed = reader
-              |> @lib.async_read_enum()
-              |> Edition::from_enum
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.edition_introduced = reader
+          |> @lib.async_read_enum()
+          |> Edition::from_enum
+          |> Some
+      (2, _) =>
+        msg.edition_deprecated = reader
+          |> @lib.async_read_enum()
+          |> Edition::from_enum
+          |> Some
+      (3, _) =>
+        msg.deprecation_warning = reader |> @lib.async_read_string() |> Some
+      (4, _) =>
+        msg.edition_removed = reader
+          |> @lib.async_read_enum()
+          |> Edition::from_enum
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -5727,60 +5545,54 @@ pub impl @lib.Read for FieldOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldOptions raise {
   let msg = FieldOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.ctype = reader
-              |> @lib.read_enum()
-              |> FieldOptions_CType::from_enum
-              |> Some
-          (2, _) => msg.packed = reader |> @lib.read_bool() |> Some
-          (6, _) =>
-            msg.jstype = reader
-              |> @lib.read_enum()
-              |> FieldOptions_JSType::from_enum
-              |> Some
-          (5, _) => msg.lazy_ = reader |> @lib.read_bool() |> Some
-          (15, _) => msg.unverified_lazy = reader |> @lib.read_bool() |> Some
-          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (10, _) => msg.weak = reader |> @lib.read_bool() |> Some
-          (16, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-          (17, _) =>
-            msg.retention = reader
-              |> @lib.read_enum()
-              |> FieldOptions_OptionRetention::from_enum
-              |> Some
-          (19, 2) => {
-            let packed = reader |> @lib.read_packed(@lib.read_enum, None)
-            for item in packed {
-              msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
-            }
-          }
-          (19, 0) =>
-            msg.targets.push(
-              reader
-              |> @lib.read_enum()
-              |> FieldOptions_OptionTargetType::from_enum,
-            )
-          (20, _) =>
-            msg.edition_defaults.push(
-              (reader |> @lib.read_message() : FieldOptions_EditionDefault),
-            )
-          (21, _) =>
-            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (22, _) =>
-            msg.feature_support = (
-                reader |> @lib.read_message() : FieldOptions_FeatureSupport)
-              |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.skip_message_field(wire)
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.ctype = reader
+          |> @lib.read_enum()
+          |> FieldOptions_CType::from_enum
+          |> Some
+      (2, _) => msg.packed = reader |> @lib.read_bool() |> Some
+      (6, _) =>
+        msg.jstype = reader
+          |> @lib.read_enum()
+          |> FieldOptions_JSType::from_enum
+          |> Some
+      (5, _) => msg.lazy_ = reader |> @lib.read_bool() |> Some
+      (15, _) => msg.unverified_lazy = reader |> @lib.read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (10, _) => msg.weak = reader |> @lib.read_bool() |> Some
+      (16, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
+      (17, _) =>
+        msg.retention = reader
+          |> @lib.read_enum()
+          |> FieldOptions_OptionRetention::from_enum
+          |> Some
+      (19, 2) => {
+        let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+        for item in packed {
+          msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
         }
-      None => break
+      }
+      (19, 0) =>
+        msg.targets.push(
+          reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum,
+        )
+      (20, _) =>
+        msg.edition_defaults.push(
+          (reader |> @lib.read_message() : FieldOptions_EditionDefault),
+        )
+      (21, _) =>
+        msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (22, _) =>
+        msg.feature_support = (
+            reader |> @lib.read_message() : FieldOptions_FeatureSupport)
+          |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -5954,64 +5766,59 @@ pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldOptions raise {
   let msg = FieldOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.ctype = reader
-              |> @lib.async_read_enum()
-              |> FieldOptions_CType::from_enum
-              |> Some
-          (2, _) => msg.packed = reader |> @lib.async_read_bool() |> Some
-          (6, _) =>
-            msg.jstype = reader
-              |> @lib.async_read_enum()
-              |> FieldOptions_JSType::from_enum
-              |> Some
-          (5, _) => msg.lazy_ = reader |> @lib.async_read_bool() |> Some
-          (15, _) =>
-            msg.unverified_lazy = reader |> @lib.async_read_bool() |> Some
-          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (10, _) => msg.weak = reader |> @lib.async_read_bool() |> Some
-          (16, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-          (17, _) =>
-            msg.retention = reader
-              |> @lib.async_read_enum()
-              |> FieldOptions_OptionRetention::from_enum
-              |> Some
-          (19, 2) => {
-            let packed = reader
-              |> @lib.async_read_packed(@lib.async_read_enum, None)
-            for item in packed {
-              msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
-            }
-          }
-          (19, 0) =>
-            msg.targets.push(
-              reader
-              |> @lib.async_read_enum()
-              |> FieldOptions_OptionTargetType::from_enum,
-            )
-          (20, _) =>
-            msg.edition_defaults.push(
-              (reader |> @lib.async_read_message() : FieldOptions_EditionDefault),
-            )
-          (21, _) =>
-            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-              |> Some
-          (22, _) =>
-            msg.feature_support = (
-                reader |> @lib.async_read_message() :
-                FieldOptions_FeatureSupport)
-              |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.async_read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.ctype = reader
+          |> @lib.async_read_enum()
+          |> FieldOptions_CType::from_enum
+          |> Some
+      (2, _) => msg.packed = reader |> @lib.async_read_bool() |> Some
+      (6, _) =>
+        msg.jstype = reader
+          |> @lib.async_read_enum()
+          |> FieldOptions_JSType::from_enum
+          |> Some
+      (5, _) => msg.lazy_ = reader |> @lib.async_read_bool() |> Some
+      (15, _) => msg.unverified_lazy = reader |> @lib.async_read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (10, _) => msg.weak = reader |> @lib.async_read_bool() |> Some
+      (16, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
+      (17, _) =>
+        msg.retention = reader
+          |> @lib.async_read_enum()
+          |> FieldOptions_OptionRetention::from_enum
+          |> Some
+      (19, 2) => {
+        let packed = reader
+          |> @lib.async_read_packed(@lib.async_read_enum, None)
+        for item in packed {
+          msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
         }
-      None => break
+      }
+      (19, 0) =>
+        msg.targets.push(
+          reader
+          |> @lib.async_read_enum()
+          |> FieldOptions_OptionTargetType::from_enum,
+        )
+      (20, _) =>
+        msg.edition_defaults.push(
+          (reader |> @lib.async_read_message() : FieldOptions_EditionDefault),
+        )
+      (21, _) =>
+        msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+          |> Some
+      (22, _) =>
+        msg.feature_support = (
+            reader |> @lib.async_read_message() : FieldOptions_FeatureSupport)
+          |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.async_read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -6124,19 +5931,15 @@ pub impl @lib.Read for OneofOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> OneofOptions raise {
   let msg = OneofOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -6196,20 +5999,17 @@ pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> OneofOptions raise {
   let msg = OneofOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-              |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.async_read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+          |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.async_read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -6301,25 +6101,21 @@ pub impl @lib.Read for EnumOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumOptions raise {
   let msg = EnumOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (2, _) => msg.allow_alias = reader |> @lib.read_bool() |> Some
-          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (6, _) =>
-            msg.deprecated_legacy_json_field_conflicts = reader
-              |> @lib.read_bool()
-              |> Some
-          (7, _) =>
-            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (2, _) => msg.allow_alias = reader |> @lib.read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (6, _) =>
+        msg.deprecated_legacy_json_field_conflicts = reader
+          |> @lib.read_bool()
+          |> Some
+      (7, _) =>
+        msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -6411,26 +6207,23 @@ pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumOptions raise {
   let msg = EnumOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (2, _) => msg.allow_alias = reader |> @lib.async_read_bool() |> Some
-          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (6, _) =>
-            msg.deprecated_legacy_json_field_conflicts = reader
-              |> @lib.async_read_bool()
-              |> Some
-          (7, _) =>
-            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-              |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.async_read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (2, _) => msg.allow_alias = reader |> @lib.async_read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (6, _) =>
+        msg.deprecated_legacy_json_field_conflicts = reader
+          |> @lib.async_read_bool()
+          |> Some
+      (7, _) =>
+        msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+          |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.async_read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -6538,25 +6331,21 @@ pub impl @lib.Read for EnumValueOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (2, _) =>
-            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-          (4, _) =>
-            msg.feature_support = (
-                reader |> @lib.read_message() : FieldOptions_FeatureSupport)
-              |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (2, _) =>
+        msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
+      (4, _) =>
+        msg.feature_support = (
+            reader |> @lib.read_message() : FieldOptions_FeatureSupport)
+          |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -6648,27 +6437,23 @@ pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (2, _) =>
-            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-              |> Some
-          (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-          (4, _) =>
-            msg.feature_support = (
-                reader |> @lib.async_read_message() :
-                FieldOptions_FeatureSupport)
-              |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.async_read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (2, _) =>
+        msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+          |> Some
+      (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
+      (4, _) =>
+        msg.feature_support = (
+            reader |> @lib.async_read_message() : FieldOptions_FeatureSupport)
+          |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.async_read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -6754,20 +6539,16 @@ pub impl @lib.Read for ServiceOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (34, _) =>
-            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (34, _) =>
+        msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -6837,21 +6618,18 @@ pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (34, _) =>
-            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-              |> Some
-          (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.async_read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (34, _) =>
+        msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+          |> Some
+      (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.async_read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -7013,25 +6791,21 @@ pub impl @lib.Read for MethodOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MethodOptions raise {
   let msg = MethodOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (34, _) =>
-            msg.idempotency_level = reader
-              |> @lib.read_enum()
-              |> MethodOptions_IdempotencyLevel::from_enum
-              |> Some
-          (35, _) =>
-            msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (34, _) =>
+        msg.idempotency_level = reader
+          |> @lib.read_enum()
+          |> MethodOptions_IdempotencyLevel::from_enum
+          |> Some
+      (35, _) =>
+        msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -7112,26 +6886,23 @@ pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MethodOptions raise {
   let msg = MethodOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (34, _) =>
-            msg.idempotency_level = reader
-              |> @lib.async_read_enum()
-              |> MethodOptions_IdempotencyLevel::from_enum
-              |> Some
-          (35, _) =>
-            msg.features = (reader |> @lib.async_read_message() : FeatureSet)
-              |> Some
-          (999, _) =>
-            msg.uninterpreted_option.push(
-              (reader |> @lib.async_read_message() : UninterpretedOption),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (34, _) =>
+        msg.idempotency_level = reader
+          |> @lib.async_read_enum()
+          |> MethodOptions_IdempotencyLevel::from_enum
+          |> Some
+      (35, _) =>
+        msg.features = (reader |> @lib.async_read_message() : FeatureSet)
+          |> Some
+      (999, _) =>
+        msg.uninterpreted_option.push(
+          (reader |> @lib.async_read_message() : UninterpretedOption),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -7199,15 +6970,11 @@ pub impl @lib.Read for UninterpretedOption_NamePart with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name_part = reader |> @lib.read_string()
-          (2, _) => msg.is_extension = reader |> @lib.read_bool()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name_part = reader |> @lib.read_string()
+      (2, _) => msg.is_extension = reader |> @lib.read_bool()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -7263,15 +7030,12 @@ pub impl @lib.AsyncRead for UninterpretedOption_NamePart with fn read_with_limit
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name_part = reader |> @lib.async_read_string()
-          (2, _) => msg.is_extension = reader |> @lib.async_read_bool()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name_part = reader |> @lib.async_read_string()
+      (2, _) => msg.is_extension = reader |> @lib.async_read_bool()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -7381,24 +7145,19 @@ pub impl @lib.Read for UninterpretedOption with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (2, _) =>
-            msg.name.push(
-              (reader |> @lib.read_message() : UninterpretedOption_NamePart),
-            )
-          (3, _) => msg.identifier_value = reader |> @lib.read_string() |> Some
-          (4, _) =>
-            msg.positive_int_value = reader |> @lib.read_uint64() |> Some
-          (5, _) => msg.negative_int_value = reader |> @lib.read_int64() |> Some
-          (6, _) => msg.double_value = reader |> @lib.read_double() |> Some
-          (7, _) => msg.string_value = reader |> @lib.read_bytes() |> Some
-          (8, _) => msg.aggregate_value = reader |> @lib.read_string() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (2, _) =>
+        msg.name.push(
+          (reader |> @lib.read_message() : UninterpretedOption_NamePart),
+        )
+      (3, _) => msg.identifier_value = reader |> @lib.read_string() |> Some
+      (4, _) => msg.positive_int_value = reader |> @lib.read_uint64() |> Some
+      (5, _) => msg.negative_int_value = reader |> @lib.read_int64() |> Some
+      (6, _) => msg.double_value = reader |> @lib.read_double() |> Some
+      (7, _) => msg.string_value = reader |> @lib.read_bytes() |> Some
+      (8, _) => msg.aggregate_value = reader |> @lib.read_string() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -7514,30 +7273,23 @@ pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (2, _) =>
-            msg.name.push(
-              (
-                reader |> @lib.async_read_message() :
-                UninterpretedOption_NamePart),
-            )
-          (3, _) =>
-            msg.identifier_value = reader |> @lib.async_read_string() |> Some
-          (4, _) =>
-            msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some
-          (5, _) =>
-            msg.negative_int_value = reader |> @lib.async_read_int64() |> Some
-          (6, _) =>
-            msg.double_value = reader |> @lib.async_read_double() |> Some
-          (7, _) => msg.string_value = reader |> @lib.async_read_bytes() |> Some
-          (8, _) =>
-            msg.aggregate_value = reader |> @lib.async_read_string() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (2, _) =>
+        msg.name.push(
+          (reader |> @lib.async_read_message() : UninterpretedOption_NamePart),
+        )
+      (3, _) =>
+        msg.identifier_value = reader |> @lib.async_read_string() |> Some
+      (4, _) =>
+        msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some
+      (5, _) =>
+        msg.negative_int_value = reader |> @lib.async_read_int64() |> Some
+      (6, _) => msg.double_value = reader |> @lib.async_read_double() |> Some
+      (7, _) => msg.string_value = reader |> @lib.async_read_bytes() |> Some
+      (8, _) => msg.aggregate_value = reader |> @lib.async_read_string() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -8326,53 +8078,49 @@ pub impl @lib.Read for FeatureSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FeatureSet raise {
   let msg = FeatureSet::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.field_presence = reader
-              |> @lib.read_enum()
-              |> FeatureSet_FieldPresence::from_enum
-              |> Some
-          (2, _) =>
-            msg.enum_type = reader
-              |> @lib.read_enum()
-              |> FeatureSet_EnumType::from_enum
-              |> Some
-          (3, _) =>
-            msg.repeated_field_encoding = reader
-              |> @lib.read_enum()
-              |> FeatureSet_RepeatedFieldEncoding::from_enum
-              |> Some
-          (4, _) =>
-            msg.utf8_validation = reader
-              |> @lib.read_enum()
-              |> FeatureSet_Utf8Validation::from_enum
-              |> Some
-          (5, _) =>
-            msg.message_encoding = reader
-              |> @lib.read_enum()
-              |> FeatureSet_MessageEncoding::from_enum
-              |> Some
-          (6, _) =>
-            msg.json_format = reader
-              |> @lib.read_enum()
-              |> FeatureSet_JsonFormat::from_enum
-              |> Some
-          (7, _) =>
-            msg.enforce_naming_style = reader
-              |> @lib.read_enum()
-              |> FeatureSet_EnforceNamingStyle::from_enum
-              |> Some
-          (8, _) =>
-            msg.default_symbol_visibility = reader
-              |> @lib.read_enum()
-              |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.field_presence = reader
+          |> @lib.read_enum()
+          |> FeatureSet_FieldPresence::from_enum
+          |> Some
+      (2, _) =>
+        msg.enum_type = reader
+          |> @lib.read_enum()
+          |> FeatureSet_EnumType::from_enum
+          |> Some
+      (3, _) =>
+        msg.repeated_field_encoding = reader
+          |> @lib.read_enum()
+          |> FeatureSet_RepeatedFieldEncoding::from_enum
+          |> Some
+      (4, _) =>
+        msg.utf8_validation = reader
+          |> @lib.read_enum()
+          |> FeatureSet_Utf8Validation::from_enum
+          |> Some
+      (5, _) =>
+        msg.message_encoding = reader
+          |> @lib.read_enum()
+          |> FeatureSet_MessageEncoding::from_enum
+          |> Some
+      (6, _) =>
+        msg.json_format = reader
+          |> @lib.read_enum()
+          |> FeatureSet_JsonFormat::from_enum
+          |> Some
+      (7, _) =>
+        msg.enforce_naming_style = reader
+          |> @lib.read_enum()
+          |> FeatureSet_EnforceNamingStyle::from_enum
+          |> Some
+      (8, _) =>
+        msg.default_symbol_visibility = reader
+          |> @lib.read_enum()
+          |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -8493,53 +8241,50 @@ pub impl @lib.AsyncRead for FeatureSet with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FeatureSet raise {
   let msg = FeatureSet::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.field_presence = reader
-              |> @lib.async_read_enum()
-              |> FeatureSet_FieldPresence::from_enum
-              |> Some
-          (2, _) =>
-            msg.enum_type = reader
-              |> @lib.async_read_enum()
-              |> FeatureSet_EnumType::from_enum
-              |> Some
-          (3, _) =>
-            msg.repeated_field_encoding = reader
-              |> @lib.async_read_enum()
-              |> FeatureSet_RepeatedFieldEncoding::from_enum
-              |> Some
-          (4, _) =>
-            msg.utf8_validation = reader
-              |> @lib.async_read_enum()
-              |> FeatureSet_Utf8Validation::from_enum
-              |> Some
-          (5, _) =>
-            msg.message_encoding = reader
-              |> @lib.async_read_enum()
-              |> FeatureSet_MessageEncoding::from_enum
-              |> Some
-          (6, _) =>
-            msg.json_format = reader
-              |> @lib.async_read_enum()
-              |> FeatureSet_JsonFormat::from_enum
-              |> Some
-          (7, _) =>
-            msg.enforce_naming_style = reader
-              |> @lib.async_read_enum()
-              |> FeatureSet_EnforceNamingStyle::from_enum
-              |> Some
-          (8, _) =>
-            msg.default_symbol_visibility = reader
-              |> @lib.async_read_enum()
-              |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.field_presence = reader
+          |> @lib.async_read_enum()
+          |> FeatureSet_FieldPresence::from_enum
+          |> Some
+      (2, _) =>
+        msg.enum_type = reader
+          |> @lib.async_read_enum()
+          |> FeatureSet_EnumType::from_enum
+          |> Some
+      (3, _) =>
+        msg.repeated_field_encoding = reader
+          |> @lib.async_read_enum()
+          |> FeatureSet_RepeatedFieldEncoding::from_enum
+          |> Some
+      (4, _) =>
+        msg.utf8_validation = reader
+          |> @lib.async_read_enum()
+          |> FeatureSet_Utf8Validation::from_enum
+          |> Some
+      (5, _) =>
+        msg.message_encoding = reader
+          |> @lib.async_read_enum()
+          |> FeatureSet_MessageEncoding::from_enum
+          |> Some
+      (6, _) =>
+        msg.json_format = reader
+          |> @lib.async_read_enum()
+          |> FeatureSet_JsonFormat::from_enum
+          |> Some
+      (7, _) =>
+        msg.enforce_naming_style = reader
+          |> @lib.async_read_enum()
+          |> FeatureSet_EnforceNamingStyle::from_enum
+          |> Some
+      (8, _) =>
+        msg.default_symbol_visibility = reader
+          |> @lib.async_read_enum()
+          |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -8643,25 +8388,17 @@ pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (3, _) =>
-            msg.edition = reader
-              |> @lib.read_enum()
-              |> Edition::from_enum
-              |> Some
-          (4, _) =>
-            msg.overridable_features = (
-                reader |> @lib.read_message() : FeatureSet)
-              |> Some
-          (5, _) =>
-            msg.fixed_features = (reader |> @lib.read_message() : FeatureSet)
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (3, _) =>
+        msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+      (4, _) =>
+        msg.overridable_features = (reader |> @lib.read_message() : FeatureSet)
+          |> Some
+      (5, _) =>
+        msg.fixed_features = (reader |> @lib.read_message() : FeatureSet)
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -8738,26 +8475,22 @@ pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn 
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (3, _) =>
-            msg.edition = reader
-              |> @lib.async_read_enum()
-              |> Edition::from_enum
-              |> Some
-          (4, _) =>
-            msg.overridable_features = (
-                reader |> @lib.async_read_message() : FeatureSet)
-              |> Some
-          (5, _) =>
-            msg.fixed_features = (
-                reader |> @lib.async_read_message() : FeatureSet)
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (3, _) =>
+        msg.edition = reader
+          |> @lib.async_read_enum()
+          |> Edition::from_enum
+          |> Some
+      (4, _) =>
+        msg.overridable_features = (
+            reader |> @lib.async_read_message() : FeatureSet)
+          |> Some
+      (5, _) =>
+        msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet)
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -8831,29 +8564,25 @@ pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.defaults.push(
-              (
-                reader |> @lib.read_message() :
-                FeatureSetDefaults_FeatureSetEditionDefault),
-            )
-          (4, _) =>
-            msg.minimum_edition = reader
-              |> @lib.read_enum()
-              |> Edition::from_enum
-              |> Some
-          (5, _) =>
-            msg.maximum_edition = reader
-              |> @lib.read_enum()
-              |> Edition::from_enum
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.defaults.push(
+          (
+            reader |> @lib.read_message() :
+            FeatureSetDefaults_FeatureSetEditionDefault),
+        )
+      (4, _) =>
+        msg.minimum_edition = reader
+          |> @lib.read_enum()
+          |> Edition::from_enum
+          |> Some
+      (5, _) =>
+        msg.maximum_edition = reader
+          |> @lib.read_enum()
+          |> Edition::from_enum
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -8925,29 +8654,26 @@ pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.defaults.push(
-              (
-                reader |> @lib.async_read_message() :
-                FeatureSetDefaults_FeatureSetEditionDefault),
-            )
-          (4, _) =>
-            msg.minimum_edition = reader
-              |> @lib.async_read_enum()
-              |> Edition::from_enum
-              |> Some
-          (5, _) =>
-            msg.maximum_edition = reader
-              |> @lib.async_read_enum()
-              |> Edition::from_enum
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.defaults.push(
+          (
+            reader |> @lib.async_read_message() :
+            FeatureSetDefaults_FeatureSetEditionDefault),
+        )
+      (4, _) =>
+        msg.minimum_edition = reader
+          |> @lib.async_read_enum()
+          |> Edition::from_enum
+          |> Some
+      (5, _) =>
+        msg.maximum_edition = reader
+          |> @lib.async_read_enum()
+          |> Edition::from_enum
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -9055,27 +8781,22 @@ pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, 2) =>
-            msg.path.push_iter(
-              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-            )
-          (1, 0) => msg.path.push(reader |> @lib.read_int32())
-          (2, 2) =>
-            msg.span.push_iter(
-              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-            )
-          (2, 0) => msg.span.push(reader |> @lib.read_int32())
-          (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
-          (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
-          (6, _) =>
-            msg.leading_detached_comments.push(reader |> @lib.read_string())
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, 2) =>
+        msg.path.push_iter(
+          (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+        )
+      (1, 0) => msg.path.push(reader |> @lib.read_int32())
+      (2, 2) =>
+        msg.span.push_iter(
+          (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+        )
+      (2, 0) => msg.span.push(reader |> @lib.read_int32())
+      (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
+      (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
+      (6, _) => msg.leading_detached_comments.push(reader |> @lib.read_string())
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -9175,31 +8896,26 @@ pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, 2) =>
-            msg.path.push_iter(
-              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-            )
-          (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
-          (2, 2) =>
-            msg.span.push_iter(
-              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-            )
-          (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
-          (3, _) =>
-            msg.leading_comments = reader |> @lib.async_read_string() |> Some
-          (4, _) =>
-            msg.trailing_comments = reader |> @lib.async_read_string() |> Some
-          (6, _) =>
-            msg.leading_detached_comments.push(
-              reader |> @lib.async_read_string(),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, 2) =>
+        msg.path.push_iter(
+          (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+        )
+      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+      (2, 2) =>
+        msg.span.push_iter(
+          (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+        )
+      (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
+      (3, _) =>
+        msg.leading_comments = reader |> @lib.async_read_string() |> Some
+      (4, _) =>
+        msg.trailing_comments = reader |> @lib.async_read_string() |> Some
+      (6, _) =>
+        msg.leading_detached_comments.push(reader |> @lib.async_read_string())
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -9275,17 +8991,13 @@ pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.location.push(
-              (reader |> @lib.read_message() : SourceCodeInfo_Location),
-            )
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.location.push(
+          (reader |> @lib.read_message() : SourceCodeInfo_Location),
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -9335,17 +9047,14 @@ pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.location.push(
-              (reader |> @lib.async_read_message() : SourceCodeInfo_Location),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.location.push(
+          (reader |> @lib.async_read_message() : SourceCodeInfo_Location),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -9499,26 +9208,22 @@ pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, 2) =>
-            msg.path.push_iter(
-              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-            )
-          (1, 0) => msg.path.push(reader |> @lib.read_int32())
-          (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
-          (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
-          (4, _) => msg.end = reader |> @lib.read_int32() |> Some
-          (5, _) =>
-            msg.semantic = reader
-              |> @lib.read_enum()
-              |> GeneratedCodeInfo_Annotation_Semantic::from_enum
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, 2) =>
+        msg.path.push_iter(
+          (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+        )
+      (1, 0) => msg.path.push(reader |> @lib.read_int32())
+      (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
+      (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
+      (4, _) => msg.end = reader |> @lib.read_int32() |> Some
+      (5, _) =>
+        msg.semantic = reader
+          |> @lib.read_enum()
+          |> GeneratedCodeInfo_Annotation_Semantic::from_enum
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -9612,26 +9317,23 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, 2) =>
-            msg.path.push_iter(
-              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-            )
-          (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
-          (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
-          (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-          (5, _) =>
-            msg.semantic = reader
-              |> @lib.async_read_enum()
-              |> GeneratedCodeInfo_Annotation_Semantic::from_enum
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, 2) =>
+        msg.path.push_iter(
+          (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+        )
+      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+      (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
+      (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+      (5, _) =>
+        msg.semantic = reader
+          |> @lib.async_read_enum()
+          |> GeneratedCodeInfo_Annotation_Semantic::from_enum
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -9703,17 +9405,13 @@ pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.annotation.push(
-              (reader |> @lib.read_message() : GeneratedCodeInfo_Annotation),
-            )
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.annotation.push(
+          (reader |> @lib.read_message() : GeneratedCodeInfo_Annotation),
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -9765,19 +9463,14 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.annotation.push(
-              (
-                reader |> @lib.async_read_message() :
-                GeneratedCodeInfo_Annotation),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.annotation.push(
+          (reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/lib/google/protobuf/duration.mbt
+++ b/lib/google/protobuf/duration.mbt
@@ -31,15 +31,11 @@ pub impl @lib.Read for Duration with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Duration raise {
   let msg = Duration::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.seconds = reader |> @lib.read_int64()
-          (2, _) => msg.nanos = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.seconds = reader |> @lib.read_int64()
+      (2, _) => msg.nanos = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -65,15 +61,12 @@ pub impl @lib.AsyncRead for Duration with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Duration raise {
   let msg = Duration::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.seconds = reader |> @lib.async_read_int64()
-          (2, _) => msg.nanos = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.seconds = reader |> @lib.async_read_int64()
+      (2, _) => msg.nanos = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/lib/google/protobuf/duration.mbt
+++ b/lib/google/protobuf/duration.mbt
@@ -31,17 +31,16 @@ pub impl @lib.Read for Duration with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Duration raise {
   let msg = Duration::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.seconds = reader |> @lib.read_int64()
-        (2, _) => msg.nanos = reader |> @lib.read_int32()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.seconds = reader |> @lib.read_int64()
+          (2, _) => msg.nanos = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -66,17 +65,16 @@ pub impl @lib.AsyncRead for Duration with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Duration raise {
   let msg = Duration::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.seconds = reader |> @lib.async_read_int64()
-        (2, _) => msg.nanos = reader |> @lib.async_read_int32()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.seconds = reader |> @lib.async_read_int64()
+          (2, _) => msg.nanos = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }

--- a/lib/google/protobuf/field_mask.mbt
+++ b/lib/google/protobuf/field_mask.mbt
@@ -31,14 +31,10 @@ pub impl @lib.Read for FieldMask with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldMask raise {
   let msg = FieldMask::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.paths.push(reader |> @lib.read_string())
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.paths.push(reader |> @lib.read_string())
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -88,14 +84,11 @@ pub impl @lib.AsyncRead for FieldMask with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldMask raise {
   let msg = FieldMask::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.paths.push(reader |> @lib.async_read_string())
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.paths.push(reader |> @lib.async_read_string())
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/lib/google/protobuf/field_mask.mbt
+++ b/lib/google/protobuf/field_mask.mbt
@@ -31,16 +31,15 @@ pub impl @lib.Read for FieldMask with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FieldMask raise {
   let msg = FieldMask::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.paths.push(reader |> @lib.read_string())
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.paths.push(reader |> @lib.read_string())
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -89,16 +88,15 @@ pub impl @lib.AsyncRead for FieldMask with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FieldMask raise {
   let msg = FieldMask::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.paths.push(reader |> @lib.async_read_string())
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.paths.push(reader |> @lib.async_read_string())
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }

--- a/lib/google/protobuf/source_context.mbt
+++ b/lib/google/protobuf/source_context.mbt
@@ -31,16 +31,15 @@ pub impl @lib.Read for SourceContext with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> SourceContext raise {
   let msg = SourceContext::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.file_name = reader |> @lib.read_string()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.file_name = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -88,16 +87,15 @@ pub impl @lib.AsyncRead for SourceContext with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> SourceContext raise {
   let msg = SourceContext::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.file_name = reader |> @lib.async_read_string()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.file_name = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }

--- a/lib/google/protobuf/source_context.mbt
+++ b/lib/google/protobuf/source_context.mbt
@@ -31,14 +31,10 @@ pub impl @lib.Read for SourceContext with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> SourceContext raise {
   let msg = SourceContext::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.file_name = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.file_name = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -87,14 +83,11 @@ pub impl @lib.AsyncRead for SourceContext with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> SourceContext raise {
   let msg = SourceContext::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.file_name = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.file_name = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/lib/google/protobuf/struct.mbt
+++ b/lib/google/protobuf/struct.mbt
@@ -103,15 +103,11 @@ pub impl @lib.Read for Struct_FieldsEntry with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Struct_FieldsEntry raise {
   let msg = Struct_FieldsEntry::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.read_string()
-          (2, _) => msg.value = (reader |> @lib.read_message() : Value)
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.read_string()
+      (2, _) => msg.value = (reader |> @lib.read_message() : Value)
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -168,15 +164,12 @@ pub impl @lib.AsyncRead for Struct_FieldsEntry with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Struct_FieldsEntry raise {
   let msg = Struct_FieldsEntry::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.async_read_string()
-          (2, _) => msg.value = (reader |> @lib.async_read_message() : Value)
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.async_read_string()
+      (2, _) => msg.value = (reader |> @lib.async_read_message() : Value)
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -234,18 +227,13 @@ pub impl @lib.Read for Struct with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Struct raise {
   let msg = Struct::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => {
-            let { key, value } = (
-              reader |> @lib.read_message() : Struct_FieldsEntry)
-            msg.fields[key] = value
-          }
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => {
+        let { key, value } = (reader |> @lib.read_message() : Struct_FieldsEntry)
+        msg.fields[key] = value
+      }
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -312,18 +300,15 @@ pub impl @lib.AsyncRead for Struct with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Struct raise {
   let msg = Struct::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => {
-            let { key, value } = (
-              reader |> @lib.async_read_message() : Struct_FieldsEntry)
-            msg.fields[key] = value
-          }
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => {
+        let { key, value } = (
+          reader |> @lib.async_read_message() : Struct_FieldsEntry)
+        msg.fields[key] = value
+      }
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -475,30 +460,25 @@ pub impl @lib.Read for Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Value raise {
   let msg = Value::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.kind = reader
-              |> @lib.read_enum()
-              |> NullValue::from_enum
-              |> Value_Kind::NullValue
-          (2, _) =>
-            msg.kind = reader |> @lib.read_double() |> Value_Kind::NumberValue
-          (3, _) =>
-            msg.kind = reader |> @lib.read_string() |> Value_Kind::StringValue
-          (4, _) =>
-            msg.kind = reader |> @lib.read_bool() |> Value_Kind::BoolValue
-          (5, _) =>
-            msg.kind = (reader |> @lib.read_message() : Struct)
-              |> Value_Kind::StructValue
-          (6, _) =>
-            msg.kind = (reader |> @lib.read_message() : ListValue)
-              |> Value_Kind::ListValue
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.kind = reader
+          |> @lib.read_enum()
+          |> NullValue::from_enum
+          |> Value_Kind::NullValue
+      (2, _) =>
+        msg.kind = reader |> @lib.read_double() |> Value_Kind::NumberValue
+      (3, _) =>
+        msg.kind = reader |> @lib.read_string() |> Value_Kind::StringValue
+      (4, _) => msg.kind = reader |> @lib.read_bool() |> Value_Kind::BoolValue
+      (5, _) =>
+        msg.kind = (reader |> @lib.read_message() : Struct)
+          |> Value_Kind::StructValue
+      (6, _) =>
+        msg.kind = (reader |> @lib.read_message() : ListValue)
+          |> Value_Kind::ListValue
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -578,34 +558,27 @@ pub impl @lib.AsyncRead for Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Value raise {
   let msg = Value::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.kind = reader
-              |> @lib.async_read_enum()
-              |> NullValue::from_enum
-              |> Value_Kind::NullValue
-          (2, _) =>
-            msg.kind = reader
-              |> @lib.async_read_double()
-              |> Value_Kind::NumberValue
-          (3, _) =>
-            msg.kind = reader
-              |> @lib.async_read_string()
-              |> Value_Kind::StringValue
-          (4, _) =>
-            msg.kind = reader |> @lib.async_read_bool() |> Value_Kind::BoolValue
-          (5, _) =>
-            msg.kind = (reader |> @lib.async_read_message() : Struct)
-              |> Value_Kind::StructValue
-          (6, _) =>
-            msg.kind = (reader |> @lib.async_read_message() : ListValue)
-              |> Value_Kind::ListValue
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.kind = reader
+          |> @lib.async_read_enum()
+          |> NullValue::from_enum
+          |> Value_Kind::NullValue
+      (2, _) =>
+        msg.kind = reader |> @lib.async_read_double() |> Value_Kind::NumberValue
+      (3, _) =>
+        msg.kind = reader |> @lib.async_read_string() |> Value_Kind::StringValue
+      (4, _) =>
+        msg.kind = reader |> @lib.async_read_bool() |> Value_Kind::BoolValue
+      (5, _) =>
+        msg.kind = (reader |> @lib.async_read_message() : Struct)
+          |> Value_Kind::StructValue
+      (6, _) =>
+        msg.kind = (reader |> @lib.async_read_message() : ListValue)
+          |> Value_Kind::ListValue
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -678,14 +651,10 @@ pub impl @lib.Read for ListValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ListValue raise {
   let msg = ListValue::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.values.push((reader |> @lib.read_message() : Value))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.values.push((reader |> @lib.read_message() : Value))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -735,15 +704,11 @@ pub impl @lib.AsyncRead for ListValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ListValue raise {
   let msg = ListValue::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.values.push((reader |> @lib.async_read_message() : Value))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.values.push((reader |> @lib.async_read_message() : Value))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/lib/google/protobuf/struct.mbt
+++ b/lib/google/protobuf/struct.mbt
@@ -103,17 +103,16 @@ pub impl @lib.Read for Struct_FieldsEntry with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Struct_FieldsEntry raise {
   let msg = Struct_FieldsEntry::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.key = reader |> @lib.read_string()
-        (2, _) => msg.value = (reader |> @lib.read_message() : Value)
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.read_string()
+          (2, _) => msg.value = (reader |> @lib.read_message() : Value)
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -128,8 +127,7 @@ pub impl @lib.Write for Struct_FieldsEntry with fn write(
     writer |> @lib.write_string(self.key)
   }
   writer |> @lib.write_varint(18UL)
-  writer |> @lib.write_uint32(@lib.size_of(self.value))
-  @lib.Write::write(self.value, writer)
+  writer |> @lib.write_message(self.value)
 }
 
 ///|
@@ -170,17 +168,16 @@ pub impl @lib.AsyncRead for Struct_FieldsEntry with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Struct_FieldsEntry raise {
   let msg = Struct_FieldsEntry::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.key = reader |> @lib.async_read_string()
-        (2, _) => msg.value = (reader |> @lib.async_read_message() : Value)
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.async_read_string()
+          (2, _) => msg.value = (reader |> @lib.async_read_message() : Value)
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -195,8 +192,7 @@ pub impl @lib.AsyncWrite for Struct_FieldsEntry with fn write(
     writer |> @lib.async_write_string(self.key)
   }
   writer |> @lib.async_write_varint(18UL)
-  writer |> @lib.async_write_uint32(@lib.size_of(self.value))
-  @lib.AsyncWrite::write(self.value, writer)
+  writer |> @lib.async_write_message(self.value)
 }
 
 ///|
@@ -238,20 +234,19 @@ pub impl @lib.Read for Struct with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Struct raise {
   let msg = Struct::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => {
-          let { key, value } = (
-            reader |> @lib.read_message() : Struct_FieldsEntry)
-          msg.fields[key] = value
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => {
+            let { key, value } = (
+              reader |> @lib.read_message() : Struct_FieldsEntry)
+            msg.fields[key] = value
+          }
+          _ => reader |> @lib.skip_message_field(wire)
         }
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -281,8 +276,7 @@ pub impl @lib.Write for Struct with fn write(
     writer |> @lib.write_string(k)
 
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -318,20 +312,19 @@ pub impl @lib.AsyncRead for Struct with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Struct raise {
   let msg = Struct::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => {
-          let { key, value } = (
-            reader |> @lib.async_read_message() : Struct_FieldsEntry)
-          msg.fields[key] = value
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => {
+            let { key, value } = (
+              reader |> @lib.async_read_message() : Struct_FieldsEntry)
+            msg.fields[key] = value
+          }
+          _ => reader |> @lib.async_skip_message_field(wire)
         }
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -361,8 +354,7 @@ pub impl @lib.AsyncWrite for Struct with fn write(
     writer |> @lib.async_write_string(k)
 
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }
 
@@ -483,31 +475,31 @@ pub impl @lib.Read for Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Value raise {
   let msg = Value::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.kind = reader
-            |> @lib.read_enum()
-            |> NullValue::from_enum
-            |> Value_Kind::NullValue
-        (2, _) =>
-          msg.kind = reader |> @lib.read_double() |> Value_Kind::NumberValue
-        (3, _) =>
-          msg.kind = reader |> @lib.read_string() |> Value_Kind::StringValue
-        (4, _) => msg.kind = reader |> @lib.read_bool() |> Value_Kind::BoolValue
-        (5, _) =>
-          msg.kind = (reader |> @lib.read_message() : Struct)
-            |> Value_Kind::StructValue
-        (6, _) =>
-          msg.kind = (reader |> @lib.read_message() : ListValue)
-            |> Value_Kind::ListValue
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.kind = reader
+              |> @lib.read_enum()
+              |> NullValue::from_enum
+              |> Value_Kind::NullValue
+          (2, _) =>
+            msg.kind = reader |> @lib.read_double() |> Value_Kind::NumberValue
+          (3, _) =>
+            msg.kind = reader |> @lib.read_string() |> Value_Kind::StringValue
+          (4, _) =>
+            msg.kind = reader |> @lib.read_bool() |> Value_Kind::BoolValue
+          (5, _) =>
+            msg.kind = (reader |> @lib.read_message() : Struct)
+              |> Value_Kind::StructValue
+          (6, _) =>
+            msg.kind = (reader |> @lib.read_message() : ListValue)
+              |> Value_Kind::ListValue
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -533,13 +525,11 @@ pub impl @lib.Write for Value with fn write(self : Value, writer : &@lib.Writer)
     }
     Value_Kind::StructValue(v) => {
       writer |> @lib.write_varint(42UL)
-      writer |> @lib.write_uint32(@lib.size_of(v))
-      @lib.Write::write(v, writer)
+      writer |> @lib.write_message(v)
     }
     Value_Kind::ListValue(v) => {
       writer |> @lib.write_varint(50UL)
-      writer |> @lib.write_uint32(@lib.size_of(v))
-      @lib.Write::write(v, writer)
+      writer |> @lib.write_message(v)
     }
     Value_Kind::NotSet => ()
   }
@@ -588,36 +578,35 @@ pub impl @lib.AsyncRead for Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Value raise {
   let msg = Value::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.kind = reader
-            |> @lib.async_read_enum()
-            |> NullValue::from_enum
-            |> Value_Kind::NullValue
-        (2, _) =>
-          msg.kind = reader
-            |> @lib.async_read_double()
-            |> Value_Kind::NumberValue
-        (3, _) =>
-          msg.kind = reader
-            |> @lib.async_read_string()
-            |> Value_Kind::StringValue
-        (4, _) =>
-          msg.kind = reader |> @lib.async_read_bool() |> Value_Kind::BoolValue
-        (5, _) =>
-          msg.kind = (reader |> @lib.async_read_message() : Struct)
-            |> Value_Kind::StructValue
-        (6, _) =>
-          msg.kind = (reader |> @lib.async_read_message() : ListValue)
-            |> Value_Kind::ListValue
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.kind = reader
+              |> @lib.async_read_enum()
+              |> NullValue::from_enum
+              |> Value_Kind::NullValue
+          (2, _) =>
+            msg.kind = reader
+              |> @lib.async_read_double()
+              |> Value_Kind::NumberValue
+          (3, _) =>
+            msg.kind = reader
+              |> @lib.async_read_string()
+              |> Value_Kind::StringValue
+          (4, _) =>
+            msg.kind = reader |> @lib.async_read_bool() |> Value_Kind::BoolValue
+          (5, _) =>
+            msg.kind = (reader |> @lib.async_read_message() : Struct)
+              |> Value_Kind::StructValue
+          (6, _) =>
+            msg.kind = (reader |> @lib.async_read_message() : ListValue)
+              |> Value_Kind::ListValue
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -646,13 +635,11 @@ pub impl @lib.AsyncWrite for Value with fn write(
     }
     Value_Kind::StructValue(v) => {
       writer |> @lib.async_write_varint(42UL)
-      writer |> @lib.async_write_uint32(@lib.size_of(v))
-      @lib.AsyncWrite::write(v, writer)
+      writer |> @lib.async_write_message(v)
     }
     Value_Kind::ListValue(v) => {
       writer |> @lib.async_write_varint(50UL)
-      writer |> @lib.async_write_uint32(@lib.size_of(v))
-      @lib.AsyncWrite::write(v, writer)
+      writer |> @lib.async_write_message(v)
     }
     Value_Kind::NotSet => ()
   }
@@ -691,16 +678,15 @@ pub impl @lib.Read for ListValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> ListValue raise {
   let msg = ListValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.values.push((reader |> @lib.read_message() : Value))
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.values.push((reader |> @lib.read_message() : Value))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -712,8 +698,7 @@ pub impl @lib.Write for ListValue with fn write(
 ) -> Unit raise {
   for item in self.values {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -750,16 +735,16 @@ pub impl @lib.AsyncRead for ListValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> ListValue raise {
   let msg = ListValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.values.push((reader |> @lib.async_read_message() : Value))
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.values.push((reader |> @lib.async_read_message() : Value))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -771,7 +756,6 @@ pub impl @lib.AsyncWrite for ListValue with fn write(
 ) -> Unit raise {
   for item in self.values {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }

--- a/lib/google/protobuf/timestamp.mbt
+++ b/lib/google/protobuf/timestamp.mbt
@@ -31,15 +31,11 @@ pub impl @lib.Read for Timestamp with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Timestamp raise {
   let msg = Timestamp::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.seconds = reader |> @lib.read_int64()
-          (2, _) => msg.nanos = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.seconds = reader |> @lib.read_int64()
+      (2, _) => msg.nanos = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -65,15 +61,12 @@ pub impl @lib.AsyncRead for Timestamp with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Timestamp raise {
   let msg = Timestamp::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.seconds = reader |> @lib.async_read_int64()
-          (2, _) => msg.nanos = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.seconds = reader |> @lib.async_read_int64()
+      (2, _) => msg.nanos = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/lib/google/protobuf/timestamp.mbt
+++ b/lib/google/protobuf/timestamp.mbt
@@ -31,17 +31,16 @@ pub impl @lib.Read for Timestamp with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Timestamp raise {
   let msg = Timestamp::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.seconds = reader |> @lib.read_int64()
-        (2, _) => msg.nanos = reader |> @lib.read_int32()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.seconds = reader |> @lib.read_int64()
+          (2, _) => msg.nanos = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -66,17 +65,16 @@ pub impl @lib.AsyncRead for Timestamp with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Timestamp raise {
   let msg = Timestamp::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.seconds = reader |> @lib.async_read_int64()
-        (2, _) => msg.nanos = reader |> @lib.async_read_int32()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.seconds = reader |> @lib.async_read_int64()
+          (2, _) => msg.nanos = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }

--- a/lib/google/protobuf/type.mbt
+++ b/lib/google/protobuf/type.mbt
@@ -166,24 +166,23 @@ pub impl @lib.Read for Type with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Type raise {
   let msg = Type::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string()
-        (2, _) => msg.fields.push((reader |> @lib.read_message() : Field))
-        (3, _) => msg.oneofs.push(reader |> @lib.read_string())
-        (4, _) => msg.options.push((reader |> @lib.read_message() : Option))
-        (5, _) =>
-          msg.source_context = (reader |> @lib.read_message() : SourceContext)
-            |> Some
-        (6, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
-        (7, _) => msg.edition = reader |> @lib.read_string()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.fields.push((reader |> @lib.read_message() : Field))
+          (3, _) => msg.oneofs.push(reader |> @lib.read_string())
+          (4, _) => msg.options.push((reader |> @lib.read_message() : Option))
+          (5, _) =>
+            msg.source_context = (reader |> @lib.read_message() : SourceContext)
+              |> Some
+          (6, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
+          (7, _) => msg.edition = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -196,8 +195,7 @@ pub impl @lib.Write for Type with fn write(self : Type, writer : &@lib.Writer) -
   }
   for item in self.fields {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.oneofs {
     writer |> @lib.write_varint(26UL)
@@ -205,13 +203,11 @@ pub impl @lib.Write for Type with fn write(self : Type, writer : &@lib.Writer) -
   }
   for item in self.options {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.source_context is Some(v) {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.syntax != Default::default() {
     writer |> @lib.write_varint(48UL)
@@ -284,27 +280,27 @@ pub impl @lib.AsyncRead for Type with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Type raise {
   let msg = Type::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string()
-        (2, _) => msg.fields.push((reader |> @lib.async_read_message() : Field))
-        (3, _) => msg.oneofs.push(reader |> @lib.async_read_string())
-        (4, _) =>
-          msg.options.push((reader |> @lib.async_read_message() : Option))
-        (5, _) =>
-          msg.source_context = (
-              reader |> @lib.async_read_message() : SourceContext)
-            |> Some
-        (6, _) =>
-          msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
-        (7, _) => msg.edition = reader |> @lib.async_read_string()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) =>
+            msg.fields.push((reader |> @lib.async_read_message() : Field))
+          (3, _) => msg.oneofs.push(reader |> @lib.async_read_string())
+          (4, _) =>
+            msg.options.push((reader |> @lib.async_read_message() : Option))
+          (5, _) =>
+            msg.source_context = (
+                reader |> @lib.async_read_message() : SourceContext)
+              |> Some
+          (6, _) =>
+            msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
+          (7, _) => msg.edition = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -320,8 +316,7 @@ pub impl @lib.AsyncWrite for Type with fn write(
   }
   for item in self.fields {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.oneofs {
     writer |> @lib.async_write_varint(26UL)
@@ -329,13 +324,11 @@ pub impl @lib.AsyncWrite for Type with fn write(
   }
   for item in self.options {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.source_context is Some(v) {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.syntax != Default::default() {
     writer |> @lib.async_write_varint(48UL)
@@ -719,28 +712,28 @@ pub impl @lib.Read for Field with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Field raise {
   let msg = Field::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.kind = reader |> @lib.read_enum() |> Field_Kind::from_enum
-        (2, _) =>
-          msg.cardinality = reader
-            |> @lib.read_enum()
-            |> Field_Cardinality::from_enum
-        (3, _) => msg.number = reader |> @lib.read_int32()
-        (4, _) => msg.name = reader |> @lib.read_string()
-        (6, _) => msg.type_url = reader |> @lib.read_string()
-        (7, _) => msg.oneof_index = reader |> @lib.read_int32()
-        (8, _) => msg.packed = reader |> @lib.read_bool()
-        (9, _) => msg.options.push((reader |> @lib.read_message() : Option))
-        (10, _) => msg.json_name = reader |> @lib.read_string()
-        (11, _) => msg.default_value = reader |> @lib.read_string()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.kind = reader |> @lib.read_enum() |> Field_Kind::from_enum
+          (2, _) =>
+            msg.cardinality = reader
+              |> @lib.read_enum()
+              |> Field_Cardinality::from_enum
+          (3, _) => msg.number = reader |> @lib.read_int32()
+          (4, _) => msg.name = reader |> @lib.read_string()
+          (6, _) => msg.type_url = reader |> @lib.read_string()
+          (7, _) => msg.oneof_index = reader |> @lib.read_int32()
+          (8, _) => msg.packed = reader |> @lib.read_bool()
+          (9, _) => msg.options.push((reader |> @lib.read_message() : Option))
+          (10, _) => msg.json_name = reader |> @lib.read_string()
+          (11, _) => msg.default_value = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -777,8 +770,7 @@ pub impl @lib.Write for Field with fn write(self : Field, writer : &@lib.Writer)
   }
   for item in self.options {
     writer |> @lib.write_varint(74UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.json_name != Default::default() {
     writer |> @lib.write_varint(82UL)
@@ -862,30 +854,29 @@ pub impl @lib.AsyncRead for Field with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Field raise {
   let msg = Field::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.kind = reader |> @lib.async_read_enum() |> Field_Kind::from_enum
-        (2, _) =>
-          msg.cardinality = reader
-            |> @lib.async_read_enum()
-            |> Field_Cardinality::from_enum
-        (3, _) => msg.number = reader |> @lib.async_read_int32()
-        (4, _) => msg.name = reader |> @lib.async_read_string()
-        (6, _) => msg.type_url = reader |> @lib.async_read_string()
-        (7, _) => msg.oneof_index = reader |> @lib.async_read_int32()
-        (8, _) => msg.packed = reader |> @lib.async_read_bool()
-        (9, _) =>
-          msg.options.push((reader |> @lib.async_read_message() : Option))
-        (10, _) => msg.json_name = reader |> @lib.async_read_string()
-        (11, _) => msg.default_value = reader |> @lib.async_read_string()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.kind = reader |> @lib.async_read_enum() |> Field_Kind::from_enum
+          (2, _) =>
+            msg.cardinality = reader
+              |> @lib.async_read_enum()
+              |> Field_Cardinality::from_enum
+          (3, _) => msg.number = reader |> @lib.async_read_int32()
+          (4, _) => msg.name = reader |> @lib.async_read_string()
+          (6, _) => msg.type_url = reader |> @lib.async_read_string()
+          (7, _) => msg.oneof_index = reader |> @lib.async_read_int32()
+          (8, _) => msg.packed = reader |> @lib.async_read_bool()
+          (9, _) =>
+            msg.options.push((reader |> @lib.async_read_message() : Option))
+          (10, _) => msg.json_name = reader |> @lib.async_read_string()
+          (11, _) => msg.default_value = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -925,8 +916,7 @@ pub impl @lib.AsyncWrite for Field with fn write(
   }
   for item in self.options {
     writer |> @lib.async_write_varint(74UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.json_name != Default::default() {
     writer |> @lib.async_write_varint(82UL)
@@ -1021,24 +1011,23 @@ pub impl @lib.Read for Enum with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Enum raise {
   let msg = Enum::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string()
-        (2, _) =>
-          msg.enumvalue.push((reader |> @lib.read_message() : EnumValue))
-        (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
-        (4, _) =>
-          msg.source_context = (reader |> @lib.read_message() : SourceContext)
-            |> Some
-        (5, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
-        (6, _) => msg.edition = reader |> @lib.read_string()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) =>
+            msg.enumvalue.push((reader |> @lib.read_message() : EnumValue))
+          (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
+          (4, _) =>
+            msg.source_context = (reader |> @lib.read_message() : SourceContext)
+              |> Some
+          (5, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
+          (6, _) => msg.edition = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1051,18 +1040,15 @@ pub impl @lib.Write for Enum with fn write(self : Enum, writer : &@lib.Writer) -
   }
   for item in self.enumvalue {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   for item in self.options {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.source_context is Some(v) {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.syntax != Default::default() {
     writer |> @lib.write_varint(40UL)
@@ -1130,27 +1116,28 @@ pub impl @lib.AsyncRead for Enum with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Enum raise {
   let msg = Enum::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string()
-        (2, _) =>
-          msg.enumvalue.push((reader |> @lib.async_read_message() : EnumValue))
-        (3, _) =>
-          msg.options.push((reader |> @lib.async_read_message() : Option))
-        (4, _) =>
-          msg.source_context = (
-              reader |> @lib.async_read_message() : SourceContext)
-            |> Some
-        (5, _) =>
-          msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
-        (6, _) => msg.edition = reader |> @lib.async_read_string()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) =>
+            msg.enumvalue.push(
+              (reader |> @lib.async_read_message() : EnumValue),
+            )
+          (3, _) =>
+            msg.options.push((reader |> @lib.async_read_message() : Option))
+          (4, _) =>
+            msg.source_context = (
+                reader |> @lib.async_read_message() : SourceContext)
+              |> Some
+          (5, _) =>
+            msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
+          (6, _) => msg.edition = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1166,18 +1153,15 @@ pub impl @lib.AsyncWrite for Enum with fn write(
   }
   for item in self.enumvalue {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   for item in self.options {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.source_context is Some(v) {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.syntax != Default::default() {
     writer |> @lib.async_write_varint(40UL)
@@ -1238,18 +1222,17 @@ pub impl @lib.Read for EnumValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumValue raise {
   let msg = EnumValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string()
-        (2, _) => msg.number = reader |> @lib.read_int32()
-        (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.number = reader |> @lib.read_int32()
+          (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1269,8 +1252,7 @@ pub impl @lib.Write for EnumValue with fn write(
   }
   for item in self.options {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -1315,19 +1297,18 @@ pub impl @lib.AsyncRead for EnumValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumValue raise {
   let msg = EnumValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string()
-        (2, _) => msg.number = reader |> @lib.async_read_int32()
-        (3, _) =>
-          msg.options.push((reader |> @lib.async_read_message() : Option))
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) => msg.number = reader |> @lib.async_read_int32()
+          (3, _) =>
+            msg.options.push((reader |> @lib.async_read_message() : Option))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1347,8 +1328,7 @@ pub impl @lib.AsyncWrite for EnumValue with fn write(
   }
   for item in self.options {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -1393,17 +1373,16 @@ pub impl @lib.Read for Option with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Option raise {
   let msg = Option::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.name = reader |> @lib.read_string()
-        (2, _) => msg.value = (reader |> @lib.read_message() : Any) |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.value = (reader |> @lib.read_message() : Any) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1419,8 +1398,7 @@ pub impl @lib.Write for Option with fn write(
   }
   if self.value is Some(v) {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -1461,18 +1439,17 @@ pub impl @lib.AsyncRead for Option with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Option raise {
   let msg = Option::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.name = reader |> @lib.async_read_string()
-        (2, _) =>
-          msg.value = (reader |> @lib.async_read_message() : Any) |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) =>
+            msg.value = (reader |> @lib.async_read_message() : Any) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1488,7 +1465,6 @@ pub impl @lib.AsyncWrite for Option with fn write(
   }
   if self.value is Some(v) {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }

--- a/lib/google/protobuf/type.mbt
+++ b/lib/google/protobuf/type.mbt
@@ -166,22 +166,18 @@ pub impl @lib.Read for Type with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Type raise {
   let msg = Type::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.fields.push((reader |> @lib.read_message() : Field))
-          (3, _) => msg.oneofs.push(reader |> @lib.read_string())
-          (4, _) => msg.options.push((reader |> @lib.read_message() : Option))
-          (5, _) =>
-            msg.source_context = (reader |> @lib.read_message() : SourceContext)
-              |> Some
-          (6, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
-          (7, _) => msg.edition = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.fields.push((reader |> @lib.read_message() : Field))
+      (3, _) => msg.oneofs.push(reader |> @lib.read_string())
+      (4, _) => msg.options.push((reader |> @lib.read_message() : Option))
+      (5, _) =>
+        msg.source_context = (reader |> @lib.read_message() : SourceContext)
+          |> Some
+      (6, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
+      (7, _) => msg.edition = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -280,26 +276,21 @@ pub impl @lib.AsyncRead for Type with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Type raise {
   let msg = Type::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) =>
-            msg.fields.push((reader |> @lib.async_read_message() : Field))
-          (3, _) => msg.oneofs.push(reader |> @lib.async_read_string())
-          (4, _) =>
-            msg.options.push((reader |> @lib.async_read_message() : Option))
-          (5, _) =>
-            msg.source_context = (
-                reader |> @lib.async_read_message() : SourceContext)
-              |> Some
-          (6, _) =>
-            msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
-          (7, _) => msg.edition = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.fields.push((reader |> @lib.async_read_message() : Field))
+      (3, _) => msg.oneofs.push(reader |> @lib.async_read_string())
+      (4, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (5, _) =>
+        msg.source_context = (
+            reader |> @lib.async_read_message() : SourceContext)
+          |> Some
+      (6, _) =>
+        msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
+      (7, _) => msg.edition = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -712,27 +703,22 @@ pub impl @lib.Read for Field with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Field raise {
   let msg = Field::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.kind = reader |> @lib.read_enum() |> Field_Kind::from_enum
-          (2, _) =>
-            msg.cardinality = reader
-              |> @lib.read_enum()
-              |> Field_Cardinality::from_enum
-          (3, _) => msg.number = reader |> @lib.read_int32()
-          (4, _) => msg.name = reader |> @lib.read_string()
-          (6, _) => msg.type_url = reader |> @lib.read_string()
-          (7, _) => msg.oneof_index = reader |> @lib.read_int32()
-          (8, _) => msg.packed = reader |> @lib.read_bool()
-          (9, _) => msg.options.push((reader |> @lib.read_message() : Option))
-          (10, _) => msg.json_name = reader |> @lib.read_string()
-          (11, _) => msg.default_value = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.kind = reader |> @lib.read_enum() |> Field_Kind::from_enum
+      (2, _) =>
+        msg.cardinality = reader
+          |> @lib.read_enum()
+          |> Field_Cardinality::from_enum
+      (3, _) => msg.number = reader |> @lib.read_int32()
+      (4, _) => msg.name = reader |> @lib.read_string()
+      (6, _) => msg.type_url = reader |> @lib.read_string()
+      (7, _) => msg.oneof_index = reader |> @lib.read_int32()
+      (8, _) => msg.packed = reader |> @lib.read_bool()
+      (9, _) => msg.options.push((reader |> @lib.read_message() : Option))
+      (10, _) => msg.json_name = reader |> @lib.read_string()
+      (11, _) => msg.default_value = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -854,28 +840,24 @@ pub impl @lib.AsyncRead for Field with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Field raise {
   let msg = Field::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.kind = reader |> @lib.async_read_enum() |> Field_Kind::from_enum
-          (2, _) =>
-            msg.cardinality = reader
-              |> @lib.async_read_enum()
-              |> Field_Cardinality::from_enum
-          (3, _) => msg.number = reader |> @lib.async_read_int32()
-          (4, _) => msg.name = reader |> @lib.async_read_string()
-          (6, _) => msg.type_url = reader |> @lib.async_read_string()
-          (7, _) => msg.oneof_index = reader |> @lib.async_read_int32()
-          (8, _) => msg.packed = reader |> @lib.async_read_bool()
-          (9, _) =>
-            msg.options.push((reader |> @lib.async_read_message() : Option))
-          (10, _) => msg.json_name = reader |> @lib.async_read_string()
-          (11, _) => msg.default_value = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.kind = reader |> @lib.async_read_enum() |> Field_Kind::from_enum
+      (2, _) =>
+        msg.cardinality = reader
+          |> @lib.async_read_enum()
+          |> Field_Cardinality::from_enum
+      (3, _) => msg.number = reader |> @lib.async_read_int32()
+      (4, _) => msg.name = reader |> @lib.async_read_string()
+      (6, _) => msg.type_url = reader |> @lib.async_read_string()
+      (7, _) => msg.oneof_index = reader |> @lib.async_read_int32()
+      (8, _) => msg.packed = reader |> @lib.async_read_bool()
+      (9, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (10, _) => msg.json_name = reader |> @lib.async_read_string()
+      (11, _) => msg.default_value = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1011,22 +993,17 @@ pub impl @lib.Read for Enum with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Enum raise {
   let msg = Enum::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) =>
-            msg.enumvalue.push((reader |> @lib.read_message() : EnumValue))
-          (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
-          (4, _) =>
-            msg.source_context = (reader |> @lib.read_message() : SourceContext)
-              |> Some
-          (5, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
-          (6, _) => msg.edition = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.enumvalue.push((reader |> @lib.read_message() : EnumValue))
+      (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
+      (4, _) =>
+        msg.source_context = (reader |> @lib.read_message() : SourceContext)
+          |> Some
+      (5, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
+      (6, _) => msg.edition = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1116,27 +1093,21 @@ pub impl @lib.AsyncRead for Enum with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Enum raise {
   let msg = Enum::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) =>
-            msg.enumvalue.push(
-              (reader |> @lib.async_read_message() : EnumValue),
-            )
-          (3, _) =>
-            msg.options.push((reader |> @lib.async_read_message() : Option))
-          (4, _) =>
-            msg.source_context = (
-                reader |> @lib.async_read_message() : SourceContext)
-              |> Some
-          (5, _) =>
-            msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
-          (6, _) => msg.edition = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) =>
+        msg.enumvalue.push((reader |> @lib.async_read_message() : EnumValue))
+      (3, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (4, _) =>
+        msg.source_context = (
+            reader |> @lib.async_read_message() : SourceContext)
+          |> Some
+      (5, _) =>
+        msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
+      (6, _) => msg.edition = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1222,16 +1193,12 @@ pub impl @lib.Read for EnumValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EnumValue raise {
   let msg = EnumValue::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.number = reader |> @lib.read_int32()
-          (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.number = reader |> @lib.read_int32()
+      (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1297,17 +1264,13 @@ pub impl @lib.AsyncRead for EnumValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EnumValue raise {
   let msg = EnumValue::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) => msg.number = reader |> @lib.async_read_int32()
-          (3, _) =>
-            msg.options.push((reader |> @lib.async_read_message() : Option))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.number = reader |> @lib.async_read_int32()
+      (3, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1373,15 +1336,11 @@ pub impl @lib.Read for Option with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Option raise {
   let msg = Option::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.value = (reader |> @lib.read_message() : Any) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.value = (reader |> @lib.read_message() : Any) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1439,16 +1398,12 @@ pub impl @lib.AsyncRead for Option with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Option raise {
   let msg = Option::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) =>
-            msg.value = (reader |> @lib.async_read_message() : Any) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.value = (reader |> @lib.async_read_message() : Any) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/lib/google/protobuf/wrappers.mbt
+++ b/lib/google/protobuf/wrappers.mbt
@@ -27,16 +27,15 @@ pub impl @lib.Read for DoubleValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> DoubleValue raise {
   let msg = DoubleValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.value = reader |> @lib.read_double()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.read_double()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -84,16 +83,15 @@ pub impl @lib.AsyncRead for DoubleValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> DoubleValue raise {
   let msg = DoubleValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.value = reader |> @lib.async_read_double()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.async_read_double()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -138,16 +136,15 @@ pub impl @lib.Read for FloatValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FloatValue raise {
   let msg = FloatValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.value = reader |> @lib.read_float()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.read_float()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -195,16 +192,15 @@ pub impl @lib.AsyncRead for FloatValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FloatValue raise {
   let msg = FloatValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.value = reader |> @lib.async_read_float()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.async_read_float()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -249,16 +245,15 @@ pub impl @lib.Read for Int64Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Int64Value raise {
   let msg = Int64Value::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.value = reader |> @lib.read_int64()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.read_int64()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -306,16 +301,15 @@ pub impl @lib.AsyncRead for Int64Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Int64Value raise {
   let msg = Int64Value::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.value = reader |> @lib.async_read_int64()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.async_read_int64()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -360,16 +354,15 @@ pub impl @lib.Read for UInt64Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> UInt64Value raise {
   let msg = UInt64Value::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.value = reader |> @lib.read_uint64()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.read_uint64()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -417,16 +410,15 @@ pub impl @lib.AsyncRead for UInt64Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> UInt64Value raise {
   let msg = UInt64Value::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.value = reader |> @lib.async_read_uint64()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.async_read_uint64()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -471,16 +463,15 @@ pub impl @lib.Read for Int32Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Int32Value raise {
   let msg = Int32Value::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.value = reader |> @lib.read_int32()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -528,16 +519,15 @@ pub impl @lib.AsyncRead for Int32Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Int32Value raise {
   let msg = Int32Value::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.value = reader |> @lib.async_read_int32()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -582,16 +572,15 @@ pub impl @lib.Read for UInt32Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> UInt32Value raise {
   let msg = UInt32Value::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.value = reader |> @lib.read_uint32()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.read_uint32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -639,16 +628,15 @@ pub impl @lib.AsyncRead for UInt32Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> UInt32Value raise {
   let msg = UInt32Value::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.value = reader |> @lib.async_read_uint32()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.async_read_uint32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -693,16 +681,15 @@ pub impl @lib.Read for BoolValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BoolValue raise {
   let msg = BoolValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.value = reader |> @lib.read_bool()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.read_bool()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -750,16 +737,15 @@ pub impl @lib.AsyncRead for BoolValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BoolValue raise {
   let msg = BoolValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.value = reader |> @lib.async_read_bool()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.async_read_bool()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -808,16 +794,15 @@ pub impl @lib.Read for StringValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> StringValue raise {
   let msg = StringValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.value = reader |> @lib.read_string()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -865,16 +850,15 @@ pub impl @lib.AsyncRead for StringValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> StringValue raise {
   let msg = StringValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.value = reader |> @lib.async_read_string()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -923,16 +907,15 @@ pub impl @lib.Read for BytesValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BytesValue raise {
   let msg = BytesValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.value = reader |> @lib.read_bytes()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.read_bytes()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -983,16 +966,15 @@ pub impl @lib.AsyncRead for BytesValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BytesValue raise {
   let msg = BytesValue::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.value = reader |> @lib.async_read_bytes()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.async_read_bytes()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }

--- a/lib/google/protobuf/wrappers.mbt
+++ b/lib/google/protobuf/wrappers.mbt
@@ -27,14 +27,10 @@ pub impl @lib.Read for DoubleValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> DoubleValue raise {
   let msg = DoubleValue::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.read_double()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.read_double()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -83,14 +79,11 @@ pub impl @lib.AsyncRead for DoubleValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> DoubleValue raise {
   let msg = DoubleValue::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.async_read_double()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.async_read_double()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -136,14 +129,10 @@ pub impl @lib.Read for FloatValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FloatValue raise {
   let msg = FloatValue::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.read_float()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.read_float()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -192,14 +181,11 @@ pub impl @lib.AsyncRead for FloatValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FloatValue raise {
   let msg = FloatValue::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.async_read_float()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.async_read_float()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -245,14 +231,10 @@ pub impl @lib.Read for Int64Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Int64Value raise {
   let msg = Int64Value::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.read_int64()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.read_int64()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -301,14 +283,11 @@ pub impl @lib.AsyncRead for Int64Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Int64Value raise {
   let msg = Int64Value::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.async_read_int64()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.async_read_int64()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -354,14 +333,10 @@ pub impl @lib.Read for UInt64Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> UInt64Value raise {
   let msg = UInt64Value::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.read_uint64()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.read_uint64()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -410,14 +385,11 @@ pub impl @lib.AsyncRead for UInt64Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> UInt64Value raise {
   let msg = UInt64Value::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.async_read_uint64()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.async_read_uint64()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -463,14 +435,10 @@ pub impl @lib.Read for Int32Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> Int32Value raise {
   let msg = Int32Value::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -519,14 +487,11 @@ pub impl @lib.AsyncRead for Int32Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> Int32Value raise {
   let msg = Int32Value::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -572,14 +537,10 @@ pub impl @lib.Read for UInt32Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> UInt32Value raise {
   let msg = UInt32Value::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.read_uint32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.read_uint32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -628,14 +589,11 @@ pub impl @lib.AsyncRead for UInt32Value with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> UInt32Value raise {
   let msg = UInt32Value::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.async_read_uint32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.async_read_uint32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -681,14 +639,10 @@ pub impl @lib.Read for BoolValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BoolValue raise {
   let msg = BoolValue::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.read_bool()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.read_bool()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -737,14 +691,11 @@ pub impl @lib.AsyncRead for BoolValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BoolValue raise {
   let msg = BoolValue::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.async_read_bool()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.async_read_bool()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -794,14 +745,10 @@ pub impl @lib.Read for StringValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> StringValue raise {
   let msg = StringValue::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -850,14 +797,11 @@ pub impl @lib.AsyncRead for StringValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> StringValue raise {
   let msg = StringValue::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -907,14 +851,10 @@ pub impl @lib.Read for BytesValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BytesValue raise {
   let msg = BytesValue::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.read_bytes()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.read_bytes()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -966,14 +906,11 @@ pub impl @lib.AsyncRead for BytesValue with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BytesValue raise {
   let msg = BytesValue::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.async_read_bytes()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.async_read_bytes()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -28,6 +28,8 @@ pub async fn[T : AsyncReader] async_read_int64(T) -> Int64
 
 pub async fn[M : AsyncRead + Default] async_read_message(LimitedReader[&AsyncReader]) -> M
 
+pub async fn[R : AsyncReader] async_read_message_fields(LimitedReader[R], async (UInt, UInt) -> Bool) -> Unit
+
 pub async fn[M : Sized, R : AsyncReader] async_read_packed(R, async (LimitedReader[R]) -> M, UInt?) -> Array[M]
 
 pub async fn[T : AsyncReader] async_read_sfixed32(T) -> Int
@@ -67,6 +69,8 @@ pub async fn[T : AsyncWriter] async_write_float(T, Float) -> Unit
 pub async fn[T : AsyncWriter] async_write_int32(T, Int) -> Unit
 
 pub async fn[T : AsyncWriter] async_write_int64(T, Int64) -> Unit
+
+pub async fn[M : AsyncWrite + Sized, T : AsyncWriter] async_write_message(T, M) -> Unit
 
 pub async fn[T : AsyncWriter] async_write_sfixed32(T, Int) -> Unit
 
@@ -110,6 +114,8 @@ pub fn[T : Reader] read_int64(T) -> Int64 raise
 
 pub fn[M : Read + Default] read_message(LimitedReader[&Reader]) -> M raise
 
+pub fn[R : Reader] read_message_fields(LimitedReader[R], (UInt, UInt) -> Bool raise) -> Unit raise
+
 pub fn[M : Sized, R : Reader] read_packed(R, (LimitedReader[R]) -> M raise, UInt?) -> Array[M] raise
 
 pub fn[T : Reader] read_sfixed32(T) -> Int raise
@@ -151,6 +157,8 @@ pub fn[T : Writer] write_float(T, Float) -> Unit raise
 pub fn[T : Writer] write_int32(T, Int) -> Unit raise
 
 pub fn[T : Writer] write_int64(T, Int64) -> Unit raise
+
+pub fn[M : Write + Sized, T : Writer] write_message(T, M) -> Unit raise
 
 pub fn[T : Writer] write_sfixed32(T, Int) -> Unit raise
 

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -28,7 +28,7 @@ pub async fn[T : AsyncReader] async_read_int64(T) -> Int64
 
 pub async fn[M : AsyncRead + Default] async_read_message(LimitedReader[&AsyncReader]) -> M
 
-pub async fn[R : AsyncReader] async_read_message_fields(LimitedReader[R], async (UInt, UInt) -> Bool) -> Unit
+pub async fn[R : AsyncReader] async_read_next_message_field(LimitedReader[R]) -> (UInt, UInt)?
 
 pub async fn[M : Sized, R : AsyncReader] async_read_packed(R, async (LimitedReader[R]) -> M, UInt?) -> Array[M]
 
@@ -51,6 +51,8 @@ pub async fn[T : AsyncReader] async_read_uint64(T) -> UInt64
 pub async fn[T : AsyncReader] async_read_unknown(T, UInt) -> Unit
 
 pub async fn[T : AsyncReader] async_read_varint32(T) -> UInt
+
+pub async fn[T : AsyncReader] async_skip_message_field(T, UInt) -> Unit
 
 pub async fn[T : AsyncWriter] async_write_bool(T, Bool) -> Unit
 
@@ -114,7 +116,7 @@ pub fn[T : Reader] read_int64(T) -> Int64 raise
 
 pub fn[M : Read + Default] read_message(LimitedReader[&Reader]) -> M raise
 
-pub fn[R : Reader] read_message_fields(LimitedReader[R], (UInt, UInt) -> Bool raise) -> Unit raise
+pub fn[R : Reader] read_next_message_field(LimitedReader[R]) -> (UInt, UInt)? raise
 
 pub fn[M : Sized, R : Reader] read_packed(R, (LimitedReader[R]) -> M raise, UInt?) -> Array[M] raise
 
@@ -139,6 +141,8 @@ pub fn[T : Reader] read_unknown(T, UInt) -> Unit raise
 pub fn[T : Reader] read_varint32(T) -> UInt raise
 
 pub fn[T : Sized] size_of(T) -> UInt
+
+pub fn[T : Reader] skip_message_field(T, UInt) -> Unit raise
 
 pub fn[T : Writer] write_bool(T, Bool) -> Unit raise
 

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -229,19 +229,11 @@ pub fn[M : Read + Default] read_message(
 }
 
 ///|
-pub fn[R : Reader] read_message_fields(
+pub fn[R : Reader] read_next_message_field(
   reader : LimitedReader[R],
-  handle_field : (UInt, UInt) -> Bool raise,
-) -> Unit raise {
-  try {
-    for ;; {
-      let (field_number, wire_type) = reader |> read_tag()
-      if !handle_field(field_number, wire_type) {
-        reader |> read_unknown(wire_type)
-      }
-    }
-  } catch {
-    EndOfStream => ()
+) -> (UInt, UInt)? raise {
+  Some(reader |> read_tag()) catch {
+    EndOfStream => None
     err => raise err
   }
 }
@@ -288,4 +280,12 @@ pub fn[T : Reader] read_unknown(reader : T, wire_type : UInt) -> Unit raise {
     5 => reader |> read_fixed32() |> ignore
     _ => raise ReaderError::UnknownWireType(wire_type)
   }
+}
+
+///|
+pub fn[T : Reader] skip_message_field(
+  reader : T,
+  wire_type : UInt,
+) -> Unit raise {
+  reader |> read_unknown(wire_type)
 }

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -229,6 +229,24 @@ pub fn[M : Read + Default] read_message(
 }
 
 ///|
+pub fn[R : Reader] read_message_fields(
+  reader : LimitedReader[R],
+  handle_field : (UInt, UInt) -> Bool raise,
+) -> Unit raise {
+  try {
+    for ;; {
+      let (field_number, wire_type) = reader |> read_tag()
+      if !handle_field(field_number, wire_type) {
+        reader |> read_unknown(wire_type)
+      }
+    }
+  } catch {
+    EndOfStream => ()
+    err => raise err
+  }
+}
+
+///|
 /// Reads packed repeated field (Array[M])
 ///
 /// Note: packed field are stored as a variable length chunk of data, while regular repeated

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -274,6 +274,25 @@ test "read_string/negative_length" {
 }
 
 ///|
+test "read_message_fields handles known fields and skips unknown fields" {
+  let reader = @protobuf.BytesReader::from_bytes(b"\x08\x96\x01\x10\x01")
+    as &@protobuf.Reader
+  let reader = @protobuf.LimitedReader::new(reader)
+  let mut value = 0
+  reader
+  |> @protobuf.read_message_fields(fn(field_number, wire_type) raise {
+    match (field_number, wire_type) {
+      (1, 0) => {
+        value = reader |> @protobuf.read_int32()
+        true
+      }
+      _ => false
+    }
+  })
+  @debug.assert_eq(value, 150)
+}
+
+///|
 test "read_packed rejects misaligned length for fixed-size elements" {
   // Length prefix of 5 bytes, but fixed32 elements are 4 bytes each.
   // 5 % 4 != 0, so this should be rejected.

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -279,14 +279,11 @@ test "read_next_message_field handles normal message completion" {
     as &@protobuf.Reader
   let reader = @protobuf.LimitedReader::new(reader)
   let mut value = 0
-  for ;; {
-    match (reader |> @protobuf.read_next_message_field()) {
-      Some((field_number, wire_type)) =>
-        match (field_number, wire_type) {
-          (1, 0) => value = reader |> @protobuf.read_int32()
-          _ => reader |> @protobuf.skip_message_field(wire_type)
-        }
-      None => break
+  while (reader |> @protobuf.read_next_message_field())
+        is Some((field_number, wire_type)) {
+    match (field_number, wire_type) {
+      (1, 0) => value = reader |> @protobuf.read_int32()
+      _ => reader |> @protobuf.skip_message_field(wire_type)
     }
   }
   @debug.assert_eq(value, 150)

--- a/lib/reader_test.mbt
+++ b/lib/reader_test.mbt
@@ -274,21 +274,21 @@ test "read_string/negative_length" {
 }
 
 ///|
-test "read_message_fields handles known fields and skips unknown fields" {
+test "read_next_message_field handles normal message completion" {
   let reader = @protobuf.BytesReader::from_bytes(b"\x08\x96\x01\x10\x01")
     as &@protobuf.Reader
   let reader = @protobuf.LimitedReader::new(reader)
   let mut value = 0
-  reader
-  |> @protobuf.read_message_fields(fn(field_number, wire_type) raise {
-    match (field_number, wire_type) {
-      (1, 0) => {
-        value = reader |> @protobuf.read_int32()
-        true
-      }
-      _ => false
+  for ;; {
+    match (reader |> @protobuf.read_next_message_field()) {
+      Some((field_number, wire_type)) =>
+        match (field_number, wire_type) {
+          (1, 0) => value = reader |> @protobuf.read_int32()
+          _ => reader |> @protobuf.skip_message_field(wire_type)
+        }
+      None => break
     }
-  })
+  }
   @debug.assert_eq(value, 150)
 }
 

--- a/lib/writer.mbt
+++ b/lib/writer.mbt
@@ -127,3 +127,12 @@ pub fn[T : Writer] write_string(writer : T, v : String) -> Unit raise {
   writer |> write_varint(utf8_string.length().reinterpret_as_uint().to_uint64())
   writer.write(utf8_string)
 }
+
+///|
+pub fn[M : Write + Sized, T : Writer] write_message(
+  writer : T,
+  message : M,
+) -> Unit raise {
+  writer |> write_uint32(size_of(message))
+  Write::write(message, writer)
+}

--- a/lib/writer_test.mbt
+++ b/lib/writer_test.mbt
@@ -61,3 +61,25 @@ test "string" {
     b"\x02\x61\x62\x06\xE4\xB8\xAD\xE6\x96\x87",
   )
 }
+
+///|
+struct TinyMessage {
+  value : Int
+}
+
+///|
+impl @protobuf.Sized for TinyMessage with fn size_of(self) {
+  @protobuf.size_of(self.value)
+}
+
+///|
+impl @protobuf.Write for TinyMessage with fn write(self, writer) raise {
+  writer |> @protobuf.write_int32(self.value)
+}
+
+///|
+test "write_message prefixes the encoded message size" {
+  let writer = Buffer()
+  writer |> @protobuf.write_message({ value: 150 })
+  @debug.assert_eq(writer.to_bytes(), b"\x02\x96\x01")
+}

--- a/test/reader/gen_proto2/src/top.mbt
+++ b/test/reader/gen_proto2/src/top.mbt
@@ -83,14 +83,10 @@ pub impl @lib.Read for BarMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BarMessageP2 raise {
   let msg = BarMessageP2::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.b_int32 = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.b_int32 = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -137,14 +133,11 @@ pub impl @lib.AsyncRead for BarMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BarMessageP2 raise {
   let msg = BarMessageP2::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -498,94 +491,86 @@ pub impl @lib.Read for FooMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FooMessageP2 raise {
   let msg = FooMessageP2::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_int32 = reader |> @lib.read_int32()
-          (2, _) => msg.f_int64 = reader |> @lib.read_int64()
-          (3, _) => msg.f_uint32 = reader |> @lib.read_uint32() |> Some
-          (4, _) => msg.f_uint64 = reader |> @lib.read_uint64() |> Some
-          (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0 |> Some
-          (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0 |> Some
-          (7, _) => msg.f_bool = reader |> @lib.read_bool() |> Some
-          (8, _) =>
-            msg.f_foo_enum = reader
-              |> @lib.read_enum()
-              |> FooEnumP2::from_enum
-              |> Some
-          (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64() |> Some
-          (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64() |> Some
-          (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32() |> Some
-          (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32() |> Some
-          (13, _) => msg.f_double = reader |> @lib.read_double() |> Some
-          (14, _) => msg.f_float = reader |> @lib.read_float() |> Some
-          (15, _) => msg.f_bytes = reader |> @lib.read_bytes() |> Some
-          (16, _) => msg.f_string = reader |> @lib.read_string() |> Some
-          (18, _) =>
-            msg.f_bar_message = (reader |> @lib.read_message() : BarMessageP2)
-              |> Some
-          (19, 2) =>
-            msg.f_repeated_int32.push_iter(
-              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-            )
-          (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
-          (20, 2) =>
-            msg.f_repeated_packed_int32.push_iter(
-              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-            )
-          (20, 0) =>
-            msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
-          (21, 2) =>
-            msg.f_repeated_packed_float.push_iter(
-              (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
-            )
-          (21, 5) =>
-            msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-          (23, _) =>
-            msg.f_baz = (reader |> @lib.read_message() : BazMessageP2) |> Some
-          (24, _) =>
-            msg.f_nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
-              |> Some
-          (25, _) =>
-            msg.f_nested_enum = reader
-              |> @lib.read_enum()
-              |> BazMessageP2_Nested_NestedEnum::from_enum
-              |> Some
-          (27, _) =>
-            msg.f_map.push((reader |> @lib.read_message() : MapEntryP2))
-          (28, _) => msg.f1 = reader |> @lib.read_int32() |> Some
-          (29, _) => msg.f2 = reader |> @lib.read_bool() |> Some
-          (30, _) => msg.f3 = reader |> @lib.read_string() |> Some
-          (31, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-          (32, _) =>
-            msg.f_repeated_baz_message.push(
-              (reader |> @lib.read_message() : BazMessageP2),
-            )
-          (33, _) =>
-            msg.f_optional_string = reader |> @lib.read_string() |> Some
-          (34, _) => msg.f_default_int32 = reader |> @lib.read_int32() |> Some
-          (35, _) => msg.f_default_string = reader |> @lib.read_string() |> Some
-          (36, _) => msg.f_default_bool = reader |> @lib.read_bool() |> Some
-          (37, _) => msg.f_default_double = reader |> @lib.read_double() |> Some
-          (38, _) =>
-            msg.f_default_enum = reader
-              |> @lib.read_enum()
-              |> FooEnumP2::from_enum
-              |> Some
-          (39, 2) => {
-            let packed = reader |> @lib.read_packed(@lib.read_enum, None)
-            for item in packed {
-              msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
-            }
-          }
-          (39, 0) =>
-            msg.f_repeated_packed_enum.push(
-              reader |> @lib.read_enum() |> FooEnumP2::from_enum,
-            )
-          _ => reader |> @lib.skip_message_field(wire)
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_int32 = reader |> @lib.read_int32()
+      (2, _) => msg.f_int64 = reader |> @lib.read_int64()
+      (3, _) => msg.f_uint32 = reader |> @lib.read_uint32() |> Some
+      (4, _) => msg.f_uint64 = reader |> @lib.read_uint64() |> Some
+      (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0 |> Some
+      (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0 |> Some
+      (7, _) => msg.f_bool = reader |> @lib.read_bool() |> Some
+      (8, _) =>
+        msg.f_foo_enum = reader
+          |> @lib.read_enum()
+          |> FooEnumP2::from_enum
+          |> Some
+      (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64() |> Some
+      (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64() |> Some
+      (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32() |> Some
+      (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32() |> Some
+      (13, _) => msg.f_double = reader |> @lib.read_double() |> Some
+      (14, _) => msg.f_float = reader |> @lib.read_float() |> Some
+      (15, _) => msg.f_bytes = reader |> @lib.read_bytes() |> Some
+      (16, _) => msg.f_string = reader |> @lib.read_string() |> Some
+      (18, _) =>
+        msg.f_bar_message = (reader |> @lib.read_message() : BarMessageP2)
+          |> Some
+      (19, 2) =>
+        msg.f_repeated_int32.push_iter(
+          (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+        )
+      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
+      (20, 2) =>
+        msg.f_repeated_packed_int32.push_iter(
+          (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+        )
+      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+      (21, 2) =>
+        msg.f_repeated_packed_float.push_iter(
+          (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
+        )
+      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
+      (23, _) =>
+        msg.f_baz = (reader |> @lib.read_message() : BazMessageP2) |> Some
+      (24, _) =>
+        msg.f_nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
+          |> Some
+      (25, _) =>
+        msg.f_nested_enum = reader
+          |> @lib.read_enum()
+          |> BazMessageP2_Nested_NestedEnum::from_enum
+          |> Some
+      (27, _) => msg.f_map.push((reader |> @lib.read_message() : MapEntryP2))
+      (28, _) => msg.f1 = reader |> @lib.read_int32() |> Some
+      (29, _) => msg.f2 = reader |> @lib.read_bool() |> Some
+      (30, _) => msg.f3 = reader |> @lib.read_string() |> Some
+      (31, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
+      (32, _) =>
+        msg.f_repeated_baz_message.push(
+          (reader |> @lib.read_message() : BazMessageP2),
+        )
+      (33, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
+      (34, _) => msg.f_default_int32 = reader |> @lib.read_int32() |> Some
+      (35, _) => msg.f_default_string = reader |> @lib.read_string() |> Some
+      (36, _) => msg.f_default_bool = reader |> @lib.read_bool() |> Some
+      (37, _) => msg.f_default_double = reader |> @lib.read_double() |> Some
+      (38, _) =>
+        msg.f_default_enum = reader
+          |> @lib.read_enum()
+          |> FooEnumP2::from_enum
+          |> Some
+      (39, 2) => {
+        let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+        for item in packed {
+          msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
         }
-      None => break
+      }
+      (39, 0) =>
+        msg.f_repeated_packed_enum.push(
+          reader |> @lib.read_enum() |> FooEnumP2::from_enum,
+        )
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -998,108 +983,95 @@ pub impl @lib.AsyncRead for FooMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FooMessageP2 raise {
   let msg = FooMessageP2::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
-          (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
-          (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32() |> Some
-          (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64() |> Some
-          (5, _) =>
-            msg.f_sint32 = (reader |> @lib.async_read_sint32()).0 |> Some
-          (6, _) =>
-            msg.f_sint64 = (reader |> @lib.async_read_sint64()).0 |> Some
-          (7, _) => msg.f_bool = reader |> @lib.async_read_bool() |> Some
-          (8, _) =>
-            msg.f_foo_enum = reader
-              |> @lib.async_read_enum()
-              |> FooEnumP2::from_enum
-              |> Some
-          (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64() |> Some
-          (10, _) =>
-            msg.f_sfixed64 = reader |> @lib.async_read_sfixed64() |> Some
-          (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32() |> Some
-          (12, _) =>
-            msg.f_sfixed32 = reader |> @lib.async_read_sfixed32() |> Some
-          (13, _) => msg.f_double = reader |> @lib.async_read_double() |> Some
-          (14, _) => msg.f_float = reader |> @lib.async_read_float() |> Some
-          (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes() |> Some
-          (16, _) => msg.f_string = reader |> @lib.async_read_string() |> Some
-          (18, _) =>
-            msg.f_bar_message = (
-                reader |> @lib.async_read_message() : BarMessageP2)
-              |> Some
-          (19, 2) =>
-            msg.f_repeated_int32.push_iter(
-              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-            )
-          (19, 0) =>
-            msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
-          (20, 2) =>
-            msg.f_repeated_packed_int32.push_iter(
-              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-            )
-          (20, 0) =>
-            msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
-          (21, 2) =>
-            msg.f_repeated_packed_float.push_iter(
-              (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
-            )
-          (21, 5) =>
-            msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-          (23, _) =>
-            msg.f_baz = (reader |> @lib.async_read_message() : BazMessageP2)
-              |> Some
-          (24, _) =>
-            msg.f_nested = (
-                reader |> @lib.async_read_message() : BazMessageP2_Nested)
-              |> Some
-          (25, _) =>
-            msg.f_nested_enum = reader
-              |> @lib.async_read_enum()
-              |> BazMessageP2_Nested_NestedEnum::from_enum
-              |> Some
-          (27, _) =>
-            msg.f_map.push((reader |> @lib.async_read_message() : MapEntryP2))
-          (28, _) => msg.f1 = reader |> @lib.async_read_int32() |> Some
-          (29, _) => msg.f2 = reader |> @lib.async_read_bool() |> Some
-          (30, _) => msg.f3 = reader |> @lib.async_read_string() |> Some
-          (31, _) =>
-            msg.f_repeated_string.push(reader |> @lib.async_read_string())
-          (32, _) =>
-            msg.f_repeated_baz_message.push(
-              (reader |> @lib.async_read_message() : BazMessageP2),
-            )
-          (33, _) =>
-            msg.f_optional_string = reader |> @lib.async_read_string() |> Some
-          (34, _) =>
-            msg.f_default_int32 = reader |> @lib.async_read_int32() |> Some
-          (35, _) =>
-            msg.f_default_string = reader |> @lib.async_read_string() |> Some
-          (36, _) =>
-            msg.f_default_bool = reader |> @lib.async_read_bool() |> Some
-          (37, _) =>
-            msg.f_default_double = reader |> @lib.async_read_double() |> Some
-          (38, _) =>
-            msg.f_default_enum = reader
-              |> @lib.async_read_enum()
-              |> FooEnumP2::from_enum
-              |> Some
-          (39, 2) => {
-            let packed = reader
-              |> @lib.async_read_packed(@lib.async_read_enum, None)
-            for item in packed {
-              msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
-            }
-          }
-          (39, 0) =>
-            msg.f_repeated_packed_enum.push(
-              reader |> @lib.async_read_enum() |> FooEnumP2::from_enum,
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
+      (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
+      (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32() |> Some
+      (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64() |> Some
+      (5, _) => msg.f_sint32 = (reader |> @lib.async_read_sint32()).0 |> Some
+      (6, _) => msg.f_sint64 = (reader |> @lib.async_read_sint64()).0 |> Some
+      (7, _) => msg.f_bool = reader |> @lib.async_read_bool() |> Some
+      (8, _) =>
+        msg.f_foo_enum = reader
+          |> @lib.async_read_enum()
+          |> FooEnumP2::from_enum
+          |> Some
+      (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64() |> Some
+      (10, _) => msg.f_sfixed64 = reader |> @lib.async_read_sfixed64() |> Some
+      (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32() |> Some
+      (12, _) => msg.f_sfixed32 = reader |> @lib.async_read_sfixed32() |> Some
+      (13, _) => msg.f_double = reader |> @lib.async_read_double() |> Some
+      (14, _) => msg.f_float = reader |> @lib.async_read_float() |> Some
+      (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes() |> Some
+      (16, _) => msg.f_string = reader |> @lib.async_read_string() |> Some
+      (18, _) =>
+        msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessageP2)
+          |> Some
+      (19, 2) =>
+        msg.f_repeated_int32.push_iter(
+          (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+        )
+      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+      (20, 2) =>
+        msg.f_repeated_packed_int32.push_iter(
+          (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+        )
+      (20, 0) =>
+        msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
+      (21, 2) =>
+        msg.f_repeated_packed_float.push_iter(
+          (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
+        )
+      (21, 5) =>
+        msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
+      (23, _) =>
+        msg.f_baz = (reader |> @lib.async_read_message() : BazMessageP2) |> Some
+      (24, _) =>
+        msg.f_nested = (
+            reader |> @lib.async_read_message() : BazMessageP2_Nested)
+          |> Some
+      (25, _) =>
+        msg.f_nested_enum = reader
+          |> @lib.async_read_enum()
+          |> BazMessageP2_Nested_NestedEnum::from_enum
+          |> Some
+      (27, _) =>
+        msg.f_map.push((reader |> @lib.async_read_message() : MapEntryP2))
+      (28, _) => msg.f1 = reader |> @lib.async_read_int32() |> Some
+      (29, _) => msg.f2 = reader |> @lib.async_read_bool() |> Some
+      (30, _) => msg.f3 = reader |> @lib.async_read_string() |> Some
+      (31, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
+      (32, _) =>
+        msg.f_repeated_baz_message.push(
+          (reader |> @lib.async_read_message() : BazMessageP2),
+        )
+      (33, _) =>
+        msg.f_optional_string = reader |> @lib.async_read_string() |> Some
+      (34, _) => msg.f_default_int32 = reader |> @lib.async_read_int32() |> Some
+      (35, _) =>
+        msg.f_default_string = reader |> @lib.async_read_string() |> Some
+      (36, _) => msg.f_default_bool = reader |> @lib.async_read_bool() |> Some
+      (37, _) =>
+        msg.f_default_double = reader |> @lib.async_read_double() |> Some
+      (38, _) =>
+        msg.f_default_enum = reader
+          |> @lib.async_read_enum()
+          |> FooEnumP2::from_enum
+          |> Some
+      (39, 2) => {
+        let packed = reader
+          |> @lib.async_read_packed(@lib.async_read_enum, None)
+        for item in packed {
+          msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
         }
-      None => break
+      }
+      (39, 0) =>
+        msg.f_repeated_packed_enum.push(
+          reader |> @lib.async_read_enum() |> FooEnumP2::from_enum,
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1303,15 +1275,11 @@ pub impl @lib.Read for MapEntryP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MapEntryP2 raise {
   let msg = MapEntryP2::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.read_string()
-          (2, _) => msg.value = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.read_string()
+      (2, _) => msg.value = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1364,15 +1332,12 @@ pub impl @lib.AsyncRead for MapEntryP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MapEntryP2 raise {
   let msg = MapEntryP2::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.async_read_string()
-          (2, _) => msg.value = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.async_read_string()
+      (2, _) => msg.value = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1490,14 +1455,10 @@ pub impl @lib.Read for BazMessageP2_Nested_NestedMessage with fn read_with_limit
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessageP2_Nested_NestedMessage raise {
   let msg = BazMessageP2_Nested_NestedMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_nested = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_nested = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1546,14 +1507,11 @@ pub impl @lib.AsyncRead for BazMessageP2_Nested_NestedMessage with fn read_with_
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessageP2_Nested_NestedMessage raise {
   let msg = BazMessageP2_Nested_NestedMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1603,18 +1561,13 @@ pub impl @lib.Read for BazMessageP2_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessageP2_Nested raise {
   let msg = BazMessageP2_Nested::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.f_nested = (
-                reader |> @lib.read_message() :
-                BazMessageP2_Nested_NestedMessage)
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.f_nested = (
+            reader |> @lib.read_message() : BazMessageP2_Nested_NestedMessage)
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1667,18 +1620,15 @@ pub impl @lib.AsyncRead for BazMessageP2_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessageP2_Nested raise {
   let msg = BazMessageP2_Nested::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.f_nested = (
-                reader |> @lib.async_read_message() :
-                BazMessageP2_Nested_NestedMessage)
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.f_nested = (
+            reader |> @lib.async_read_message() :
+            BazMessageP2_Nested_NestedMessage)
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1744,18 +1694,14 @@ pub impl @lib.Read for BazMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessageP2 raise {
   let msg = BazMessageP2::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
-              |> Some
-          (2, _) => msg.b_int64 = reader |> @lib.read_int64() |> Some
-          (3, _) => msg.b_string = reader |> @lib.read_string() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
+          |> Some
+      (2, _) => msg.b_int64 = reader |> @lib.read_int64() |> Some
+      (3, _) => msg.b_string = reader |> @lib.read_string() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1824,19 +1770,15 @@ pub impl @lib.AsyncRead for BazMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessageP2 raise {
   let msg = BazMessageP2::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.nested = (
-                reader |> @lib.async_read_message() : BazMessageP2_Nested)
-              |> Some
-          (2, _) => msg.b_int64 = reader |> @lib.async_read_int64() |> Some
-          (3, _) => msg.b_string = reader |> @lib.async_read_string() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.nested = (reader |> @lib.async_read_message() : BazMessageP2_Nested)
+          |> Some
+      (2, _) => msg.b_int64 = reader |> @lib.async_read_int64() |> Some
+      (3, _) => msg.b_string = reader |> @lib.async_read_string() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1896,15 +1838,11 @@ pub impl @lib.Read for RepeatedMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> RepeatedMessageP2 raise {
   let msg = RepeatedMessageP2::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.bar_message.push((reader |> @lib.read_message() : BarMessageP2))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.bar_message.push((reader |> @lib.read_message() : BarMessageP2))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1956,17 +1894,14 @@ pub impl @lib.AsyncRead for RepeatedMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> RepeatedMessageP2 raise {
   let msg = RepeatedMessageP2::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.bar_message.push(
-              (reader |> @lib.async_read_message() : BarMessageP2),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.bar_message.push(
+          (reader |> @lib.async_read_message() : BarMessageP2),
+        )
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/reader/gen_proto2/src/top.mbt
+++ b/test/reader/gen_proto2/src/top.mbt
@@ -83,16 +83,15 @@ pub impl @lib.Read for BarMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BarMessageP2 raise {
   let msg = BarMessageP2::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.b_int32 = reader |> @lib.read_int32()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.b_int32 = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -138,16 +137,15 @@ pub impl @lib.AsyncRead for BarMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BarMessageP2 raise {
   let msg = BarMessageP2::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -500,92 +498,95 @@ pub impl @lib.Read for FooMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FooMessageP2 raise {
   let msg = FooMessageP2::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.f_int32 = reader |> @lib.read_int32()
-        (2, _) => msg.f_int64 = reader |> @lib.read_int64()
-        (3, _) => msg.f_uint32 = reader |> @lib.read_uint32() |> Some
-        (4, _) => msg.f_uint64 = reader |> @lib.read_uint64() |> Some
-        (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0 |> Some
-        (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0 |> Some
-        (7, _) => msg.f_bool = reader |> @lib.read_bool() |> Some
-        (8, _) =>
-          msg.f_foo_enum = reader
-            |> @lib.read_enum()
-            |> FooEnumP2::from_enum
-            |> Some
-        (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64() |> Some
-        (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64() |> Some
-        (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32() |> Some
-        (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32() |> Some
-        (13, _) => msg.f_double = reader |> @lib.read_double() |> Some
-        (14, _) => msg.f_float = reader |> @lib.read_float() |> Some
-        (15, _) => msg.f_bytes = reader |> @lib.read_bytes() |> Some
-        (16, _) => msg.f_string = reader |> @lib.read_string() |> Some
-        (18, _) =>
-          msg.f_bar_message = (reader |> @lib.read_message() : BarMessageP2)
-            |> Some
-        (19, 2) =>
-          msg.f_repeated_int32.push_iter(
-            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-          )
-        (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
-        (20, 2) =>
-          msg.f_repeated_packed_int32.push_iter(
-            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-          )
-        (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
-        (21, 2) =>
-          msg.f_repeated_packed_float.push_iter(
-            (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
-          )
-        (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-        (23, _) =>
-          msg.f_baz = (reader |> @lib.read_message() : BazMessageP2) |> Some
-        (24, _) =>
-          msg.f_nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
-            |> Some
-        (25, _) =>
-          msg.f_nested_enum = reader
-            |> @lib.read_enum()
-            |> BazMessageP2_Nested_NestedEnum::from_enum
-            |> Some
-        (27, _) => msg.f_map.push((reader |> @lib.read_message() : MapEntryP2))
-        (28, _) => msg.f1 = reader |> @lib.read_int32() |> Some
-        (29, _) => msg.f2 = reader |> @lib.read_bool() |> Some
-        (30, _) => msg.f3 = reader |> @lib.read_string() |> Some
-        (31, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-        (32, _) =>
-          msg.f_repeated_baz_message.push(
-            (reader |> @lib.read_message() : BazMessageP2),
-          )
-        (33, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
-        (34, _) => msg.f_default_int32 = reader |> @lib.read_int32() |> Some
-        (35, _) => msg.f_default_string = reader |> @lib.read_string() |> Some
-        (36, _) => msg.f_default_bool = reader |> @lib.read_bool() |> Some
-        (37, _) => msg.f_default_double = reader |> @lib.read_double() |> Some
-        (38, _) =>
-          msg.f_default_enum = reader
-            |> @lib.read_enum()
-            |> FooEnumP2::from_enum
-            |> Some
-        (39, 2) => {
-          let packed = reader |> @lib.read_packed(@lib.read_enum, None)
-          for item in packed {
-            msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_int32 = reader |> @lib.read_int32()
+          (2, _) => msg.f_int64 = reader |> @lib.read_int64()
+          (3, _) => msg.f_uint32 = reader |> @lib.read_uint32() |> Some
+          (4, _) => msg.f_uint64 = reader |> @lib.read_uint64() |> Some
+          (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0 |> Some
+          (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0 |> Some
+          (7, _) => msg.f_bool = reader |> @lib.read_bool() |> Some
+          (8, _) =>
+            msg.f_foo_enum = reader
+              |> @lib.read_enum()
+              |> FooEnumP2::from_enum
+              |> Some
+          (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64() |> Some
+          (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64() |> Some
+          (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32() |> Some
+          (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32() |> Some
+          (13, _) => msg.f_double = reader |> @lib.read_double() |> Some
+          (14, _) => msg.f_float = reader |> @lib.read_float() |> Some
+          (15, _) => msg.f_bytes = reader |> @lib.read_bytes() |> Some
+          (16, _) => msg.f_string = reader |> @lib.read_string() |> Some
+          (18, _) =>
+            msg.f_bar_message = (reader |> @lib.read_message() : BarMessageP2)
+              |> Some
+          (19, 2) =>
+            msg.f_repeated_int32.push_iter(
+              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+            )
+          (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
+          (20, 2) =>
+            msg.f_repeated_packed_int32.push_iter(
+              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+            )
+          (20, 0) =>
+            msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+          (21, 2) =>
+            msg.f_repeated_packed_float.push_iter(
+              (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
+            )
+          (21, 5) =>
+            msg.f_repeated_packed_float.push(reader |> @lib.read_float())
+          (23, _) =>
+            msg.f_baz = (reader |> @lib.read_message() : BazMessageP2) |> Some
+          (24, _) =>
+            msg.f_nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
+              |> Some
+          (25, _) =>
+            msg.f_nested_enum = reader
+              |> @lib.read_enum()
+              |> BazMessageP2_Nested_NestedEnum::from_enum
+              |> Some
+          (27, _) =>
+            msg.f_map.push((reader |> @lib.read_message() : MapEntryP2))
+          (28, _) => msg.f1 = reader |> @lib.read_int32() |> Some
+          (29, _) => msg.f2 = reader |> @lib.read_bool() |> Some
+          (30, _) => msg.f3 = reader |> @lib.read_string() |> Some
+          (31, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
+          (32, _) =>
+            msg.f_repeated_baz_message.push(
+              (reader |> @lib.read_message() : BazMessageP2),
+            )
+          (33, _) =>
+            msg.f_optional_string = reader |> @lib.read_string() |> Some
+          (34, _) => msg.f_default_int32 = reader |> @lib.read_int32() |> Some
+          (35, _) => msg.f_default_string = reader |> @lib.read_string() |> Some
+          (36, _) => msg.f_default_bool = reader |> @lib.read_bool() |> Some
+          (37, _) => msg.f_default_double = reader |> @lib.read_double() |> Some
+          (38, _) =>
+            msg.f_default_enum = reader
+              |> @lib.read_enum()
+              |> FooEnumP2::from_enum
+              |> Some
+          (39, 2) => {
+            let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+            for item in packed {
+              msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
+            }
           }
+          (39, 0) =>
+            msg.f_repeated_packed_enum.push(
+              reader |> @lib.read_enum() |> FooEnumP2::from_enum,
+            )
+          _ => reader |> @lib.skip_message_field(wire)
         }
-        (39, 0) =>
-          msg.f_repeated_packed_enum.push(
-            reader |> @lib.read_enum() |> FooEnumP2::from_enum,
-          )
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -657,8 +658,7 @@ pub impl @lib.Write for FooMessageP2 with fn write(
   }
   if self.f_bar_message is Some(v) {
     writer |> @lib.write_varint(146UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   for item in self.f_repeated_int32 {
     writer |> @lib.write_varint(152UL)
@@ -685,13 +685,11 @@ pub impl @lib.Write for FooMessageP2 with fn write(
   }
   if self.f_baz is Some(v) {
     writer |> @lib.write_varint(186UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.f_nested is Some(v) {
     writer |> @lib.write_varint(194UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.f_nested_enum is Some(v) {
     writer |> @lib.write_varint(200UL)
@@ -699,8 +697,7 @@ pub impl @lib.Write for FooMessageP2 with fn write(
   }
   for item in self.f_map {
     writer |> @lib.write_varint(218UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.f1 is Some(v) {
     writer |> @lib.write_varint(224UL)
@@ -720,8 +717,7 @@ pub impl @lib.Write for FooMessageP2 with fn write(
   }
   for item in self.f_repeated_baz_message {
     writer |> @lib.write_varint(258UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.f_optional_string is Some(v) {
     writer |> @lib.write_varint(266UL)
@@ -940,9 +936,11 @@ pub impl @json.FromJson for FooMessageP2 with fn from_json(
       ("fFloat", Number(value, ..)) =>
         message.f_float = Some(Float::from_double(value))
       ("fBytes", String(value)) =>
-        message.f_bytes = Some(try @lib.base64_decode(value) catch {
-          _ => raise @json.JsonDecodeError((path, "Invalid base64 encoding"))
-        })
+        message.f_bytes = Some(
+          @lib.base64_decode(value) catch {
+            _ => raise @json.JsonDecodeError((path, "Invalid base64 encoding"))
+          },
+        )
       ("fString", value) =>
         message.f_string = Some(@json.from_json(value, path~))
       ("fBarMessage", value) =>
@@ -1000,104 +998,109 @@ pub impl @lib.AsyncRead for FooMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FooMessageP2 raise {
   let msg = FooMessageP2::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
-        (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
-        (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32() |> Some
-        (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64() |> Some
-        (5, _) => msg.f_sint32 = (reader |> @lib.async_read_sint32()).0 |> Some
-        (6, _) => msg.f_sint64 = (reader |> @lib.async_read_sint64()).0 |> Some
-        (7, _) => msg.f_bool = reader |> @lib.async_read_bool() |> Some
-        (8, _) =>
-          msg.f_foo_enum = reader
-            |> @lib.async_read_enum()
-            |> FooEnumP2::from_enum
-            |> Some
-        (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64() |> Some
-        (10, _) => msg.f_sfixed64 = reader |> @lib.async_read_sfixed64() |> Some
-        (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32() |> Some
-        (12, _) => msg.f_sfixed32 = reader |> @lib.async_read_sfixed32() |> Some
-        (13, _) => msg.f_double = reader |> @lib.async_read_double() |> Some
-        (14, _) => msg.f_float = reader |> @lib.async_read_float() |> Some
-        (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes() |> Some
-        (16, _) => msg.f_string = reader |> @lib.async_read_string() |> Some
-        (18, _) =>
-          msg.f_bar_message = (
-              reader |> @lib.async_read_message() : BarMessageP2)
-            |> Some
-        (19, 2) =>
-          msg.f_repeated_int32.push_iter(
-            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-          )
-        (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
-        (20, 2) =>
-          msg.f_repeated_packed_int32.push_iter(
-            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-          )
-        (20, 0) =>
-          msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
-        (21, 2) =>
-          msg.f_repeated_packed_float.push_iter(
-            (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
-          )
-        (21, 5) =>
-          msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-        (23, _) =>
-          msg.f_baz = (reader |> @lib.async_read_message() : BazMessageP2)
-            |> Some
-        (24, _) =>
-          msg.f_nested = (
-              reader |> @lib.async_read_message() : BazMessageP2_Nested)
-            |> Some
-        (25, _) =>
-          msg.f_nested_enum = reader
-            |> @lib.async_read_enum()
-            |> BazMessageP2_Nested_NestedEnum::from_enum
-            |> Some
-        (27, _) =>
-          msg.f_map.push((reader |> @lib.async_read_message() : MapEntryP2))
-        (28, _) => msg.f1 = reader |> @lib.async_read_int32() |> Some
-        (29, _) => msg.f2 = reader |> @lib.async_read_bool() |> Some
-        (30, _) => msg.f3 = reader |> @lib.async_read_string() |> Some
-        (31, _) =>
-          msg.f_repeated_string.push(reader |> @lib.async_read_string())
-        (32, _) =>
-          msg.f_repeated_baz_message.push(
-            (reader |> @lib.async_read_message() : BazMessageP2),
-          )
-        (33, _) =>
-          msg.f_optional_string = reader |> @lib.async_read_string() |> Some
-        (34, _) =>
-          msg.f_default_int32 = reader |> @lib.async_read_int32() |> Some
-        (35, _) =>
-          msg.f_default_string = reader |> @lib.async_read_string() |> Some
-        (36, _) => msg.f_default_bool = reader |> @lib.async_read_bool() |> Some
-        (37, _) =>
-          msg.f_default_double = reader |> @lib.async_read_double() |> Some
-        (38, _) =>
-          msg.f_default_enum = reader
-            |> @lib.async_read_enum()
-            |> FooEnumP2::from_enum
-            |> Some
-        (39, 2) => {
-          let packed = reader
-            |> @lib.async_read_packed(@lib.async_read_enum, None)
-          for item in packed {
-            msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
+          (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
+          (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32() |> Some
+          (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64() |> Some
+          (5, _) =>
+            msg.f_sint32 = (reader |> @lib.async_read_sint32()).0 |> Some
+          (6, _) =>
+            msg.f_sint64 = (reader |> @lib.async_read_sint64()).0 |> Some
+          (7, _) => msg.f_bool = reader |> @lib.async_read_bool() |> Some
+          (8, _) =>
+            msg.f_foo_enum = reader
+              |> @lib.async_read_enum()
+              |> FooEnumP2::from_enum
+              |> Some
+          (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64() |> Some
+          (10, _) =>
+            msg.f_sfixed64 = reader |> @lib.async_read_sfixed64() |> Some
+          (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32() |> Some
+          (12, _) =>
+            msg.f_sfixed32 = reader |> @lib.async_read_sfixed32() |> Some
+          (13, _) => msg.f_double = reader |> @lib.async_read_double() |> Some
+          (14, _) => msg.f_float = reader |> @lib.async_read_float() |> Some
+          (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes() |> Some
+          (16, _) => msg.f_string = reader |> @lib.async_read_string() |> Some
+          (18, _) =>
+            msg.f_bar_message = (
+                reader |> @lib.async_read_message() : BarMessageP2)
+              |> Some
+          (19, 2) =>
+            msg.f_repeated_int32.push_iter(
+              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+            )
+          (19, 0) =>
+            msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+          (20, 2) =>
+            msg.f_repeated_packed_int32.push_iter(
+              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+            )
+          (20, 0) =>
+            msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
+          (21, 2) =>
+            msg.f_repeated_packed_float.push_iter(
+              (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
+            )
+          (21, 5) =>
+            msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
+          (23, _) =>
+            msg.f_baz = (reader |> @lib.async_read_message() : BazMessageP2)
+              |> Some
+          (24, _) =>
+            msg.f_nested = (
+                reader |> @lib.async_read_message() : BazMessageP2_Nested)
+              |> Some
+          (25, _) =>
+            msg.f_nested_enum = reader
+              |> @lib.async_read_enum()
+              |> BazMessageP2_Nested_NestedEnum::from_enum
+              |> Some
+          (27, _) =>
+            msg.f_map.push((reader |> @lib.async_read_message() : MapEntryP2))
+          (28, _) => msg.f1 = reader |> @lib.async_read_int32() |> Some
+          (29, _) => msg.f2 = reader |> @lib.async_read_bool() |> Some
+          (30, _) => msg.f3 = reader |> @lib.async_read_string() |> Some
+          (31, _) =>
+            msg.f_repeated_string.push(reader |> @lib.async_read_string())
+          (32, _) =>
+            msg.f_repeated_baz_message.push(
+              (reader |> @lib.async_read_message() : BazMessageP2),
+            )
+          (33, _) =>
+            msg.f_optional_string = reader |> @lib.async_read_string() |> Some
+          (34, _) =>
+            msg.f_default_int32 = reader |> @lib.async_read_int32() |> Some
+          (35, _) =>
+            msg.f_default_string = reader |> @lib.async_read_string() |> Some
+          (36, _) =>
+            msg.f_default_bool = reader |> @lib.async_read_bool() |> Some
+          (37, _) =>
+            msg.f_default_double = reader |> @lib.async_read_double() |> Some
+          (38, _) =>
+            msg.f_default_enum = reader
+              |> @lib.async_read_enum()
+              |> FooEnumP2::from_enum
+              |> Some
+          (39, 2) => {
+            let packed = reader
+              |> @lib.async_read_packed(@lib.async_read_enum, None)
+            for item in packed {
+              msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
+            }
           }
+          (39, 0) =>
+            msg.f_repeated_packed_enum.push(
+              reader |> @lib.async_read_enum() |> FooEnumP2::from_enum,
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
         }
-        (39, 0) =>
-          msg.f_repeated_packed_enum.push(
-            reader |> @lib.async_read_enum() |> FooEnumP2::from_enum,
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1169,8 +1172,7 @@ pub impl @lib.AsyncWrite for FooMessageP2 with fn write(
   }
   if self.f_bar_message is Some(v) {
     writer |> @lib.async_write_varint(146UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   for item in self.f_repeated_int32 {
     writer |> @lib.async_write_varint(152UL)
@@ -1197,13 +1199,11 @@ pub impl @lib.AsyncWrite for FooMessageP2 with fn write(
   }
   if self.f_baz is Some(v) {
     writer |> @lib.async_write_varint(186UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.f_nested is Some(v) {
     writer |> @lib.async_write_varint(194UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.f_nested_enum is Some(v) {
     writer |> @lib.async_write_varint(200UL)
@@ -1211,8 +1211,7 @@ pub impl @lib.AsyncWrite for FooMessageP2 with fn write(
   }
   for item in self.f_map {
     writer |> @lib.async_write_varint(218UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.f1 is Some(v) {
     writer |> @lib.async_write_varint(224UL)
@@ -1232,8 +1231,7 @@ pub impl @lib.AsyncWrite for FooMessageP2 with fn write(
   }
   for item in self.f_repeated_baz_message {
     writer |> @lib.async_write_varint(258UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.f_optional_string is Some(v) {
     writer |> @lib.async_write_varint(266UL)
@@ -1305,17 +1303,16 @@ pub impl @lib.Read for MapEntryP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> MapEntryP2 raise {
   let msg = MapEntryP2::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.key = reader |> @lib.read_string()
-        (2, _) => msg.value = reader |> @lib.read_int32()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.read_string()
+          (2, _) => msg.value = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1367,17 +1364,16 @@ pub impl @lib.AsyncRead for MapEntryP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> MapEntryP2 raise {
   let msg = MapEntryP2::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.key = reader |> @lib.async_read_string()
-        (2, _) => msg.value = reader |> @lib.async_read_int32()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.async_read_string()
+          (2, _) => msg.value = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1494,16 +1490,15 @@ pub impl @lib.Read for BazMessageP2_Nested_NestedMessage with fn read_with_limit
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessageP2_Nested_NestedMessage raise {
   let msg = BazMessageP2_Nested_NestedMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.f_nested = reader |> @lib.read_int32()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_nested = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1551,16 +1546,15 @@ pub impl @lib.AsyncRead for BazMessageP2_Nested_NestedMessage with fn read_with_
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessageP2_Nested_NestedMessage raise {
   let msg = BazMessageP2_Nested_NestedMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1609,19 +1603,19 @@ pub impl @lib.Read for BazMessageP2_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessageP2_Nested raise {
   let msg = BazMessageP2_Nested::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.f_nested = (
-              reader |> @lib.read_message() : BazMessageP2_Nested_NestedMessage)
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.f_nested = (
+                reader |> @lib.read_message() :
+                BazMessageP2_Nested_NestedMessage)
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1633,8 +1627,7 @@ pub impl @lib.Write for BazMessageP2_Nested with fn write(
 ) -> Unit raise {
   if self.f_nested is Some(v) {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -1674,20 +1667,19 @@ pub impl @lib.AsyncRead for BazMessageP2_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessageP2_Nested raise {
   let msg = BazMessageP2_Nested::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.f_nested = (
-              reader |> @lib.async_read_message() :
-              BazMessageP2_Nested_NestedMessage)
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.f_nested = (
+                reader |> @lib.async_read_message() :
+                BazMessageP2_Nested_NestedMessage)
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1699,8 +1691,7 @@ pub impl @lib.AsyncWrite for BazMessageP2_Nested with fn write(
 ) -> Unit raise {
   if self.f_nested is Some(v) {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }
 
@@ -1753,20 +1744,19 @@ pub impl @lib.Read for BazMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessageP2 raise {
   let msg = BazMessageP2::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
-            |> Some
-        (2, _) => msg.b_int64 = reader |> @lib.read_int64() |> Some
-        (3, _) => msg.b_string = reader |> @lib.read_string() |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
+              |> Some
+          (2, _) => msg.b_int64 = reader |> @lib.read_int64() |> Some
+          (3, _) => msg.b_string = reader |> @lib.read_string() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1778,8 +1768,7 @@ pub impl @lib.Write for BazMessageP2 with fn write(
 ) -> Unit raise {
   if self.nested is Some(v) {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.b_int64 is Some(v) {
     writer |> @lib.write_varint(16UL)
@@ -1835,21 +1824,20 @@ pub impl @lib.AsyncRead for BazMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessageP2 raise {
   let msg = BazMessageP2::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.nested = (
-              reader |> @lib.async_read_message() : BazMessageP2_Nested)
-            |> Some
-        (2, _) => msg.b_int64 = reader |> @lib.async_read_int64() |> Some
-        (3, _) => msg.b_string = reader |> @lib.async_read_string() |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.nested = (
+                reader |> @lib.async_read_message() : BazMessageP2_Nested)
+              |> Some
+          (2, _) => msg.b_int64 = reader |> @lib.async_read_int64() |> Some
+          (3, _) => msg.b_string = reader |> @lib.async_read_string() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1861,8 +1849,7 @@ pub impl @lib.AsyncWrite for BazMessageP2 with fn write(
 ) -> Unit raise {
   if self.nested is Some(v) {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.b_int64 is Some(v) {
     writer |> @lib.async_write_varint(16UL)
@@ -1909,17 +1896,16 @@ pub impl @lib.Read for RepeatedMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> RepeatedMessageP2 raise {
   let msg = RepeatedMessageP2::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.bar_message.push((reader |> @lib.read_message() : BarMessageP2))
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.bar_message.push((reader |> @lib.read_message() : BarMessageP2))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1931,8 +1917,7 @@ pub impl @lib.Write for RepeatedMessageP2 with fn write(
 ) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -1971,19 +1956,18 @@ pub impl @lib.AsyncRead for RepeatedMessageP2 with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> RepeatedMessageP2 raise {
   let msg = RepeatedMessageP2::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.bar_message.push(
-            (reader |> @lib.async_read_message() : BarMessageP2),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.bar_message.push(
+              (reader |> @lib.async_read_message() : BarMessageP2),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1995,7 +1979,6 @@ pub impl @lib.AsyncWrite for RepeatedMessageP2 with fn write(
 ) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -96,16 +96,15 @@ pub impl @lib.Read for BarMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BarMessage raise {
   let msg = BarMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.b_int32 = reader |> @lib.read_int32()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.b_int32 = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -153,16 +152,15 @@ pub impl @lib.AsyncRead for BarMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BarMessage raise {
   let msg = BarMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -218,17 +216,16 @@ pub impl @lib.Read for FooMessage_FMapEntry with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.key = reader |> @lib.read_string()
-        (2, _) => msg.value = reader |> @lib.read_int32()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.read_string()
+          (2, _) => msg.value = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -286,17 +283,16 @@ pub impl @lib.AsyncRead for FooMessage_FMapEntry with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.key = reader |> @lib.async_read_string()
-        (2, _) => msg.value = reader |> @lib.async_read_int32()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.async_read_string()
+          (2, _) => msg.value = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -707,109 +703,112 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FooMessage raise {
   let msg = FooMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.f_int32 = reader |> @lib.read_int32()
-        (2, _) => msg.f_int64 = reader |> @lib.read_int64()
-        (3, _) => msg.f_uint32 = reader |> @lib.read_uint32()
-        (4, _) => msg.f_uint64 = reader |> @lib.read_uint64()
-        (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0
-        (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0
-        (7, _) => msg.f_bool = reader |> @lib.read_bool()
-        (8, _) =>
-          msg.f_foo_enum = reader |> @lib.read_enum() |> FooEnum::from_enum
-        (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64()
-        (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64()
-        (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32()
-        (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32()
-        (13, _) => msg.f_double = reader |> @lib.read_double()
-        (14, _) => msg.f_float = reader |> @lib.read_float()
-        (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
-        (16, _) => msg.f_string = reader |> @lib.read_string()
-        (18, _) =>
-          msg.f_bar_message = (reader |> @lib.read_message() : BarMessage)
-            |> Some
-        (19, 2) =>
-          msg.f_repeated_int32.push_iter(
-            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-          )
-        (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
-        (20, 2) =>
-          msg.f_repeated_packed_int32.push_iter(
-            (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-          )
-        (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
-        (21, 2) =>
-          msg.f_repeated_packed_float.push_iter(
-            (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
-          )
-        (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-        (23, _) =>
-          msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
-        (24, _) =>
-          msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested)
-            |> Some
-        (25, _) =>
-          msg.f_nested_enum = reader
-            |> @lib.read_enum()
-            |> BazMessage_Nested_NestedEnum::from_enum
-        (26, _) => {
-          let { key, value } = (
-            reader |> @lib.read_message() : FooMessage_FMapEntry)
-          msg.f_map[key] = value
-        }
-        (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-        (31, _) =>
-          msg.f_repeated_baz_message.push(
-            (reader |> @lib.read_message() : BazMessage),
-          )
-        (32, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
-        (33, _) => msg.with_json_name = reader |> @lib.read_string()
-        (34, 2) => {
-          let packed = reader |> @lib.read_packed(@lib.read_enum, None)
-          for item in packed {
-            msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_int32 = reader |> @lib.read_int32()
+          (2, _) => msg.f_int64 = reader |> @lib.read_int64()
+          (3, _) => msg.f_uint32 = reader |> @lib.read_uint32()
+          (4, _) => msg.f_uint64 = reader |> @lib.read_uint64()
+          (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0
+          (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0
+          (7, _) => msg.f_bool = reader |> @lib.read_bool()
+          (8, _) =>
+            msg.f_foo_enum = reader |> @lib.read_enum() |> FooEnum::from_enum
+          (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64()
+          (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64()
+          (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32()
+          (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32()
+          (13, _) => msg.f_double = reader |> @lib.read_double()
+          (14, _) => msg.f_float = reader |> @lib.read_float()
+          (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
+          (16, _) => msg.f_string = reader |> @lib.read_string()
+          (18, _) =>
+            msg.f_bar_message = (reader |> @lib.read_message() : BarMessage)
+              |> Some
+          (19, 2) =>
+            msg.f_repeated_int32.push_iter(
+              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+            )
+          (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
+          (20, 2) =>
+            msg.f_repeated_packed_int32.push_iter(
+              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+            )
+          (20, 0) =>
+            msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+          (21, 2) =>
+            msg.f_repeated_packed_float.push_iter(
+              (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
+            )
+          (21, 5) =>
+            msg.f_repeated_packed_float.push(reader |> @lib.read_float())
+          (23, _) =>
+            msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
+          (24, _) =>
+            msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested)
+              |> Some
+          (25, _) =>
+            msg.f_nested_enum = reader
+              |> @lib.read_enum()
+              |> BazMessage_Nested_NestedEnum::from_enum
+          (26, _) => {
+            let { key, value } = (
+              reader |> @lib.read_message() : FooMessage_FMapEntry)
+            msg.f_map[key] = value
           }
-        }
-        (34, 0) =>
-          msg.f_repeated_packed_enum.push(
-            reader |> @lib.read_enum() |> FooEnum::from_enum,
-          )
-        (35, 2) => {
-          let packed = reader |> @lib.read_packed(@lib.read_enum, None)
-          for item in packed {
-            msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
+          (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
+          (31, _) =>
+            msg.f_repeated_baz_message.push(
+              (reader |> @lib.read_message() : BazMessage),
+            )
+          (32, _) =>
+            msg.f_optional_string = reader |> @lib.read_string() |> Some
+          (33, _) => msg.with_json_name = reader |> @lib.read_string()
+          (34, 2) => {
+            let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+            for item in packed {
+              msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
+            }
           }
+          (34, 0) =>
+            msg.f_repeated_packed_enum.push(
+              reader |> @lib.read_enum() |> FooEnum::from_enum,
+            )
+          (35, 2) => {
+            let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+            for item in packed {
+              msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
+            }
+          }
+          (35, 0) =>
+            msg.f_repeated_unpacked_enum.push(
+              reader |> @lib.read_enum() |> FooEnum::from_enum,
+            )
+          (36, _) =>
+            msg.f_timestamp = (
+                reader |> @lib.read_message() : @protobuf.Timestamp)
+              |> Some
+          (37, _) =>
+            msg.f_duration = (reader |> @lib.read_message() : @protobuf.Duration)
+              |> Some
+          (27, _) =>
+            msg.test_oneof = reader
+              |> @lib.read_int32()
+              |> FooMessage_TestOneof::F1
+          (28, _) =>
+            msg.test_oneof = reader
+              |> @lib.read_bool()
+              |> FooMessage_TestOneof::F2
+          (29, _) =>
+            msg.test_oneof = reader
+              |> @lib.read_string()
+              |> FooMessage_TestOneof::F3
+          _ => reader |> @lib.skip_message_field(wire)
         }
-        (35, 0) =>
-          msg.f_repeated_unpacked_enum.push(
-            reader |> @lib.read_enum() |> FooEnum::from_enum,
-          )
-        (36, _) =>
-          msg.f_timestamp = (reader |> @lib.read_message() : @protobuf.Timestamp)
-            |> Some
-        (37, _) =>
-          msg.f_duration = (reader |> @lib.read_message() : @protobuf.Duration)
-            |> Some
-        (27, _) =>
-          msg.test_oneof = reader
-            |> @lib.read_int32()
-            |> FooMessage_TestOneof::F1
-        (28, _) =>
-          msg.test_oneof = reader
-            |> @lib.read_bool()
-            |> FooMessage_TestOneof::F2
-        (29, _) =>
-          msg.test_oneof = reader
-            |> @lib.read_string()
-            |> FooMessage_TestOneof::F3
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -885,8 +884,7 @@ pub impl @lib.Write for FooMessage with fn write(
   }
   if self.f_bar_message is Some(v) {
     writer |> @lib.write_varint(146UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if !self.f_repeated_int32.is_empty() {
     writer |> @lib.write_varint(154UL)
@@ -920,13 +918,11 @@ pub impl @lib.Write for FooMessage with fn write(
   }
   if self.f_baz is Some(v) {
     writer |> @lib.write_varint(186UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.f_nested is Some(v) {
     writer |> @lib.write_varint(194UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.f_nested_enum != Default::default() {
     writer |> @lib.write_varint(200UL)
@@ -956,8 +952,7 @@ pub impl @lib.Write for FooMessage with fn write(
   }
   for item in self.f_repeated_baz_message {
     writer |> @lib.write_varint(250UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
   if self.f_optional_string is Some(v) {
     writer |> @lib.write_varint(258UL)
@@ -984,13 +979,11 @@ pub impl @lib.Write for FooMessage with fn write(
   }
   if self.f_timestamp is Some(v) {
     writer |> @lib.write_varint(290UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.f_duration is Some(v) {
     writer |> @lib.write_varint(298UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   match self.test_oneof {
     FooMessage_TestOneof::F1(v) => {
@@ -1150,7 +1143,7 @@ pub impl @json.FromJson for FooMessage with fn from_json(
       ("fFloat", Number(value, ..)) =>
         message.f_float = Float::from_double(value)
       ("fBytes", String(value)) =>
-        message.f_bytes = try @lib.base64_decode(value) catch {
+        message.f_bytes = @lib.base64_decode(value) catch {
           _ => raise @json.JsonDecodeError((path, "Invalid base64 encoding"))
         }
       ("fString", value) => message.f_string = @json.from_json(value, path~)
@@ -1207,120 +1200,122 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FooMessage raise {
   let msg = FooMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
-        (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
-        (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32()
-        (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64()
-        (5, _) => msg.f_sint32 = (reader |> @lib.async_read_sint32()).0
-        (6, _) => msg.f_sint64 = (reader |> @lib.async_read_sint64()).0
-        (7, _) => msg.f_bool = reader |> @lib.async_read_bool()
-        (8, _) =>
-          msg.f_foo_enum = reader
-            |> @lib.async_read_enum()
-            |> FooEnum::from_enum
-        (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64()
-        (10, _) => msg.f_sfixed64 = reader |> @lib.async_read_sfixed64()
-        (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32()
-        (12, _) => msg.f_sfixed32 = reader |> @lib.async_read_sfixed32()
-        (13, _) => msg.f_double = reader |> @lib.async_read_double()
-        (14, _) => msg.f_float = reader |> @lib.async_read_float()
-        (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
-        (16, _) => msg.f_string = reader |> @lib.async_read_string()
-        (18, _) =>
-          msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage)
-            |> Some
-        (19, 2) =>
-          msg.f_repeated_int32.push_iter(
-            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-          )
-        (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
-        (20, 2) =>
-          msg.f_repeated_packed_int32.push_iter(
-            (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-          )
-        (20, 0) =>
-          msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
-        (21, 2) =>
-          msg.f_repeated_packed_float.push_iter(
-            (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
-          )
-        (21, 5) =>
-          msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-        (23, _) =>
-          msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
-        (24, _) =>
-          msg.f_nested = (
-              reader |> @lib.async_read_message() : BazMessage_Nested)
-            |> Some
-        (25, _) =>
-          msg.f_nested_enum = reader
-            |> @lib.async_read_enum()
-            |> BazMessage_Nested_NestedEnum::from_enum
-        (26, _) => {
-          let { key, value } = (
-            reader |> @lib.async_read_message() : FooMessage_FMapEntry)
-          msg.f_map[key] = value
-        }
-        (30, _) =>
-          msg.f_repeated_string.push(reader |> @lib.async_read_string())
-        (31, _) =>
-          msg.f_repeated_baz_message.push(
-            (reader |> @lib.async_read_message() : BazMessage),
-          )
-        (32, _) =>
-          msg.f_optional_string = reader |> @lib.async_read_string() |> Some
-        (33, _) => msg.with_json_name = reader |> @lib.async_read_string()
-        (34, 2) => {
-          let packed = reader
-            |> @lib.async_read_packed(@lib.async_read_enum, None)
-          for item in packed {
-            msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
+          (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
+          (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32()
+          (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64()
+          (5, _) => msg.f_sint32 = (reader |> @lib.async_read_sint32()).0
+          (6, _) => msg.f_sint64 = (reader |> @lib.async_read_sint64()).0
+          (7, _) => msg.f_bool = reader |> @lib.async_read_bool()
+          (8, _) =>
+            msg.f_foo_enum = reader
+              |> @lib.async_read_enum()
+              |> FooEnum::from_enum
+          (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64()
+          (10, _) => msg.f_sfixed64 = reader |> @lib.async_read_sfixed64()
+          (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32()
+          (12, _) => msg.f_sfixed32 = reader |> @lib.async_read_sfixed32()
+          (13, _) => msg.f_double = reader |> @lib.async_read_double()
+          (14, _) => msg.f_float = reader |> @lib.async_read_float()
+          (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
+          (16, _) => msg.f_string = reader |> @lib.async_read_string()
+          (18, _) =>
+            msg.f_bar_message = (
+                reader |> @lib.async_read_message() : BarMessage)
+              |> Some
+          (19, 2) =>
+            msg.f_repeated_int32.push_iter(
+              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+            )
+          (19, 0) =>
+            msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+          (20, 2) =>
+            msg.f_repeated_packed_int32.push_iter(
+              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+            )
+          (20, 0) =>
+            msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
+          (21, 2) =>
+            msg.f_repeated_packed_float.push_iter(
+              (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
+            )
+          (21, 5) =>
+            msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
+          (23, _) =>
+            msg.f_baz = (reader |> @lib.async_read_message() : BazMessage)
+              |> Some
+          (24, _) =>
+            msg.f_nested = (
+                reader |> @lib.async_read_message() : BazMessage_Nested)
+              |> Some
+          (25, _) =>
+            msg.f_nested_enum = reader
+              |> @lib.async_read_enum()
+              |> BazMessage_Nested_NestedEnum::from_enum
+          (26, _) => {
+            let { key, value } = (
+              reader |> @lib.async_read_message() : FooMessage_FMapEntry)
+            msg.f_map[key] = value
           }
-        }
-        (34, 0) =>
-          msg.f_repeated_packed_enum.push(
-            reader |> @lib.async_read_enum() |> FooEnum::from_enum,
-          )
-        (35, 2) => {
-          let packed = reader
-            |> @lib.async_read_packed(@lib.async_read_enum, None)
-          for item in packed {
-            msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
+          (30, _) =>
+            msg.f_repeated_string.push(reader |> @lib.async_read_string())
+          (31, _) =>
+            msg.f_repeated_baz_message.push(
+              (reader |> @lib.async_read_message() : BazMessage),
+            )
+          (32, _) =>
+            msg.f_optional_string = reader |> @lib.async_read_string() |> Some
+          (33, _) => msg.with_json_name = reader |> @lib.async_read_string()
+          (34, 2) => {
+            let packed = reader
+              |> @lib.async_read_packed(@lib.async_read_enum, None)
+            for item in packed {
+              msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
+            }
           }
+          (34, 0) =>
+            msg.f_repeated_packed_enum.push(
+              reader |> @lib.async_read_enum() |> FooEnum::from_enum,
+            )
+          (35, 2) => {
+            let packed = reader
+              |> @lib.async_read_packed(@lib.async_read_enum, None)
+            for item in packed {
+              msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
+            }
+          }
+          (35, 0) =>
+            msg.f_repeated_unpacked_enum.push(
+              reader |> @lib.async_read_enum() |> FooEnum::from_enum,
+            )
+          (36, _) =>
+            msg.f_timestamp = (
+                reader |> @lib.async_read_message() : @protobuf.Timestamp)
+              |> Some
+          (37, _) =>
+            msg.f_duration = (
+                reader |> @lib.async_read_message() : @protobuf.Duration)
+              |> Some
+          (27, _) =>
+            msg.test_oneof = reader
+              |> @lib.async_read_int32()
+              |> FooMessage_TestOneof::F1
+          (28, _) =>
+            msg.test_oneof = reader
+              |> @lib.async_read_bool()
+              |> FooMessage_TestOneof::F2
+          (29, _) =>
+            msg.test_oneof = reader
+              |> @lib.async_read_string()
+              |> FooMessage_TestOneof::F3
+          _ => reader |> @lib.async_skip_message_field(wire)
         }
-        (35, 0) =>
-          msg.f_repeated_unpacked_enum.push(
-            reader |> @lib.async_read_enum() |> FooEnum::from_enum,
-          )
-        (36, _) =>
-          msg.f_timestamp = (
-              reader |> @lib.async_read_message() : @protobuf.Timestamp)
-            |> Some
-        (37, _) =>
-          msg.f_duration = (
-              reader |> @lib.async_read_message() : @protobuf.Duration)
-            |> Some
-        (27, _) =>
-          msg.test_oneof = reader
-            |> @lib.async_read_int32()
-            |> FooMessage_TestOneof::F1
-        (28, _) =>
-          msg.test_oneof = reader
-            |> @lib.async_read_bool()
-            |> FooMessage_TestOneof::F2
-        (29, _) =>
-          msg.test_oneof = reader
-            |> @lib.async_read_string()
-            |> FooMessage_TestOneof::F3
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1396,8 +1391,7 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(
   }
   if self.f_bar_message is Some(v) {
     writer |> @lib.async_write_varint(146UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if !self.f_repeated_int32.is_empty() {
     writer |> @lib.async_write_varint(154UL)
@@ -1431,13 +1425,11 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(
   }
   if self.f_baz is Some(v) {
     writer |> @lib.async_write_varint(186UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.f_nested is Some(v) {
     writer |> @lib.async_write_varint(194UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.f_nested_enum != Default::default() {
     writer |> @lib.async_write_varint(200UL)
@@ -1467,8 +1459,7 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(
   }
   for item in self.f_repeated_baz_message {
     writer |> @lib.async_write_varint(250UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
   if self.f_optional_string is Some(v) {
     writer |> @lib.async_write_varint(258UL)
@@ -1495,13 +1486,11 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(
   }
   if self.f_timestamp is Some(v) {
     writer |> @lib.async_write_varint(290UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.f_duration is Some(v) {
     writer |> @lib.async_write_varint(298UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   match self.test_oneof {
     FooMessage_TestOneof::F1(v) => {
@@ -1634,16 +1623,15 @@ pub impl @lib.Read for BazMessage_Nested_NestedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.f_nested = reader |> @lib.read_int32()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_nested = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1693,16 +1681,15 @@ pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with fn read_with_li
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1753,19 +1740,18 @@ pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.f_nested = (
-              reader |> @lib.read_message() : BazMessage_Nested_NestedMessage)
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.f_nested = (
+                reader |> @lib.read_message() : BazMessage_Nested_NestedMessage)
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1777,8 +1763,7 @@ pub impl @lib.Write for BazMessage_Nested with fn write(
 ) -> Unit raise {
   if self.f_nested is Some(v) {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -1818,20 +1803,19 @@ pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.f_nested = (
-              reader |> @lib.async_read_message() :
-              BazMessage_Nested_NestedMessage)
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.f_nested = (
+                reader |> @lib.async_read_message() :
+                BazMessage_Nested_NestedMessage)
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1843,8 +1827,7 @@ pub impl @lib.AsyncWrite for BazMessage_Nested with fn write(
 ) -> Unit raise {
   if self.f_nested is Some(v) {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }
 
@@ -1901,20 +1884,19 @@ pub impl @lib.Read for BazMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessage raise {
   let msg = BazMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.nested = (reader |> @lib.read_message() : BazMessage_Nested)
-            |> Some
-        (2, _) => msg.b_int64 = reader |> @lib.read_int64()
-        (3, _) => msg.b_string = reader |> @lib.read_string()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.nested = (reader |> @lib.read_message() : BazMessage_Nested)
+              |> Some
+          (2, _) => msg.b_int64 = reader |> @lib.read_int64()
+          (3, _) => msg.b_string = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -1926,8 +1908,7 @@ pub impl @lib.Write for BazMessage with fn write(
 ) -> Unit raise {
   if self.nested is Some(v) {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
   if self.b_int64 != Default::default() {
     writer |> @lib.write_varint(16UL)
@@ -1980,20 +1961,20 @@ pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessage raise {
   let msg = BazMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested)
-            |> Some
-        (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
-        (3, _) => msg.b_string = reader |> @lib.async_read_string()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.nested = (
+                reader |> @lib.async_read_message() : BazMessage_Nested)
+              |> Some
+          (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
+          (3, _) => msg.b_string = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2005,8 +1986,7 @@ pub impl @lib.AsyncWrite for BazMessage with fn write(
 ) -> Unit raise {
   if self.nested is Some(v) {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
   if self.b_int64 != Default::default() {
     writer |> @lib.async_write_varint(16UL)
@@ -2051,17 +2031,16 @@ pub impl @lib.Read for RepeatedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2073,8 +2052,7 @@ pub impl @lib.Write for RepeatedMessage with fn write(
 ) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item))
-    @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
   }
 }
 
@@ -2113,19 +2091,18 @@ pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.bar_message.push(
-            (reader |> @lib.async_read_message() : BarMessage),
-          )
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.bar_message.push(
+              (reader |> @lib.async_read_message() : BarMessage),
+            )
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2137,8 +2114,7 @@ pub impl @lib.AsyncWrite for RepeatedMessage with fn write(
 ) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item))
-    @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
   }
 }
 
@@ -2171,16 +2147,15 @@ pub impl @lib.Read for EmptyMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EmptyMessage raise {
   let msg = EmptyMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) => msg.field = reader |> @lib.read_int32()
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.field = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2228,16 +2203,15 @@ pub impl @lib.AsyncRead for EmptyMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EmptyMessage raise {
   let msg = EmptyMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) => msg.field = reader |> @lib.async_read_int32()
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.field = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2288,18 +2262,17 @@ pub impl @lib.Read for EmptyMessageWithField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EmptyMessageWithField raise {
   let msg = EmptyMessageWithField::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.empty_message = (reader |> @lib.read_message() : EmptyMessage)
-            |> Some
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.empty_message = (reader |> @lib.read_message() : EmptyMessage)
+              |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2311,8 +2284,7 @@ pub impl @lib.Write for EmptyMessageWithField with fn write(
 ) -> Unit raise {
   if self.empty_message is Some(v) {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(v))
-    @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
   }
 }
 
@@ -2352,19 +2324,18 @@ pub impl @lib.AsyncRead for EmptyMessageWithField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EmptyMessageWithField raise {
   let msg = EmptyMessageWithField::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.empty_message = (
-              reader |> @lib.async_read_message() : EmptyMessage)
-            |> Some
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.empty_message = (
+                reader |> @lib.async_read_message() : EmptyMessage)
+              |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2376,8 +2347,7 @@ pub impl @lib.AsyncWrite for EmptyMessageWithField with fn write(
 ) -> Unit raise {
   if self.empty_message is Some(v) {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(v))
-    @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
   }
 }
 
@@ -2468,27 +2438,26 @@ pub impl @lib.Read for OnlyOneOfField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> OnlyOneOfField raise {
   let msg = OnlyOneOfField::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-        (1, _) =>
-          msg.test_oneof = reader
-            |> @lib.read_int32()
-            |> OnlyOneOfField_TestOneof::F1
-        (2, _) =>
-          msg.test_oneof = reader
-            |> @lib.read_bool()
-            |> OnlyOneOfField_TestOneof::F2
-        (3, _) =>
-          msg.test_oneof = reader
-            |> @lib.read_string()
-            |> OnlyOneOfField_TestOneof::F3
-        (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.test_oneof = reader
+              |> @lib.read_int32()
+              |> OnlyOneOfField_TestOneof::F1
+          (2, _) =>
+            msg.test_oneof = reader
+              |> @lib.read_bool()
+              |> OnlyOneOfField_TestOneof::F2
+          (3, _) =>
+            msg.test_oneof = reader
+              |> @lib.read_string()
+              |> OnlyOneOfField_TestOneof::F3
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }
@@ -2552,27 +2521,26 @@ pub impl @lib.AsyncRead for OnlyOneOfField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> OnlyOneOfField raise {
   let msg = OnlyOneOfField::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-        (1, _) =>
-          msg.test_oneof = reader
-            |> @lib.async_read_int32()
-            |> OnlyOneOfField_TestOneof::F1
-        (2, _) =>
-          msg.test_oneof = reader
-            |> @lib.async_read_bool()
-            |> OnlyOneOfField_TestOneof::F2
-        (3, _) =>
-          msg.test_oneof = reader
-            |> @lib.async_read_string()
-            |> OnlyOneOfField_TestOneof::F3
-        (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) =>
+            msg.test_oneof = reader
+              |> @lib.async_read_int32()
+              |> OnlyOneOfField_TestOneof::F1
+          (2, _) =>
+            msg.test_oneof = reader
+              |> @lib.async_read_bool()
+              |> OnlyOneOfField_TestOneof::F2
+          (3, _) =>
+            msg.test_oneof = reader
+              |> @lib.async_read_string()
+              |> OnlyOneOfField_TestOneof::F3
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
   }
   msg
 }

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -96,14 +96,10 @@ pub impl @lib.Read for BarMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BarMessage raise {
   let msg = BarMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.b_int32 = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.b_int32 = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -152,14 +148,11 @@ pub impl @lib.AsyncRead for BarMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BarMessage raise {
   let msg = BarMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -216,15 +209,11 @@ pub impl @lib.Read for FooMessage_FMapEntry with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.read_string()
-          (2, _) => msg.value = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.read_string()
+      (2, _) => msg.value = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -283,15 +272,12 @@ pub impl @lib.AsyncRead for FooMessage_FMapEntry with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.async_read_string()
-          (2, _) => msg.value = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.async_read_string()
+      (2, _) => msg.value = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -703,111 +689,98 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> FooMessage raise {
   let msg = FooMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_int32 = reader |> @lib.read_int32()
-          (2, _) => msg.f_int64 = reader |> @lib.read_int64()
-          (3, _) => msg.f_uint32 = reader |> @lib.read_uint32()
-          (4, _) => msg.f_uint64 = reader |> @lib.read_uint64()
-          (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0
-          (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0
-          (7, _) => msg.f_bool = reader |> @lib.read_bool()
-          (8, _) =>
-            msg.f_foo_enum = reader |> @lib.read_enum() |> FooEnum::from_enum
-          (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64()
-          (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64()
-          (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32()
-          (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32()
-          (13, _) => msg.f_double = reader |> @lib.read_double()
-          (14, _) => msg.f_float = reader |> @lib.read_float()
-          (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
-          (16, _) => msg.f_string = reader |> @lib.read_string()
-          (18, _) =>
-            msg.f_bar_message = (reader |> @lib.read_message() : BarMessage)
-              |> Some
-          (19, 2) =>
-            msg.f_repeated_int32.push_iter(
-              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-            )
-          (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
-          (20, 2) =>
-            msg.f_repeated_packed_int32.push_iter(
-              (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
-            )
-          (20, 0) =>
-            msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
-          (21, 2) =>
-            msg.f_repeated_packed_float.push_iter(
-              (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
-            )
-          (21, 5) =>
-            msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-          (23, _) =>
-            msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
-          (24, _) =>
-            msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested)
-              |> Some
-          (25, _) =>
-            msg.f_nested_enum = reader
-              |> @lib.read_enum()
-              |> BazMessage_Nested_NestedEnum::from_enum
-          (26, _) => {
-            let { key, value } = (
-              reader |> @lib.read_message() : FooMessage_FMapEntry)
-            msg.f_map[key] = value
-          }
-          (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-          (31, _) =>
-            msg.f_repeated_baz_message.push(
-              (reader |> @lib.read_message() : BazMessage),
-            )
-          (32, _) =>
-            msg.f_optional_string = reader |> @lib.read_string() |> Some
-          (33, _) => msg.with_json_name = reader |> @lib.read_string()
-          (34, 2) => {
-            let packed = reader |> @lib.read_packed(@lib.read_enum, None)
-            for item in packed {
-              msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
-            }
-          }
-          (34, 0) =>
-            msg.f_repeated_packed_enum.push(
-              reader |> @lib.read_enum() |> FooEnum::from_enum,
-            )
-          (35, 2) => {
-            let packed = reader |> @lib.read_packed(@lib.read_enum, None)
-            for item in packed {
-              msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
-            }
-          }
-          (35, 0) =>
-            msg.f_repeated_unpacked_enum.push(
-              reader |> @lib.read_enum() |> FooEnum::from_enum,
-            )
-          (36, _) =>
-            msg.f_timestamp = (
-                reader |> @lib.read_message() : @protobuf.Timestamp)
-              |> Some
-          (37, _) =>
-            msg.f_duration = (reader |> @lib.read_message() : @protobuf.Duration)
-              |> Some
-          (27, _) =>
-            msg.test_oneof = reader
-              |> @lib.read_int32()
-              |> FooMessage_TestOneof::F1
-          (28, _) =>
-            msg.test_oneof = reader
-              |> @lib.read_bool()
-              |> FooMessage_TestOneof::F2
-          (29, _) =>
-            msg.test_oneof = reader
-              |> @lib.read_string()
-              |> FooMessage_TestOneof::F3
-          _ => reader |> @lib.skip_message_field(wire)
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_int32 = reader |> @lib.read_int32()
+      (2, _) => msg.f_int64 = reader |> @lib.read_int64()
+      (3, _) => msg.f_uint32 = reader |> @lib.read_uint32()
+      (4, _) => msg.f_uint64 = reader |> @lib.read_uint64()
+      (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0
+      (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0
+      (7, _) => msg.f_bool = reader |> @lib.read_bool()
+      (8, _) =>
+        msg.f_foo_enum = reader |> @lib.read_enum() |> FooEnum::from_enum
+      (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64()
+      (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64()
+      (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32()
+      (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32()
+      (13, _) => msg.f_double = reader |> @lib.read_double()
+      (14, _) => msg.f_float = reader |> @lib.read_float()
+      (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
+      (16, _) => msg.f_string = reader |> @lib.read_string()
+      (18, _) =>
+        msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
+      (19, 2) =>
+        msg.f_repeated_int32.push_iter(
+          (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+        )
+      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
+      (20, 2) =>
+        msg.f_repeated_packed_int32.push_iter(
+          (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
+        )
+      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+      (21, 2) =>
+        msg.f_repeated_packed_float.push_iter(
+          (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
+        )
+      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
+      (23, _) =>
+        msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
+      (24, _) =>
+        msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested)
+          |> Some
+      (25, _) =>
+        msg.f_nested_enum = reader
+          |> @lib.read_enum()
+          |> BazMessage_Nested_NestedEnum::from_enum
+      (26, _) => {
+        let { key, value } = (
+          reader |> @lib.read_message() : FooMessage_FMapEntry)
+        msg.f_map[key] = value
+      }
+      (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
+      (31, _) =>
+        msg.f_repeated_baz_message.push(
+          (reader |> @lib.read_message() : BazMessage),
+        )
+      (32, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
+      (33, _) => msg.with_json_name = reader |> @lib.read_string()
+      (34, 2) => {
+        let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+        for item in packed {
+          msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
         }
-      None => break
+      }
+      (34, 0) =>
+        msg.f_repeated_packed_enum.push(
+          reader |> @lib.read_enum() |> FooEnum::from_enum,
+        )
+      (35, 2) => {
+        let packed = reader |> @lib.read_packed(@lib.read_enum, None)
+        for item in packed {
+          msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
+        }
+      }
+      (35, 0) =>
+        msg.f_repeated_unpacked_enum.push(
+          reader |> @lib.read_enum() |> FooEnum::from_enum,
+        )
+      (36, _) =>
+        msg.f_timestamp = (reader |> @lib.read_message() : @protobuf.Timestamp)
+          |> Some
+      (37, _) =>
+        msg.f_duration = (reader |> @lib.read_message() : @protobuf.Duration)
+          |> Some
+      (27, _) =>
+        msg.test_oneof = reader |> @lib.read_int32() |> FooMessage_TestOneof::F1
+      (28, _) =>
+        msg.test_oneof = reader |> @lib.read_bool() |> FooMessage_TestOneof::F2
+      (29, _) =>
+        msg.test_oneof = reader
+          |> @lib.read_string()
+          |> FooMessage_TestOneof::F3
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1200,121 +1173,111 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> FooMessage raise {
   let msg = FooMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
-          (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
-          (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32()
-          (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64()
-          (5, _) => msg.f_sint32 = (reader |> @lib.async_read_sint32()).0
-          (6, _) => msg.f_sint64 = (reader |> @lib.async_read_sint64()).0
-          (7, _) => msg.f_bool = reader |> @lib.async_read_bool()
-          (8, _) =>
-            msg.f_foo_enum = reader
-              |> @lib.async_read_enum()
-              |> FooEnum::from_enum
-          (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64()
-          (10, _) => msg.f_sfixed64 = reader |> @lib.async_read_sfixed64()
-          (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32()
-          (12, _) => msg.f_sfixed32 = reader |> @lib.async_read_sfixed32()
-          (13, _) => msg.f_double = reader |> @lib.async_read_double()
-          (14, _) => msg.f_float = reader |> @lib.async_read_float()
-          (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
-          (16, _) => msg.f_string = reader |> @lib.async_read_string()
-          (18, _) =>
-            msg.f_bar_message = (
-                reader |> @lib.async_read_message() : BarMessage)
-              |> Some
-          (19, 2) =>
-            msg.f_repeated_int32.push_iter(
-              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-            )
-          (19, 0) =>
-            msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
-          (20, 2) =>
-            msg.f_repeated_packed_int32.push_iter(
-              (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
-            )
-          (20, 0) =>
-            msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
-          (21, 2) =>
-            msg.f_repeated_packed_float.push_iter(
-              (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
-            )
-          (21, 5) =>
-            msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-          (23, _) =>
-            msg.f_baz = (reader |> @lib.async_read_message() : BazMessage)
-              |> Some
-          (24, _) =>
-            msg.f_nested = (
-                reader |> @lib.async_read_message() : BazMessage_Nested)
-              |> Some
-          (25, _) =>
-            msg.f_nested_enum = reader
-              |> @lib.async_read_enum()
-              |> BazMessage_Nested_NestedEnum::from_enum
-          (26, _) => {
-            let { key, value } = (
-              reader |> @lib.async_read_message() : FooMessage_FMapEntry)
-            msg.f_map[key] = value
-          }
-          (30, _) =>
-            msg.f_repeated_string.push(reader |> @lib.async_read_string())
-          (31, _) =>
-            msg.f_repeated_baz_message.push(
-              (reader |> @lib.async_read_message() : BazMessage),
-            )
-          (32, _) =>
-            msg.f_optional_string = reader |> @lib.async_read_string() |> Some
-          (33, _) => msg.with_json_name = reader |> @lib.async_read_string()
-          (34, 2) => {
-            let packed = reader
-              |> @lib.async_read_packed(@lib.async_read_enum, None)
-            for item in packed {
-              msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
-            }
-          }
-          (34, 0) =>
-            msg.f_repeated_packed_enum.push(
-              reader |> @lib.async_read_enum() |> FooEnum::from_enum,
-            )
-          (35, 2) => {
-            let packed = reader
-              |> @lib.async_read_packed(@lib.async_read_enum, None)
-            for item in packed {
-              msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
-            }
-          }
-          (35, 0) =>
-            msg.f_repeated_unpacked_enum.push(
-              reader |> @lib.async_read_enum() |> FooEnum::from_enum,
-            )
-          (36, _) =>
-            msg.f_timestamp = (
-                reader |> @lib.async_read_message() : @protobuf.Timestamp)
-              |> Some
-          (37, _) =>
-            msg.f_duration = (
-                reader |> @lib.async_read_message() : @protobuf.Duration)
-              |> Some
-          (27, _) =>
-            msg.test_oneof = reader
-              |> @lib.async_read_int32()
-              |> FooMessage_TestOneof::F1
-          (28, _) =>
-            msg.test_oneof = reader
-              |> @lib.async_read_bool()
-              |> FooMessage_TestOneof::F2
-          (29, _) =>
-            msg.test_oneof = reader
-              |> @lib.async_read_string()
-              |> FooMessage_TestOneof::F3
-          _ => reader |> @lib.async_skip_message_field(wire)
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
+      (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
+      (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32()
+      (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64()
+      (5, _) => msg.f_sint32 = (reader |> @lib.async_read_sint32()).0
+      (6, _) => msg.f_sint64 = (reader |> @lib.async_read_sint64()).0
+      (7, _) => msg.f_bool = reader |> @lib.async_read_bool()
+      (8, _) =>
+        msg.f_foo_enum = reader |> @lib.async_read_enum() |> FooEnum::from_enum
+      (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64()
+      (10, _) => msg.f_sfixed64 = reader |> @lib.async_read_sfixed64()
+      (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32()
+      (12, _) => msg.f_sfixed32 = reader |> @lib.async_read_sfixed32()
+      (13, _) => msg.f_double = reader |> @lib.async_read_double()
+      (14, _) => msg.f_float = reader |> @lib.async_read_float()
+      (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
+      (16, _) => msg.f_string = reader |> @lib.async_read_string()
+      (18, _) =>
+        msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage)
+          |> Some
+      (19, 2) =>
+        msg.f_repeated_int32.push_iter(
+          (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+        )
+      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+      (20, 2) =>
+        msg.f_repeated_packed_int32.push_iter(
+          (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
+        )
+      (20, 0) =>
+        msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
+      (21, 2) =>
+        msg.f_repeated_packed_float.push_iter(
+          (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
+        )
+      (21, 5) =>
+        msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
+      (23, _) =>
+        msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
+      (24, _) =>
+        msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested)
+          |> Some
+      (25, _) =>
+        msg.f_nested_enum = reader
+          |> @lib.async_read_enum()
+          |> BazMessage_Nested_NestedEnum::from_enum
+      (26, _) => {
+        let { key, value } = (
+          reader |> @lib.async_read_message() : FooMessage_FMapEntry)
+        msg.f_map[key] = value
+      }
+      (30, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
+      (31, _) =>
+        msg.f_repeated_baz_message.push(
+          (reader |> @lib.async_read_message() : BazMessage),
+        )
+      (32, _) =>
+        msg.f_optional_string = reader |> @lib.async_read_string() |> Some
+      (33, _) => msg.with_json_name = reader |> @lib.async_read_string()
+      (34, 2) => {
+        let packed = reader
+          |> @lib.async_read_packed(@lib.async_read_enum, None)
+        for item in packed {
+          msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
         }
-      None => break
+      }
+      (34, 0) =>
+        msg.f_repeated_packed_enum.push(
+          reader |> @lib.async_read_enum() |> FooEnum::from_enum,
+        )
+      (35, 2) => {
+        let packed = reader
+          |> @lib.async_read_packed(@lib.async_read_enum, None)
+        for item in packed {
+          msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
+        }
+      }
+      (35, 0) =>
+        msg.f_repeated_unpacked_enum.push(
+          reader |> @lib.async_read_enum() |> FooEnum::from_enum,
+        )
+      (36, _) =>
+        msg.f_timestamp = (
+            reader |> @lib.async_read_message() : @protobuf.Timestamp)
+          |> Some
+      (37, _) =>
+        msg.f_duration = (
+            reader |> @lib.async_read_message() : @protobuf.Duration)
+          |> Some
+      (27, _) =>
+        msg.test_oneof = reader
+          |> @lib.async_read_int32()
+          |> FooMessage_TestOneof::F1
+      (28, _) =>
+        msg.test_oneof = reader
+          |> @lib.async_read_bool()
+          |> FooMessage_TestOneof::F2
+      (29, _) =>
+        msg.test_oneof = reader
+          |> @lib.async_read_string()
+          |> FooMessage_TestOneof::F3
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1623,14 +1586,10 @@ pub impl @lib.Read for BazMessage_Nested_NestedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_nested = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_nested = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1681,14 +1640,11 @@ pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with fn read_with_li
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1740,17 +1696,13 @@ pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.f_nested = (
-                reader |> @lib.read_message() : BazMessage_Nested_NestedMessage)
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.f_nested = (
+            reader |> @lib.read_message() : BazMessage_Nested_NestedMessage)
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1803,18 +1755,15 @@ pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.f_nested = (
-                reader |> @lib.async_read_message() :
-                BazMessage_Nested_NestedMessage)
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.f_nested = (
+            reader |> @lib.async_read_message() :
+            BazMessage_Nested_NestedMessage)
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1884,18 +1833,13 @@ pub impl @lib.Read for BazMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> BazMessage raise {
   let msg = BazMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.nested = (reader |> @lib.read_message() : BazMessage_Nested)
-              |> Some
-          (2, _) => msg.b_int64 = reader |> @lib.read_int64()
-          (3, _) => msg.b_string = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
+      (2, _) => msg.b_int64 = reader |> @lib.read_int64()
+      (3, _) => msg.b_string = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1961,19 +1905,15 @@ pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> BazMessage raise {
   let msg = BazMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.nested = (
-                reader |> @lib.async_read_message() : BazMessage_Nested)
-              |> Some
-          (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
-          (3, _) => msg.b_string = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested)
+          |> Some
+      (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
+      (3, _) => msg.b_string = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2031,15 +1971,11 @@ pub impl @lib.Read for RepeatedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2091,17 +2027,12 @@ pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.bar_message.push(
-              (reader |> @lib.async_read_message() : BarMessage),
-            )
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2147,14 +2078,10 @@ pub impl @lib.Read for EmptyMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EmptyMessage raise {
   let msg = EmptyMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.field = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.field = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2203,14 +2130,11 @@ pub impl @lib.AsyncRead for EmptyMessage with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EmptyMessage raise {
   let msg = EmptyMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.field = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.field = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2262,16 +2186,12 @@ pub impl @lib.Read for EmptyMessageWithField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> EmptyMessageWithField raise {
   let msg = EmptyMessageWithField::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.empty_message = (reader |> @lib.read_message() : EmptyMessage)
-              |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.empty_message = (reader |> @lib.read_message() : EmptyMessage)
+          |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2324,17 +2244,13 @@ pub impl @lib.AsyncRead for EmptyMessageWithField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> EmptyMessageWithField raise {
   let msg = EmptyMessageWithField::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.empty_message = (
-                reader |> @lib.async_read_message() : EmptyMessage)
-              |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.empty_message = (reader |> @lib.async_read_message() : EmptyMessage)
+          |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2438,25 +2354,21 @@ pub impl @lib.Read for OnlyOneOfField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.Reader],
 ) -> OnlyOneOfField raise {
   let msg = OnlyOneOfField::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.test_oneof = reader
-              |> @lib.read_int32()
-              |> OnlyOneOfField_TestOneof::F1
-          (2, _) =>
-            msg.test_oneof = reader
-              |> @lib.read_bool()
-              |> OnlyOneOfField_TestOneof::F2
-          (3, _) =>
-            msg.test_oneof = reader
-              |> @lib.read_string()
-              |> OnlyOneOfField_TestOneof::F3
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.test_oneof = reader
+          |> @lib.read_int32()
+          |> OnlyOneOfField_TestOneof::F1
+      (2, _) =>
+        msg.test_oneof = reader
+          |> @lib.read_bool()
+          |> OnlyOneOfField_TestOneof::F2
+      (3, _) =>
+        msg.test_oneof = reader
+          |> @lib.read_string()
+          |> OnlyOneOfField_TestOneof::F3
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2521,25 +2433,22 @@ pub impl @lib.AsyncRead for OnlyOneOfField with fn read_with_limit(
   reader : @lib.LimitedReader[&@lib.AsyncReader],
 ) -> OnlyOneOfField raise {
   let msg = OnlyOneOfField::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) =>
-            msg.test_oneof = reader
-              |> @lib.async_read_int32()
-              |> OnlyOneOfField_TestOneof::F1
-          (2, _) =>
-            msg.test_oneof = reader
-              |> @lib.async_read_bool()
-              |> OnlyOneOfField_TestOneof::F2
-          (3, _) =>
-            msg.test_oneof = reader
-              |> @lib.async_read_string()
-              |> OnlyOneOfField_TestOneof::F3
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field())
+        is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) =>
+        msg.test_oneof = reader
+          |> @lib.async_read_int32()
+          |> OnlyOneOfField_TestOneof::F1
+      (2, _) =>
+        msg.test_oneof = reader
+          |> @lib.async_read_bool()
+          |> OnlyOneOfField_TestOneof::F2
+      (3, _) =>
+        msg.test_oneof = reader
+          |> @lib.async_read_string()
+          |> OnlyOneOfField_TestOneof::F3
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -67,14 +67,10 @@ pub fn BarMessage::new(b_int32 : Int) -> BarMessage {
 }
 pub impl @lib.Read for BarMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BarMessage raise {
   let msg = BarMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.b_int32 = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.b_int32 = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -107,14 +103,10 @@ pub impl @json.FromJson for BarMessage with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for BarMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BarMessage raise {
   let msg = BarMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -153,15 +145,11 @@ pub fn FooMessage_FMapEntry::new(key : String, value : Int) -> FooMessage_FMapEn
 }
 pub impl @lib.Read for FooMessage_FMapEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.read_string()
-          (2, _) => msg.value = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.read_string()
+      (2, _) => msg.value = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -202,15 +190,11 @@ pub impl @json.FromJson for FooMessage_FMapEntry with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for FooMessage_FMapEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.async_read_string()
-          (2, _) => msg.value = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.async_read_string()
+      (2, _) => msg.value = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -449,46 +433,42 @@ pub fn FooMessage::new(f_int32 : Int, f_int64 : Int64, f_uint32 : UInt, f_uint64
 }
 pub impl @lib.Read for FooMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FooMessage raise {
   let msg = FooMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_int32 = reader |> @lib.read_int32()
-          (2, _) => msg.f_int64 = reader |> @lib.read_int64()
-          (3, _) => msg.f_uint32 = reader |> @lib.read_uint32()
-          (4, _) => msg.f_uint64 = reader |> @lib.read_uint64()
-          (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0
-          (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0
-          (7, _) => msg.f_bool = reader |> @lib.read_bool()
-          (8, _) => msg.f_foo_enum = reader |> @lib.read_enum() |> FooEnum::from_enum
-          (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64()
-          (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64()
-          (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32()
-          (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32()
-          (13, _) => msg.f_double = reader |> @lib.read_double()
-          (14, _) => msg.f_float = reader |> @lib.read_float()
-          (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
-          (16, _) => msg.f_string = reader |> @lib.read_string()
-          (18, _) => msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
-          (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-          (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
-          (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-          (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
-          (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()) }
-          (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-          (23, _) => msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
-          (24, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
-          (25, _) => msg.f_nested_enum = reader |> @lib.read_enum() |> BazMessage_Nested_NestedEnum::from_enum
-          (26, _) => { let {key, value} = (reader |> @lib.read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
-          (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-          (31, _) => msg.f_repeated_baz_message.push((reader |> @lib.read_message() : BazMessage))
-          (32, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
-          (27, _) => msg.test_oneof = reader |> @lib.read_int32() |> FooMessage_TestOneof::F1
-          (28, _) => msg.test_oneof = reader |> @lib.read_bool() |> FooMessage_TestOneof::F2
-          (29, _) => msg.test_oneof = reader |> @lib.read_string() |> FooMessage_TestOneof::F3
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_int32 = reader |> @lib.read_int32()
+      (2, _) => msg.f_int64 = reader |> @lib.read_int64()
+      (3, _) => msg.f_uint32 = reader |> @lib.read_uint32()
+      (4, _) => msg.f_uint64 = reader |> @lib.read_uint64()
+      (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0
+      (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0
+      (7, _) => msg.f_bool = reader |> @lib.read_bool()
+      (8, _) => msg.f_foo_enum = reader |> @lib.read_enum() |> FooEnum::from_enum
+      (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64()
+      (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64()
+      (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32()
+      (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32()
+      (13, _) => msg.f_double = reader |> @lib.read_double()
+      (14, _) => msg.f_float = reader |> @lib.read_float()
+      (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
+      (16, _) => msg.f_string = reader |> @lib.read_string()
+      (18, _) => msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
+      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
+      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()) }
+      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
+      (23, _) => msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
+      (24, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
+      (25, _) => msg.f_nested_enum = reader |> @lib.read_enum() |> BazMessage_Nested_NestedEnum::from_enum
+      (26, _) => { let {key, value} = (reader |> @lib.read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
+      (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
+      (31, _) => msg.f_repeated_baz_message.push((reader |> @lib.read_message() : BazMessage))
+      (32, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
+      (27, _) => msg.test_oneof = reader |> @lib.read_int32() |> FooMessage_TestOneof::F1
+      (28, _) => msg.test_oneof = reader |> @lib.read_bool() |> FooMessage_TestOneof::F2
+      (29, _) => msg.test_oneof = reader |> @lib.read_string() |> FooMessage_TestOneof::F3
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -797,46 +777,42 @@ Float::from_double(@json.from_json(v, path~)))
 }
 pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FooMessage raise {
   let msg = FooMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
-          (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
-          (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32()
-          (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64()
-          (5, _) => msg.f_sint32 = (reader |> @lib.async_read_sint32()).0
-          (6, _) => msg.f_sint64 = (reader |> @lib.async_read_sint64()).0
-          (7, _) => msg.f_bool = reader |> @lib.async_read_bool()
-          (8, _) => msg.f_foo_enum = reader |> @lib.async_read_enum() |> FooEnum::from_enum
-          (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64()
-          (10, _) => msg.f_sfixed64 = reader |> @lib.async_read_sfixed64()
-          (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32()
-          (12, _) => msg.f_sfixed32 = reader |> @lib.async_read_sfixed32()
-          (13, _) => msg.f_double = reader |> @lib.async_read_double()
-          (14, _) => msg.f_float = reader |> @lib.async_read_float()
-          (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
-          (16, _) => msg.f_string = reader |> @lib.async_read_string()
-          (18, _) => msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage) |> Some
-          (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-          (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
-          (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-          (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
-          (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()) }
-          (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-          (23, _) => msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
-          (24, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
-          (25, _) => msg.f_nested_enum = reader |> @lib.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum
-          (26, _) => { let {key, value} = (reader |> @lib.async_read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
-          (30, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
-          (31, _) => msg.f_repeated_baz_message.push((reader |> @lib.async_read_message() : BazMessage))
-          (32, _) => msg.f_optional_string = reader |> @lib.async_read_string() |> Some
-          (27, _) => msg.test_oneof = reader |> @lib.async_read_int32() |> FooMessage_TestOneof::F1
-          (28, _) => msg.test_oneof = reader |> @lib.async_read_bool() |> FooMessage_TestOneof::F2
-          (29, _) => msg.test_oneof = reader |> @lib.async_read_string() |> FooMessage_TestOneof::F3
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
+      (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
+      (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32()
+      (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64()
+      (5, _) => msg.f_sint32 = (reader |> @lib.async_read_sint32()).0
+      (6, _) => msg.f_sint64 = (reader |> @lib.async_read_sint64()).0
+      (7, _) => msg.f_bool = reader |> @lib.async_read_bool()
+      (8, _) => msg.f_foo_enum = reader |> @lib.async_read_enum() |> FooEnum::from_enum
+      (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64()
+      (10, _) => msg.f_sfixed64 = reader |> @lib.async_read_sfixed64()
+      (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32()
+      (12, _) => msg.f_sfixed32 = reader |> @lib.async_read_sfixed32()
+      (13, _) => msg.f_double = reader |> @lib.async_read_double()
+      (14, _) => msg.f_float = reader |> @lib.async_read_float()
+      (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
+      (16, _) => msg.f_string = reader |> @lib.async_read_string()
+      (18, _) => msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage) |> Some
+      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
+      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()) }
+      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
+      (23, _) => msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
+      (24, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
+      (25, _) => msg.f_nested_enum = reader |> @lib.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum
+      (26, _) => { let {key, value} = (reader |> @lib.async_read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
+      (30, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
+      (31, _) => msg.f_repeated_baz_message.push((reader |> @lib.async_read_message() : BazMessage))
+      (32, _) => msg.f_optional_string = reader |> @lib.async_read_string() |> Some
+      (27, _) => msg.test_oneof = reader |> @lib.async_read_int32() |> FooMessage_TestOneof::F1
+      (28, _) => msg.test_oneof = reader |> @lib.async_read_bool() |> FooMessage_TestOneof::F2
+      (29, _) => msg.test_oneof = reader |> @lib.async_read_string() |> FooMessage_TestOneof::F3
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1076,14 +1052,10 @@ pub fn BazMessage_Nested_NestedMessage::new(f_nested : Int) -> BazMessage_Nested
 }
 pub impl @lib.Read for BazMessage_Nested_NestedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_nested = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_nested = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1116,14 +1088,10 @@ pub impl @json.FromJson for BazMessage_Nested_NestedMessage with fn from_json(js
 }
 pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1156,14 +1124,10 @@ pub fn BazMessage_Nested::new(f_nested? : BazMessage_Nested_NestedMessage) -> Ba
 }
 pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1198,14 +1162,10 @@ pub impl @json.FromJson for BazMessage_Nested with fn from_json(json: Json, path
 }
 pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1251,16 +1211,12 @@ pub fn BazMessage::new(nested? : BazMessage_Nested, b_int64 : Int64, b_string : 
 }
 pub impl @lib.Read for BazMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage raise {
   let msg = BazMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
-          (2, _) => msg.b_int64 = reader |> @lib.read_int64()
-          (3, _) => msg.b_string = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
+      (2, _) => msg.b_int64 = reader |> @lib.read_int64()
+      (3, _) => msg.b_string = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1311,16 +1267,12 @@ pub impl @json.FromJson for BazMessage with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage raise {
   let msg = BazMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
-          (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
-          (3, _) => msg.b_string = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
+      (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
+      (3, _) => msg.b_string = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1362,14 +1314,10 @@ pub fn RepeatedMessage::new(bar_message : Array[BarMessage]) -> RepeatedMessage 
 }
 pub impl @lib.Read for RepeatedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1404,14 +1352,10 @@ pub impl @json.FromJson for RepeatedMessage with fn from_json(json: Json, path: 
 }
 pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -67,17 +67,12 @@ pub fn BarMessage::new(b_int32 : Int) -> BarMessage {
 }
 pub impl @lib.Read for BarMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BarMessage raise {
   let msg = BarMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.b_int32 = reader |> @lib.read_int32()
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.b_int32 = reader |> @lib.read_int32(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for BarMessage with fn write(self: BarMessage, writer : &@lib.Writer) -> Unit raise {
@@ -108,17 +103,12 @@ pub impl @json.FromJson for BarMessage with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for BarMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BarMessage raise {
   let msg = BarMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.b_int32 = reader |> @lib.async_read_int32(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for BarMessage with fn write(self: BarMessage, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -155,18 +145,13 @@ pub fn FooMessage_FMapEntry::new(key : String, value : Int) -> FooMessage_FMapEn
 }
 pub impl @lib.Read for FooMessage_FMapEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.key = reader |> @lib.read_string()
-      (2, _) => msg.value = reader |> @lib.read_int32()
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.key = reader |> @lib.read_string(); true }
+      (2, _) => { msg.value = reader |> @lib.read_int32(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FooMessage_FMapEntry with fn write(self: FooMessage_FMapEntry, writer : &@lib.Writer) -> Unit raise {
@@ -205,18 +190,13 @@ pub impl @json.FromJson for FooMessage_FMapEntry with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for FooMessage_FMapEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.key = reader |> @lib.async_read_string()
-      (2, _) => msg.value = reader |> @lib.async_read_int32()
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.key = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.value = reader |> @lib.async_read_int32(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FooMessage_FMapEntry with fn write(self: FooMessage_FMapEntry, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -453,49 +433,44 @@ pub fn FooMessage::new(f_int32 : Int, f_int64 : Int64, f_uint32 : UInt, f_uint64
 }
 pub impl @lib.Read for FooMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FooMessage raise {
   let msg = FooMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.f_int32 = reader |> @lib.read_int32()
-      (2, _) => msg.f_int64 = reader |> @lib.read_int64()
-      (3, _) => msg.f_uint32 = reader |> @lib.read_uint32()
-      (4, _) => msg.f_uint64 = reader |> @lib.read_uint64()
-      (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0
-      (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0
-      (7, _) => msg.f_bool = reader |> @lib.read_bool()
-      (8, _) => msg.f_foo_enum = reader |> @lib.read_enum() |> FooEnum::from_enum
-      (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64()
-      (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64()
-      (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32()
-      (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32()
-      (13, _) => msg.f_double = reader |> @lib.read_double()
-      (14, _) => msg.f_float = reader |> @lib.read_float()
-      (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
-      (16, _) => msg.f_string = reader |> @lib.read_string()
-      (18, _) => msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
-      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
-      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
-      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()) }
-      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-      (23, _) => msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
-      (24, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
-      (25, _) => msg.f_nested_enum = reader |> @lib.read_enum() |> BazMessage_Nested_NestedEnum::from_enum
-      (26, _) => { let {key, value} = (reader |> @lib.read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
-      (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-      (31, _) => msg.f_repeated_baz_message.push((reader |> @lib.read_message() : BazMessage))
-      (32, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
-        (27, _) => msg.test_oneof = reader |> @lib.read_int32() |> FooMessage_TestOneof::F1
-        (28, _) => msg.test_oneof = reader |> @lib.read_bool() |> FooMessage_TestOneof::F2
-        (29, _) => msg.test_oneof = reader |> @lib.read_string() |> FooMessage_TestOneof::F3
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.f_int32 = reader |> @lib.read_int32(); true }
+      (2, _) => { msg.f_int64 = reader |> @lib.read_int64(); true }
+      (3, _) => { msg.f_uint32 = reader |> @lib.read_uint32(); true }
+      (4, _) => { msg.f_uint64 = reader |> @lib.read_uint64(); true }
+      (5, _) => { msg.f_sint32 = (reader |> @lib.read_sint32()).0; true }
+      (6, _) => { msg.f_sint64 = (reader |> @lib.read_sint64()).0; true }
+      (7, _) => { msg.f_bool = reader |> @lib.read_bool(); true }
+      (8, _) => { msg.f_foo_enum = reader |> @lib.read_enum() |> FooEnum::from_enum; true }
+      (9, _) => { msg.f_fixed64 = reader |> @lib.read_fixed64(); true }
+      (10, _) => { msg.f_sfixed64 = reader |> @lib.read_sfixed64(); true }
+      (11, _) => { msg.f_fixed32 = reader |> @lib.read_fixed32(); true }
+      (12, _) => { msg.f_sfixed32 = reader |> @lib.read_sfixed32(); true }
+      (13, _) => { msg.f_double = reader |> @lib.read_double(); true }
+      (14, _) => { msg.f_float = reader |> @lib.read_float(); true }
+      (15, _) => { msg.f_bytes = reader |> @lib.read_bytes(); true }
+      (16, _) => { msg.f_string = reader |> @lib.read_string(); true }
+      (18, _) => { msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some; true }
+      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
+      (19, 0) => { msg.f_repeated_int32.push(reader |> @lib.read_int32()); true }
+      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
+      (20, 0) => { msg.f_repeated_packed_int32.push(reader |> @lib.read_int32()); true }
+      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()); true }
+      (21, 5) => { msg.f_repeated_packed_float.push(reader |> @lib.read_float()); true }
+      (23, _) => { msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some; true }
+      (24, _) => { msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some; true }
+      (25, _) => { msg.f_nested_enum = reader |> @lib.read_enum() |> BazMessage_Nested_NestedEnum::from_enum; true }
+      (26, _) => { let {key, value} = (reader |> @lib.read_message() : FooMessage_FMapEntry); msg.f_map[key] = value; true }
+      (30, _) => { msg.f_repeated_string.push(reader |> @lib.read_string()); true }
+      (31, _) => { msg.f_repeated_baz_message.push((reader |> @lib.read_message() : BazMessage)); true }
+      (32, _) => { msg.f_optional_string = reader |> @lib.read_string() |> Some; true }
+      (27, _) => { msg.test_oneof = reader |> @lib.read_int32() |> FooMessage_TestOneof::F1; true }
+      (28, _) => { msg.test_oneof = reader |> @lib.read_bool() |> FooMessage_TestOneof::F2; true }
+      (29, _) => { msg.test_oneof = reader |> @lib.read_string() |> FooMessage_TestOneof::F3; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@lib.Writer) -> Unit raise {
@@ -565,7 +540,7 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
   }
   if self.f_bar_message is Some(v) {
     writer |> @lib.write_varint(146UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if !self.f_repeated_int32.is_empty() {
@@ -597,12 +572,12 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
   }
   if self.f_baz is Some(v) {
     writer |> @lib.write_varint(186UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.f_nested is Some(v) {
     writer |> @lib.write_varint(194UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.f_nested_enum != Default::default() {
@@ -631,7 +606,7 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
   }
   for item in self.f_repeated_baz_message {
     writer |> @lib.write_varint(250UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.f_optional_string is Some(v) {
@@ -802,49 +777,44 @@ Float::from_double(@json.from_json(v, path~)))
 }
 pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FooMessage raise {
   let msg = FooMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
-      (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
-      (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32()
-      (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64()
-      (5, _) => msg.f_sint32 = (reader |> @lib.async_read_sint32()).0
-      (6, _) => msg.f_sint64 = (reader |> @lib.async_read_sint64()).0
-      (7, _) => msg.f_bool = reader |> @lib.async_read_bool()
-      (8, _) => msg.f_foo_enum = reader |> @lib.async_read_enum() |> FooEnum::from_enum
-      (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64()
-      (10, _) => msg.f_sfixed64 = reader |> @lib.async_read_sfixed64()
-      (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32()
-      (12, _) => msg.f_sfixed32 = reader |> @lib.async_read_sfixed32()
-      (13, _) => msg.f_double = reader |> @lib.async_read_double()
-      (14, _) => msg.f_float = reader |> @lib.async_read_float()
-      (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
-      (16, _) => msg.f_string = reader |> @lib.async_read_string()
-      (18, _) => msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage) |> Some
-      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
-      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
-      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()) }
-      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-      (23, _) => msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
-      (24, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
-      (25, _) => msg.f_nested_enum = reader |> @lib.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum
-      (26, _) => { let {key, value} = (reader |> @lib.async_read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
-      (30, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
-      (31, _) => msg.f_repeated_baz_message.push((reader |> @lib.async_read_message() : BazMessage))
-      (32, _) => msg.f_optional_string = reader |> @lib.async_read_string() |> Some
-        (27, _) => msg.test_oneof = reader |> @lib.async_read_int32() |> FooMessage_TestOneof::F1
-        (28, _) => msg.test_oneof = reader |> @lib.async_read_bool() |> FooMessage_TestOneof::F2
-        (29, _) => msg.test_oneof = reader |> @lib.async_read_string() |> FooMessage_TestOneof::F3
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.f_int32 = reader |> @lib.async_read_int32(); true }
+      (2, _) => { msg.f_int64 = reader |> @lib.async_read_int64(); true }
+      (3, _) => { msg.f_uint32 = reader |> @lib.async_read_uint32(); true }
+      (4, _) => { msg.f_uint64 = reader |> @lib.async_read_uint64(); true }
+      (5, _) => { msg.f_sint32 = (reader |> @lib.async_read_sint32()).0; true }
+      (6, _) => { msg.f_sint64 = (reader |> @lib.async_read_sint64()).0; true }
+      (7, _) => { msg.f_bool = reader |> @lib.async_read_bool(); true }
+      (8, _) => { msg.f_foo_enum = reader |> @lib.async_read_enum() |> FooEnum::from_enum; true }
+      (9, _) => { msg.f_fixed64 = reader |> @lib.async_read_fixed64(); true }
+      (10, _) => { msg.f_sfixed64 = reader |> @lib.async_read_sfixed64(); true }
+      (11, _) => { msg.f_fixed32 = reader |> @lib.async_read_fixed32(); true }
+      (12, _) => { msg.f_sfixed32 = reader |> @lib.async_read_sfixed32(); true }
+      (13, _) => { msg.f_double = reader |> @lib.async_read_double(); true }
+      (14, _) => { msg.f_float = reader |> @lib.async_read_float(); true }
+      (15, _) => { msg.f_bytes = reader |> @lib.async_read_bytes(); true }
+      (16, _) => { msg.f_string = reader |> @lib.async_read_string(); true }
+      (18, _) => { msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage) |> Some; true }
+      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
+      (19, 0) => { msg.f_repeated_int32.push(reader |> @lib.async_read_int32()); true }
+      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
+      (20, 0) => { msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32()); true }
+      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()); true }
+      (21, 5) => { msg.f_repeated_packed_float.push(reader |> @lib.async_read_float()); true }
+      (23, _) => { msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some; true }
+      (24, _) => { msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some; true }
+      (25, _) => { msg.f_nested_enum = reader |> @lib.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum; true }
+      (26, _) => { let {key, value} = (reader |> @lib.async_read_message() : FooMessage_FMapEntry); msg.f_map[key] = value; true }
+      (30, _) => { msg.f_repeated_string.push(reader |> @lib.async_read_string()); true }
+      (31, _) => { msg.f_repeated_baz_message.push((reader |> @lib.async_read_message() : BazMessage)); true }
+      (32, _) => { msg.f_optional_string = reader |> @lib.async_read_string() |> Some; true }
+      (27, _) => { msg.test_oneof = reader |> @lib.async_read_int32() |> FooMessage_TestOneof::F1; true }
+      (28, _) => { msg.test_oneof = reader |> @lib.async_read_bool() |> FooMessage_TestOneof::F2; true }
+      (29, _) => { msg.test_oneof = reader |> @lib.async_read_string() |> FooMessage_TestOneof::F3; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -914,7 +884,7 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
   }
   if self.f_bar_message is Some(v) {
     writer |> @lib.async_write_varint(146UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if !self.f_repeated_int32.is_empty() {
@@ -946,12 +916,12 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
   }
   if self.f_baz is Some(v) {
     writer |> @lib.async_write_varint(186UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.f_nested is Some(v) {
     writer |> @lib.async_write_varint(194UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.f_nested_enum != Default::default() {
@@ -980,7 +950,7 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
   }
   for item in self.f_repeated_baz_message {
     writer |> @lib.async_write_varint(250UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.f_optional_string is Some(v) {
@@ -1082,17 +1052,12 @@ pub fn BazMessage_Nested_NestedMessage::new(f_nested : Int) -> BazMessage_Nested
 }
 pub impl @lib.Read for BazMessage_Nested_NestedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.f_nested = reader |> @lib.read_int32()
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.f_nested = reader |> @lib.read_int32(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for BazMessage_Nested_NestedMessage with fn write(self: BazMessage_Nested_NestedMessage, writer : &@lib.Writer) -> Unit raise {
@@ -1123,17 +1088,12 @@ pub impl @json.FromJson for BazMessage_Nested_NestedMessage with fn from_json(js
 }
 pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.f_nested = reader |> @lib.async_read_int32(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for BazMessage_Nested_NestedMessage with fn write(self: BazMessage_Nested_NestedMessage, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1164,23 +1124,18 @@ pub fn BazMessage_Nested::new(f_nested? : BazMessage_Nested_NestedMessage) -> Ba
 }
 pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.Writer) -> Unit raise {
   if self.f_nested is Some(v) {
     writer |> @lib.write_varint(10UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -1207,23 +1162,18 @@ pub impl @json.FromJson for BazMessage_Nested with fn from_json(json: Json, path
 }
 pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.f_nested is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -1261,25 +1211,20 @@ pub fn BazMessage::new(nested? : BazMessage_Nested, b_int64 : Int64, b_string : 
 }
 pub impl @lib.Read for BazMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage raise {
   let msg = BazMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
-      (2, _) => msg.b_int64 = reader |> @lib.read_int64()
-      (3, _) => msg.b_string = reader |> @lib.read_string()
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some; true }
+      (2, _) => { msg.b_int64 = reader |> @lib.read_int64(); true }
+      (3, _) => { msg.b_string = reader |> @lib.read_string(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for BazMessage with fn write(self: BazMessage, writer : &@lib.Writer) -> Unit raise {
   if self.nested is Some(v) {
     writer |> @lib.write_varint(10UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.b_int64 != Default::default() {
@@ -1322,25 +1267,20 @@ pub impl @json.FromJson for BazMessage with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage raise {
   let msg = BazMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
-      (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
-      (3, _) => msg.b_string = reader |> @lib.async_read_string()
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some; true }
+      (2, _) => { msg.b_int64 = reader |> @lib.async_read_int64(); true }
+      (3, _) => { msg.b_string = reader |> @lib.async_read_string(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for BazMessage with fn write(self: BazMessage, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.nested is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.b_int64 != Default::default() {
@@ -1374,23 +1314,18 @@ pub fn RepeatedMessage::new(bar_message : Array[BarMessage]) -> RepeatedMessage 
 }
 pub impl @lib.Read for RepeatedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.bar_message.push((reader |> @lib.read_message() : BarMessage)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for RepeatedMessage with fn write(self: RepeatedMessage, writer : &@lib.Writer) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -1417,23 +1352,18 @@ pub impl @json.FromJson for RepeatedMessage with fn from_json(json: Json, path: 
 }
 pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for RepeatedMessage with fn write(self: RepeatedMessage, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -67,12 +67,16 @@ pub fn BarMessage::new(b_int32 : Int) -> BarMessage {
 }
 pub impl @lib.Read for BarMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BarMessage raise {
   let msg = BarMessage::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.b_int32 = reader |> @lib.read_int32(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.b_int32 = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for BarMessage with fn write(self: BarMessage, writer : &@lib.Writer) -> Unit raise {
@@ -103,12 +107,16 @@ pub impl @json.FromJson for BarMessage with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for BarMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BarMessage raise {
   let msg = BarMessage::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.b_int32 = reader |> @lib.async_read_int32(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for BarMessage with fn write(self: BarMessage, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -145,13 +153,17 @@ pub fn FooMessage_FMapEntry::new(key : String, value : Int) -> FooMessage_FMapEn
 }
 pub impl @lib.Read for FooMessage_FMapEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.key = reader |> @lib.read_string(); true }
-      (2, _) => { msg.value = reader |> @lib.read_int32(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.read_string()
+          (2, _) => msg.value = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FooMessage_FMapEntry with fn write(self: FooMessage_FMapEntry, writer : &@lib.Writer) -> Unit raise {
@@ -190,13 +202,17 @@ pub impl @json.FromJson for FooMessage_FMapEntry with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for FooMessage_FMapEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FooMessage_FMapEntry raise {
   let msg = FooMessage_FMapEntry::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.key = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.value = reader |> @lib.async_read_int32(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.async_read_string()
+          (2, _) => msg.value = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FooMessage_FMapEntry with fn write(self: FooMessage_FMapEntry, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -433,44 +449,48 @@ pub fn FooMessage::new(f_int32 : Int, f_int64 : Int64, f_uint32 : UInt, f_uint64
 }
 pub impl @lib.Read for FooMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FooMessage raise {
   let msg = FooMessage::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.f_int32 = reader |> @lib.read_int32(); true }
-      (2, _) => { msg.f_int64 = reader |> @lib.read_int64(); true }
-      (3, _) => { msg.f_uint32 = reader |> @lib.read_uint32(); true }
-      (4, _) => { msg.f_uint64 = reader |> @lib.read_uint64(); true }
-      (5, _) => { msg.f_sint32 = (reader |> @lib.read_sint32()).0; true }
-      (6, _) => { msg.f_sint64 = (reader |> @lib.read_sint64()).0; true }
-      (7, _) => { msg.f_bool = reader |> @lib.read_bool(); true }
-      (8, _) => { msg.f_foo_enum = reader |> @lib.read_enum() |> FooEnum::from_enum; true }
-      (9, _) => { msg.f_fixed64 = reader |> @lib.read_fixed64(); true }
-      (10, _) => { msg.f_sfixed64 = reader |> @lib.read_sfixed64(); true }
-      (11, _) => { msg.f_fixed32 = reader |> @lib.read_fixed32(); true }
-      (12, _) => { msg.f_sfixed32 = reader |> @lib.read_sfixed32(); true }
-      (13, _) => { msg.f_double = reader |> @lib.read_double(); true }
-      (14, _) => { msg.f_float = reader |> @lib.read_float(); true }
-      (15, _) => { msg.f_bytes = reader |> @lib.read_bytes(); true }
-      (16, _) => { msg.f_string = reader |> @lib.read_string(); true }
-      (18, _) => { msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some; true }
-      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
-      (19, 0) => { msg.f_repeated_int32.push(reader |> @lib.read_int32()); true }
-      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
-      (20, 0) => { msg.f_repeated_packed_int32.push(reader |> @lib.read_int32()); true }
-      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()); true }
-      (21, 5) => { msg.f_repeated_packed_float.push(reader |> @lib.read_float()); true }
-      (23, _) => { msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some; true }
-      (24, _) => { msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some; true }
-      (25, _) => { msg.f_nested_enum = reader |> @lib.read_enum() |> BazMessage_Nested_NestedEnum::from_enum; true }
-      (26, _) => { let {key, value} = (reader |> @lib.read_message() : FooMessage_FMapEntry); msg.f_map[key] = value; true }
-      (30, _) => { msg.f_repeated_string.push(reader |> @lib.read_string()); true }
-      (31, _) => { msg.f_repeated_baz_message.push((reader |> @lib.read_message() : BazMessage)); true }
-      (32, _) => { msg.f_optional_string = reader |> @lib.read_string() |> Some; true }
-      (27, _) => { msg.test_oneof = reader |> @lib.read_int32() |> FooMessage_TestOneof::F1; true }
-      (28, _) => { msg.test_oneof = reader |> @lib.read_bool() |> FooMessage_TestOneof::F2; true }
-      (29, _) => { msg.test_oneof = reader |> @lib.read_string() |> FooMessage_TestOneof::F3; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_int32 = reader |> @lib.read_int32()
+          (2, _) => msg.f_int64 = reader |> @lib.read_int64()
+          (3, _) => msg.f_uint32 = reader |> @lib.read_uint32()
+          (4, _) => msg.f_uint64 = reader |> @lib.read_uint64()
+          (5, _) => msg.f_sint32 = (reader |> @lib.read_sint32()).0
+          (6, _) => msg.f_sint64 = (reader |> @lib.read_sint64()).0
+          (7, _) => msg.f_bool = reader |> @lib.read_bool()
+          (8, _) => msg.f_foo_enum = reader |> @lib.read_enum() |> FooEnum::from_enum
+          (9, _) => msg.f_fixed64 = reader |> @lib.read_fixed64()
+          (10, _) => msg.f_sfixed64 = reader |> @lib.read_sfixed64()
+          (11, _) => msg.f_fixed32 = reader |> @lib.read_fixed32()
+          (12, _) => msg.f_sfixed32 = reader |> @lib.read_sfixed32()
+          (13, _) => msg.f_double = reader |> @lib.read_double()
+          (14, _) => msg.f_float = reader |> @lib.read_float()
+          (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
+          (16, _) => msg.f_string = reader |> @lib.read_string()
+          (18, _) => msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
+          (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+          (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
+          (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+          (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+          (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()) }
+          (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
+          (23, _) => msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
+          (24, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
+          (25, _) => msg.f_nested_enum = reader |> @lib.read_enum() |> BazMessage_Nested_NestedEnum::from_enum
+          (26, _) => { let {key, value} = (reader |> @lib.read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
+          (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
+          (31, _) => msg.f_repeated_baz_message.push((reader |> @lib.read_message() : BazMessage))
+          (32, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
+          (27, _) => msg.test_oneof = reader |> @lib.read_int32() |> FooMessage_TestOneof::F1
+          (28, _) => msg.test_oneof = reader |> @lib.read_bool() |> FooMessage_TestOneof::F2
+          (29, _) => msg.test_oneof = reader |> @lib.read_string() |> FooMessage_TestOneof::F3
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@lib.Writer) -> Unit raise {
@@ -777,44 +797,48 @@ Float::from_double(@json.from_json(v, path~)))
 }
 pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FooMessage raise {
   let msg = FooMessage::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.f_int32 = reader |> @lib.async_read_int32(); true }
-      (2, _) => { msg.f_int64 = reader |> @lib.async_read_int64(); true }
-      (3, _) => { msg.f_uint32 = reader |> @lib.async_read_uint32(); true }
-      (4, _) => { msg.f_uint64 = reader |> @lib.async_read_uint64(); true }
-      (5, _) => { msg.f_sint32 = (reader |> @lib.async_read_sint32()).0; true }
-      (6, _) => { msg.f_sint64 = (reader |> @lib.async_read_sint64()).0; true }
-      (7, _) => { msg.f_bool = reader |> @lib.async_read_bool(); true }
-      (8, _) => { msg.f_foo_enum = reader |> @lib.async_read_enum() |> FooEnum::from_enum; true }
-      (9, _) => { msg.f_fixed64 = reader |> @lib.async_read_fixed64(); true }
-      (10, _) => { msg.f_sfixed64 = reader |> @lib.async_read_sfixed64(); true }
-      (11, _) => { msg.f_fixed32 = reader |> @lib.async_read_fixed32(); true }
-      (12, _) => { msg.f_sfixed32 = reader |> @lib.async_read_sfixed32(); true }
-      (13, _) => { msg.f_double = reader |> @lib.async_read_double(); true }
-      (14, _) => { msg.f_float = reader |> @lib.async_read_float(); true }
-      (15, _) => { msg.f_bytes = reader |> @lib.async_read_bytes(); true }
-      (16, _) => { msg.f_string = reader |> @lib.async_read_string(); true }
-      (18, _) => { msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage) |> Some; true }
-      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
-      (19, 0) => { msg.f_repeated_int32.push(reader |> @lib.async_read_int32()); true }
-      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
-      (20, 0) => { msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32()); true }
-      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()); true }
-      (21, 5) => { msg.f_repeated_packed_float.push(reader |> @lib.async_read_float()); true }
-      (23, _) => { msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some; true }
-      (24, _) => { msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some; true }
-      (25, _) => { msg.f_nested_enum = reader |> @lib.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum; true }
-      (26, _) => { let {key, value} = (reader |> @lib.async_read_message() : FooMessage_FMapEntry); msg.f_map[key] = value; true }
-      (30, _) => { msg.f_repeated_string.push(reader |> @lib.async_read_string()); true }
-      (31, _) => { msg.f_repeated_baz_message.push((reader |> @lib.async_read_message() : BazMessage)); true }
-      (32, _) => { msg.f_optional_string = reader |> @lib.async_read_string() |> Some; true }
-      (27, _) => { msg.test_oneof = reader |> @lib.async_read_int32() |> FooMessage_TestOneof::F1; true }
-      (28, _) => { msg.test_oneof = reader |> @lib.async_read_bool() |> FooMessage_TestOneof::F2; true }
-      (29, _) => { msg.test_oneof = reader |> @lib.async_read_string() |> FooMessage_TestOneof::F3; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_int32 = reader |> @lib.async_read_int32()
+          (2, _) => msg.f_int64 = reader |> @lib.async_read_int64()
+          (3, _) => msg.f_uint32 = reader |> @lib.async_read_uint32()
+          (4, _) => msg.f_uint64 = reader |> @lib.async_read_uint64()
+          (5, _) => msg.f_sint32 = (reader |> @lib.async_read_sint32()).0
+          (6, _) => msg.f_sint64 = (reader |> @lib.async_read_sint64()).0
+          (7, _) => msg.f_bool = reader |> @lib.async_read_bool()
+          (8, _) => msg.f_foo_enum = reader |> @lib.async_read_enum() |> FooEnum::from_enum
+          (9, _) => msg.f_fixed64 = reader |> @lib.async_read_fixed64()
+          (10, _) => msg.f_sfixed64 = reader |> @lib.async_read_sfixed64()
+          (11, _) => msg.f_fixed32 = reader |> @lib.async_read_fixed32()
+          (12, _) => msg.f_sfixed32 = reader |> @lib.async_read_sfixed32()
+          (13, _) => msg.f_double = reader |> @lib.async_read_double()
+          (14, _) => msg.f_float = reader |> @lib.async_read_float()
+          (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
+          (16, _) => msg.f_string = reader |> @lib.async_read_string()
+          (18, _) => msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage) |> Some
+          (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+          (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+          (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+          (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
+          (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()) }
+          (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
+          (23, _) => msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
+          (24, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
+          (25, _) => msg.f_nested_enum = reader |> @lib.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum
+          (26, _) => { let {key, value} = (reader |> @lib.async_read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
+          (30, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
+          (31, _) => msg.f_repeated_baz_message.push((reader |> @lib.async_read_message() : BazMessage))
+          (32, _) => msg.f_optional_string = reader |> @lib.async_read_string() |> Some
+          (27, _) => msg.test_oneof = reader |> @lib.async_read_int32() |> FooMessage_TestOneof::F1
+          (28, _) => msg.test_oneof = reader |> @lib.async_read_bool() |> FooMessage_TestOneof::F2
+          (29, _) => msg.test_oneof = reader |> @lib.async_read_string() |> FooMessage_TestOneof::F3
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1052,12 +1076,16 @@ pub fn BazMessage_Nested_NestedMessage::new(f_nested : Int) -> BazMessage_Nested
 }
 pub impl @lib.Read for BazMessage_Nested_NestedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.f_nested = reader |> @lib.read_int32(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_nested = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for BazMessage_Nested_NestedMessage with fn write(self: BazMessage_Nested_NestedMessage, writer : &@lib.Writer) -> Unit raise {
@@ -1088,12 +1116,16 @@ pub impl @json.FromJson for BazMessage_Nested_NestedMessage with fn from_json(js
 }
 pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage_Nested_NestedMessage raise {
   let msg = BazMessage_Nested_NestedMessage::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.f_nested = reader |> @lib.async_read_int32(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for BazMessage_Nested_NestedMessage with fn write(self: BazMessage_Nested_NestedMessage, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1124,12 +1156,16 @@ pub fn BazMessage_Nested::new(f_nested? : BazMessage_Nested_NestedMessage) -> Ba
 }
 pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.Writer) -> Unit raise {
@@ -1162,12 +1198,16 @@ pub impl @json.FromJson for BazMessage_Nested with fn from_json(json: Json, path
 }
 pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage_Nested raise {
   let msg = BazMessage_Nested::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1211,14 +1251,18 @@ pub fn BazMessage::new(nested? : BazMessage_Nested, b_int64 : Int64, b_string : 
 }
 pub impl @lib.Read for BazMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> BazMessage raise {
   let msg = BazMessage::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some; true }
-      (2, _) => { msg.b_int64 = reader |> @lib.read_int64(); true }
-      (3, _) => { msg.b_string = reader |> @lib.read_string(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
+          (2, _) => msg.b_int64 = reader |> @lib.read_int64()
+          (3, _) => msg.b_string = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for BazMessage with fn write(self: BazMessage, writer : &@lib.Writer) -> Unit raise {
@@ -1267,14 +1311,18 @@ pub impl @json.FromJson for BazMessage with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> BazMessage raise {
   let msg = BazMessage::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some; true }
-      (2, _) => { msg.b_int64 = reader |> @lib.async_read_int64(); true }
-      (3, _) => { msg.b_string = reader |> @lib.async_read_string(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
+          (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
+          (3, _) => msg.b_string = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for BazMessage with fn write(self: BazMessage, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1314,12 +1362,16 @@ pub fn RepeatedMessage::new(bar_message : Array[BarMessage]) -> RepeatedMessage 
 }
 pub impl @lib.Read for RepeatedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.bar_message.push((reader |> @lib.read_message() : BarMessage)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for RepeatedMessage with fn write(self: RepeatedMessage, writer : &@lib.Writer) -> Unit raise {
@@ -1352,12 +1404,16 @@ pub impl @json.FromJson for RepeatedMessage with fn from_json(json: Json, path: 
 }
 pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> RepeatedMessage raise {
   let msg = RepeatedMessage::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for RepeatedMessage with fn write(self: RepeatedMessage, writer : &@lib.AsyncWriter) -> Unit raise {

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -26,15 +26,11 @@ pub fn Hello_MetadataEntry::new(key : String, value : String) -> Hello_MetadataE
 }
 pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.read_string()
-          (2, _) => msg.value = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.read_string()
+      (2, _) => msg.value = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -75,15 +71,11 @@ pub impl @json.FromJson for Hello_MetadataEntry with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.async_read_string()
-          (2, _) => msg.value = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.async_read_string()
+      (2, _) => msg.value = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -146,18 +138,14 @@ pub fn Hello::new(name : String, age : Int, hobbies : Array[String], metadata : 
 }
 pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello raise {
   let msg = Hello::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.age = reader |> @lib.read_int32()
-          (3, _) => msg.hobbies.push(reader |> @lib.read_string())
-          (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-          (5, _) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.age = reader |> @lib.read_int32()
+      (3, _) => msg.hobbies.push(reader |> @lib.read_string())
+      (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, _) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -237,18 +225,14 @@ pub impl @json.FromJson for Hello with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello raise {
   let msg = Hello::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) => msg.age = reader |> @lib.async_read_int32()
-          (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
-          (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-          (5, _) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.age = reader |> @lib.async_read_int32()
+      (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
+      (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, _) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -26,18 +26,13 @@ pub fn Hello_MetadataEntry::new(key : String, value : String) -> Hello_MetadataE
 }
 pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.key = reader |> @lib.read_string()
-      (2, _) => msg.value = reader |> @lib.read_string()
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.key = reader |> @lib.read_string(); true }
+      (2, _) => { msg.value = reader |> @lib.read_string(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.Writer) -> Unit raise {
@@ -76,18 +71,13 @@ pub impl @json.FromJson for Hello_MetadataEntry with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.key = reader |> @lib.async_read_string()
-      (2, _) => msg.value = reader |> @lib.async_read_string()
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.key = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.value = reader |> @lib.async_read_string(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -148,21 +138,16 @@ pub fn Hello::new(name : String, age : Int, hobbies : Array[String], metadata : 
 }
 pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello raise {
   let msg = Hello::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string()
-      (2, _) => msg.age = reader |> @lib.read_int32()
-      (3, _) => msg.hobbies.push(reader |> @lib.read_string())
-      (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, _) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string(); true }
+      (2, _) => { msg.age = reader |> @lib.read_int32(); true }
+      (3, _) => { msg.hobbies.push(reader |> @lib.read_string()); true }
+      (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value; true }
+      (5, _) => { msg.friend = (reader |> @lib.read_message() : Hello) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) -> Unit raise {
@@ -196,7 +181,7 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
   }
    if self.friend is Some(v) {
     writer |> @lib.write_varint(42UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -240,21 +225,16 @@ pub impl @json.FromJson for Hello with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello raise {
   let msg = Hello::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, _) => msg.age = reader |> @lib.async_read_int32()
-      (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
-      (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, _) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.age = reader |> @lib.async_read_int32(); true }
+      (3, _) => { msg.hobbies.push(reader |> @lib.async_read_string()); true }
+      (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value; true }
+      (5, _) => { msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -288,7 +268,7 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
   }
    if self.friend is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -26,13 +26,17 @@ pub fn Hello_MetadataEntry::new(key : String, value : String) -> Hello_MetadataE
 }
 pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.key = reader |> @lib.read_string(); true }
-      (2, _) => { msg.value = reader |> @lib.read_string(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.read_string()
+          (2, _) => msg.value = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.Writer) -> Unit raise {
@@ -71,13 +75,17 @@ pub impl @json.FromJson for Hello_MetadataEntry with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.key = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.value = reader |> @lib.async_read_string(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.async_read_string()
+          (2, _) => msg.value = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -138,16 +146,20 @@ pub fn Hello::new(name : String, age : Int, hobbies : Array[String], metadata : 
 }
 pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello raise {
   let msg = Hello::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string(); true }
-      (2, _) => { msg.age = reader |> @lib.read_int32(); true }
-      (3, _) => { msg.hobbies.push(reader |> @lib.read_string()); true }
-      (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value; true }
-      (5, _) => { msg.friend = (reader |> @lib.read_message() : Hello) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.age = reader |> @lib.read_int32()
+          (3, _) => msg.hobbies.push(reader |> @lib.read_string())
+          (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+          (5, _) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) -> Unit raise {
@@ -225,16 +237,20 @@ pub impl @json.FromJson for Hello with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello raise {
   let msg = Hello::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.age = reader |> @lib.async_read_int32(); true }
-      (3, _) => { msg.hobbies.push(reader |> @lib.async_read_string()); true }
-      (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value; true }
-      (5, _) => { msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) => msg.age = reader |> @lib.async_read_int32()
+          (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
+          (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+          (5, _) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.AsyncWriter) -> Unit raise {

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
@@ -20,12 +20,16 @@ pub fn Test::new(test_hello? : @lib1.Hello) -> Test {
 }
 pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
@@ -58,12 +62,16 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
@@ -20,23 +20,18 @@ pub fn Test::new(test_hello? : @lib1.Hello) -> Test {
 }
 pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   if self.test_hello is Some(v) {
     writer |> @lib.write_varint(10UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -63,23 +58,18 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.test_hello is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
@@ -20,14 +20,10 @@ pub fn Test::new(test_hello? : @lib1.Hello) -> Test {
 }
 pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -62,14 +58,10 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
@@ -20,12 +20,16 @@ pub fn Test::new(created_at? : @protobuf.Timestamp) -> Test {
 }
 pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
@@ -58,12 +62,16 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {

--- a/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
@@ -20,14 +20,10 @@ pub fn Test::new(created_at? : @protobuf.Timestamp) -> Test {
 }
 pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -62,14 +58,10 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
@@ -20,23 +20,18 @@ pub fn Test::new(created_at? : @protobuf.Timestamp) -> Test {
 }
 pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.write_varint(10UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -63,23 +58,18 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -26,15 +26,11 @@ pub fn Hello_MetadataEntry::new(key : String, value : String) -> Hello_MetadataE
 }
 pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.read_string()
-          (2, _) => msg.value = reader |> @lib.read_string()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.read_string()
+      (2, _) => msg.value = reader |> @lib.read_string()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -75,15 +71,11 @@ pub impl @json.FromJson for Hello_MetadataEntry with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.key = reader |> @lib.async_read_string()
-          (2, _) => msg.value = reader |> @lib.async_read_string()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.key = reader |> @lib.async_read_string()
+      (2, _) => msg.value = reader |> @lib.async_read_string()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -146,18 +138,14 @@ pub fn Hello::new(name : String, age : Int, hobbies : Array[String], metadata : 
 }
 pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello raise {
   let msg = Hello::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.age = reader |> @lib.read_int32()
-          (3, _) => msg.hobbies.push(reader |> @lib.read_string())
-          (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-          (5, _) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.age = reader |> @lib.read_int32()
+      (3, _) => msg.hobbies.push(reader |> @lib.read_string())
+      (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, _) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -237,18 +225,14 @@ pub impl @json.FromJson for Hello with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello raise {
   let msg = Hello::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) => msg.age = reader |> @lib.async_read_int32()
-          (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
-          (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-          (5, _) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.age = reader |> @lib.async_read_int32()
+      (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
+      (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, _) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -26,18 +26,13 @@ pub fn Hello_MetadataEntry::new(key : String, value : String) -> Hello_MetadataE
 }
 pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.key = reader |> @lib.read_string()
-      (2, _) => msg.value = reader |> @lib.read_string()
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.key = reader |> @lib.read_string(); true }
+      (2, _) => { msg.value = reader |> @lib.read_string(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.Writer) -> Unit raise {
@@ -76,18 +71,13 @@ pub impl @json.FromJson for Hello_MetadataEntry with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.key = reader |> @lib.async_read_string()
-      (2, _) => msg.value = reader |> @lib.async_read_string()
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.key = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.value = reader |> @lib.async_read_string(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -148,21 +138,16 @@ pub fn Hello::new(name : String, age : Int, hobbies : Array[String], metadata : 
 }
 pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello raise {
   let msg = Hello::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string()
-      (2, _) => msg.age = reader |> @lib.read_int32()
-      (3, _) => msg.hobbies.push(reader |> @lib.read_string())
-      (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, _) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string(); true }
+      (2, _) => { msg.age = reader |> @lib.read_int32(); true }
+      (3, _) => { msg.hobbies.push(reader |> @lib.read_string()); true }
+      (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value; true }
+      (5, _) => { msg.friend = (reader |> @lib.read_message() : Hello) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) -> Unit raise {
@@ -196,7 +181,7 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
   }
    if self.friend is Some(v) {
     writer |> @lib.write_varint(42UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -240,21 +225,16 @@ pub impl @json.FromJson for Hello with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello raise {
   let msg = Hello::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, _) => msg.age = reader |> @lib.async_read_int32()
-      (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
-      (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, _) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.age = reader |> @lib.async_read_int32(); true }
+      (3, _) => { msg.hobbies.push(reader |> @lib.async_read_string()); true }
+      (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value; true }
+      (5, _) => { msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -288,7 +268,7 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
   }
    if self.friend is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -26,13 +26,17 @@ pub fn Hello_MetadataEntry::new(key : String, value : String) -> Hello_MetadataE
 }
 pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.key = reader |> @lib.read_string(); true }
-      (2, _) => { msg.value = reader |> @lib.read_string(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.read_string()
+          (2, _) => msg.value = reader |> @lib.read_string()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.Writer) -> Unit raise {
@@ -71,13 +75,17 @@ pub impl @json.FromJson for Hello_MetadataEntry with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello_MetadataEntry raise {
   let msg = Hello_MetadataEntry::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.key = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.value = reader |> @lib.async_read_string(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.key = reader |> @lib.async_read_string()
+          (2, _) => msg.value = reader |> @lib.async_read_string()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Hello_MetadataEntry with fn write(self: Hello_MetadataEntry, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -138,16 +146,20 @@ pub fn Hello::new(name : String, age : Int, hobbies : Array[String], metadata : 
 }
 pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Hello raise {
   let msg = Hello::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string(); true }
-      (2, _) => { msg.age = reader |> @lib.read_int32(); true }
-      (3, _) => { msg.hobbies.push(reader |> @lib.read_string()); true }
-      (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value; true }
-      (5, _) => { msg.friend = (reader |> @lib.read_message() : Hello) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.age = reader |> @lib.read_int32()
+          (3, _) => msg.hobbies.push(reader |> @lib.read_string())
+          (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+          (5, _) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) -> Unit raise {
@@ -225,16 +237,20 @@ pub impl @json.FromJson for Hello with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Hello raise {
   let msg = Hello::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.age = reader |> @lib.async_read_int32(); true }
-      (3, _) => { msg.hobbies.push(reader |> @lib.async_read_string()); true }
-      (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value; true }
-      (5, _) => { msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) => msg.age = reader |> @lib.async_read_int32()
+          (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
+          (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+          (5, _) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.AsyncWriter) -> Unit raise {

--- a/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
@@ -20,14 +20,10 @@ pub fn Test::new(created_at? : @test2.Hello) -> Test {
 }
 pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.created_at = (reader |> @lib.read_message() : @test2.Hello) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.created_at = (reader |> @lib.read_message() : @test2.Hello) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -62,14 +58,10 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
@@ -20,12 +20,16 @@ pub fn Test::new(created_at? : @test2.Hello) -> Test {
 }
 pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.created_at = (reader |> @lib.read_message() : @test2.Hello) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.created_at = (reader |> @lib.read_message() : @test2.Hello) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
@@ -58,12 +62,16 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {

--- a/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
@@ -20,23 +20,18 @@ pub fn Test::new(created_at? : @test2.Hello) -> Test {
 }
 pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Test raise {
   let msg = Test::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.created_at = (reader |> @lib.read_message() : @test2.Hello) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.created_at = (reader |> @lib.read_message() : @test2.Hello) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.write_varint(10UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -63,23 +58,18 @@ pub impl @json.FromJson for Test with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Test raise {
   let msg = Test::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }

--- a/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
+++ b/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
@@ -38,17 +38,13 @@ pub fn Version::new(major? : Int, minor? : Int, patch? : Int, suffix? : String) 
 }
 pub impl @lib.Read for Version with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Version raise {
   let msg = Version::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.major = reader |> @lib.read_int32() |> Some
-          (2, _) => msg.minor = reader |> @lib.read_int32() |> Some
-          (3, _) => msg.patch = reader |> @lib.read_int32() |> Some
-          (4, _) => msg.suffix = reader |> @lib.read_string() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.major = reader |> @lib.read_int32() |> Some
+      (2, _) => msg.minor = reader |> @lib.read_int32() |> Some
+      (3, _) => msg.patch = reader |> @lib.read_int32() |> Some
+      (4, _) => msg.suffix = reader |> @lib.read_string() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -113,17 +109,13 @@ pub impl @json.FromJson for Version with fn from_json(json: Json, path: @json.Js
 }
 pub impl @lib.AsyncRead for Version with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Version raise {
   let msg = Version::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.major = reader |> @lib.async_read_int32() |> Some
-          (2, _) => msg.minor = reader |> @lib.async_read_int32() |> Some
-          (3, _) => msg.patch = reader |> @lib.async_read_int32() |> Some
-          (4, _) => msg.suffix = reader |> @lib.async_read_string() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.major = reader |> @lib.async_read_int32() |> Some
+      (2, _) => msg.minor = reader |> @lib.async_read_int32() |> Some
+      (3, _) => msg.patch = reader |> @lib.async_read_int32() |> Some
+      (4, _) => msg.suffix = reader |> @lib.async_read_string() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -196,18 +188,14 @@ pub fn CodeGeneratorRequest::new(file_to_generate : Array[String], parameter? : 
 }
 pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
-          (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
-          (15, _) => msg.proto_file.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
-          (17, _) => msg.source_file_descriptors.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
-          (3, _) => msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
+      (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
+      (15, _) => msg.proto_file.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
+      (17, _) => msg.source_file_descriptors.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
+      (3, _) => msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -282,18 +270,14 @@ pub impl @json.FromJson for CodeGeneratorRequest with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.file_to_generate.push(reader |> @lib.async_read_string())
-          (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
-          (15, _) => msg.proto_file.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
-          (17, _) => msg.source_file_descriptors.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
-          (3, _) => msg.compiler_version = (reader |> @lib.async_read_message() : Version) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.file_to_generate.push(reader |> @lib.async_read_string())
+      (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
+      (15, _) => msg.proto_file.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
+      (17, _) => msg.source_file_descriptors.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
+      (3, _) => msg.compiler_version = (reader |> @lib.async_read_message() : Version) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -409,17 +393,13 @@ pub fn CodeGeneratorResponse_File::new(name? : String, insertion_point? : String
 }
 pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
-          (15, _) => msg.content = reader |> @lib.read_string() |> Some
-          (16, _) => msg.generated_code_info = (reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
+      (15, _) => msg.content = reader |> @lib.read_string() |> Some
+      (16, _) => msg.generated_code_info = (reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -484,17 +464,13 @@ pub impl @json.FromJson for CodeGeneratorResponse_File with fn from_json(json: J
 }
 pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.insertion_point = reader |> @lib.async_read_string() |> Some
-          (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
-          (16, _) => msg.generated_code_info = (reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.insertion_point = reader |> @lib.async_read_string() |> Some
+      (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
+      (16, _) => msg.generated_code_info = (reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -567,18 +543,14 @@ pub fn CodeGeneratorResponse::new(error? : String, supported_features? : UInt64,
 }
 pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.error = reader |> @lib.read_string() |> Some
-          (2, _) => msg.supported_features = reader |> @lib.read_uint64() |> Some
-          (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
-          (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
-          (15, _) => msg.file.push((reader |> @lib.read_message() : CodeGeneratorResponse_File))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.error = reader |> @lib.read_string() |> Some
+      (2, _) => msg.supported_features = reader |> @lib.read_uint64() |> Some
+      (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
+      (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
+      (15, _) => msg.file.push((reader |> @lib.read_message() : CodeGeneratorResponse_File))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -653,18 +625,14 @@ pub impl @json.FromJson for CodeGeneratorResponse with fn from_json(json: Json, 
 }
 pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.error = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.supported_features = reader |> @lib.async_read_uint64() |> Some
-          (3, _) => msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
-          (4, _) => msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
-          (15, _) => msg.file.push((reader |> @lib.async_read_message() : CodeGeneratorResponse_File))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.error = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.supported_features = reader |> @lib.async_read_uint64() |> Some
+      (3, _) => msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
+      (4, _) => msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
+      (15, _) => msg.file.push((reader |> @lib.async_read_message() : CodeGeneratorResponse_File))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
+++ b/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
@@ -38,15 +38,19 @@ pub fn Version::new(major? : Int, minor? : Int, patch? : Int, suffix? : String) 
 }
 pub impl @lib.Read for Version with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Version raise {
   let msg = Version::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.major = reader |> @lib.read_int32() |> Some; true }
-      (2, _) => { msg.minor = reader |> @lib.read_int32() |> Some; true }
-      (3, _) => { msg.patch = reader |> @lib.read_int32() |> Some; true }
-      (4, _) => { msg.suffix = reader |> @lib.read_string() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.major = reader |> @lib.read_int32() |> Some
+          (2, _) => msg.minor = reader |> @lib.read_int32() |> Some
+          (3, _) => msg.patch = reader |> @lib.read_int32() |> Some
+          (4, _) => msg.suffix = reader |> @lib.read_string() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Version with fn write(self: Version, writer : &@lib.Writer) -> Unit raise {
@@ -109,15 +113,19 @@ pub impl @json.FromJson for Version with fn from_json(json: Json, path: @json.Js
 }
 pub impl @lib.AsyncRead for Version with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Version raise {
   let msg = Version::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.major = reader |> @lib.async_read_int32() |> Some; true }
-      (2, _) => { msg.minor = reader |> @lib.async_read_int32() |> Some; true }
-      (3, _) => { msg.patch = reader |> @lib.async_read_int32() |> Some; true }
-      (4, _) => { msg.suffix = reader |> @lib.async_read_string() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.major = reader |> @lib.async_read_int32() |> Some
+          (2, _) => msg.minor = reader |> @lib.async_read_int32() |> Some
+          (3, _) => msg.patch = reader |> @lib.async_read_int32() |> Some
+          (4, _) => msg.suffix = reader |> @lib.async_read_string() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Version with fn write(self: Version, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -188,16 +196,20 @@ pub fn CodeGeneratorRequest::new(file_to_generate : Array[String], parameter? : 
 }
 pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.file_to_generate.push(reader |> @lib.read_string()); true }
-      (2, _) => { msg.parameter = reader |> @lib.read_string() |> Some; true }
-      (15, _) => { msg.proto_file.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto)); true }
-      (17, _) => { msg.source_file_descriptors.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto)); true }
-      (3, _) => { msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
+          (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
+          (15, _) => msg.proto_file.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
+          (17, _) => msg.source_file_descriptors.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
+          (3, _) => msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for CodeGeneratorRequest with fn write(self: CodeGeneratorRequest, writer : &@lib.Writer) -> Unit raise {
@@ -270,16 +282,20 @@ pub impl @json.FromJson for CodeGeneratorRequest with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.file_to_generate.push(reader |> @lib.async_read_string()); true }
-      (2, _) => { msg.parameter = reader |> @lib.async_read_string() |> Some; true }
-      (15, _) => { msg.proto_file.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto)); true }
-      (17, _) => { msg.source_file_descriptors.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto)); true }
-      (3, _) => { msg.compiler_version = (reader |> @lib.async_read_message() : Version) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.file_to_generate.push(reader |> @lib.async_read_string())
+          (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
+          (15, _) => msg.proto_file.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
+          (17, _) => msg.source_file_descriptors.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
+          (3, _) => msg.compiler_version = (reader |> @lib.async_read_message() : Version) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for CodeGeneratorRequest with fn write(self: CodeGeneratorRequest, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -393,15 +409,19 @@ pub fn CodeGeneratorResponse_File::new(name? : String, insertion_point? : String
 }
 pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
-      (2, _) => { msg.insertion_point = reader |> @lib.read_string() |> Some; true }
-      (15, _) => { msg.content = reader |> @lib.read_string() |> Some; true }
-      (16, _) => { msg.generated_code_info = (reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
+          (15, _) => msg.content = reader |> @lib.read_string() |> Some
+          (16, _) => msg.generated_code_info = (reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for CodeGeneratorResponse_File with fn write(self: CodeGeneratorResponse_File, writer : &@lib.Writer) -> Unit raise {
@@ -464,15 +484,19 @@ pub impl @json.FromJson for CodeGeneratorResponse_File with fn from_json(json: J
 }
 pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
-      (2, _) => { msg.insertion_point = reader |> @lib.async_read_string() |> Some; true }
-      (15, _) => { msg.content = reader |> @lib.async_read_string() |> Some; true }
-      (16, _) => { msg.generated_code_info = (reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.insertion_point = reader |> @lib.async_read_string() |> Some
+          (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
+          (16, _) => msg.generated_code_info = (reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for CodeGeneratorResponse_File with fn write(self: CodeGeneratorResponse_File, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -543,16 +567,20 @@ pub fn CodeGeneratorResponse::new(error? : String, supported_features? : UInt64,
 }
 pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.error = reader |> @lib.read_string() |> Some; true }
-      (2, _) => { msg.supported_features = reader |> @lib.read_uint64() |> Some; true }
-      (3, _) => { msg.minimum_edition = reader |> @lib.read_int32() |> Some; true }
-      (4, _) => { msg.maximum_edition = reader |> @lib.read_int32() |> Some; true }
-      (15, _) => { msg.file.push((reader |> @lib.read_message() : CodeGeneratorResponse_File)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.error = reader |> @lib.read_string() |> Some
+          (2, _) => msg.supported_features = reader |> @lib.read_uint64() |> Some
+          (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
+          (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
+          (15, _) => msg.file.push((reader |> @lib.read_message() : CodeGeneratorResponse_File))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for CodeGeneratorResponse with fn write(self: CodeGeneratorResponse, writer : &@lib.Writer) -> Unit raise {
@@ -625,16 +653,20 @@ pub impl @json.FromJson for CodeGeneratorResponse with fn from_json(json: Json, 
 }
 pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.error = reader |> @lib.async_read_string() |> Some; true }
-      (2, _) => { msg.supported_features = reader |> @lib.async_read_uint64() |> Some; true }
-      (3, _) => { msg.minimum_edition = reader |> @lib.async_read_int32() |> Some; true }
-      (4, _) => { msg.maximum_edition = reader |> @lib.async_read_int32() |> Some; true }
-      (15, _) => { msg.file.push((reader |> @lib.async_read_message() : CodeGeneratorResponse_File)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.error = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.supported_features = reader |> @lib.async_read_uint64() |> Some
+          (3, _) => msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
+          (4, _) => msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
+          (15, _) => msg.file.push((reader |> @lib.async_read_message() : CodeGeneratorResponse_File))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for CodeGeneratorResponse with fn write(self: CodeGeneratorResponse, writer : &@lib.AsyncWriter) -> Unit raise {

--- a/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
+++ b/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
@@ -38,20 +38,15 @@ pub fn Version::new(major? : Int, minor? : Int, patch? : Int, suffix? : String) 
 }
 pub impl @lib.Read for Version with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Version raise {
   let msg = Version::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.major = reader |> @lib.read_int32() |> Some
-      (2, _) => msg.minor = reader |> @lib.read_int32() |> Some
-      (3, _) => msg.patch = reader |> @lib.read_int32() |> Some
-      (4, _) => msg.suffix = reader |> @lib.read_string() |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.major = reader |> @lib.read_int32() |> Some; true }
+      (2, _) => { msg.minor = reader |> @lib.read_int32() |> Some; true }
+      (3, _) => { msg.patch = reader |> @lib.read_int32() |> Some; true }
+      (4, _) => { msg.suffix = reader |> @lib.read_string() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Version with fn write(self: Version, writer : &@lib.Writer) -> Unit raise {
@@ -114,20 +109,15 @@ pub impl @json.FromJson for Version with fn from_json(json: Json, path: @json.Js
 }
 pub impl @lib.AsyncRead for Version with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Version raise {
   let msg = Version::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.major = reader |> @lib.async_read_int32() |> Some
-      (2, _) => msg.minor = reader |> @lib.async_read_int32() |> Some
-      (3, _) => msg.patch = reader |> @lib.async_read_int32() |> Some
-      (4, _) => msg.suffix = reader |> @lib.async_read_string() |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.major = reader |> @lib.async_read_int32() |> Some; true }
+      (2, _) => { msg.minor = reader |> @lib.async_read_int32() |> Some; true }
+      (3, _) => { msg.patch = reader |> @lib.async_read_int32() |> Some; true }
+      (4, _) => { msg.suffix = reader |> @lib.async_read_string() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Version with fn write(self: Version, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -198,21 +188,16 @@ pub fn CodeGeneratorRequest::new(file_to_generate : Array[String], parameter? : 
 }
 pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
-      (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
-      (15, _) => msg.proto_file.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
-      (17, _) => msg.source_file_descriptors.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
-      (3, _) => msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.file_to_generate.push(reader |> @lib.read_string()); true }
+      (2, _) => { msg.parameter = reader |> @lib.read_string() |> Some; true }
+      (15, _) => { msg.proto_file.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto)); true }
+      (17, _) => { msg.source_file_descriptors.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto)); true }
+      (3, _) => { msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for CodeGeneratorRequest with fn write(self: CodeGeneratorRequest, writer : &@lib.Writer) -> Unit raise {
@@ -228,17 +213,17 @@ pub impl @lib.Write for CodeGeneratorRequest with fn write(self: CodeGeneratorRe
   }
   for item in self.proto_file {
     writer |> @lib.write_varint(122UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.source_file_descriptors {
     writer |> @lib.write_varint(138UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.compiler_version is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -285,21 +270,16 @@ pub impl @json.FromJson for CodeGeneratorRequest with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorRequest raise {
   let msg = CodeGeneratorRequest::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.file_to_generate.push(reader |> @lib.async_read_string())
-      (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
-      (15, _) => msg.proto_file.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
-      (17, _) => msg.source_file_descriptors.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
-      (3, _) => msg.compiler_version = (reader |> @lib.async_read_message() : Version) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.file_to_generate.push(reader |> @lib.async_read_string()); true }
+      (2, _) => { msg.parameter = reader |> @lib.async_read_string() |> Some; true }
+      (15, _) => { msg.proto_file.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto)); true }
+      (17, _) => { msg.source_file_descriptors.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto)); true }
+      (3, _) => { msg.compiler_version = (reader |> @lib.async_read_message() : Version) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for CodeGeneratorRequest with fn write(self: CodeGeneratorRequest, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -315,17 +295,17 @@ pub impl @lib.AsyncWrite for CodeGeneratorRequest with fn write(self: CodeGenera
   }
   for item in self.proto_file {
     writer |> @lib.async_write_varint(122UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.source_file_descriptors {
     writer |> @lib.async_write_varint(138UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.compiler_version is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -413,20 +393,15 @@ pub fn CodeGeneratorResponse_File::new(name? : String, insertion_point? : String
 }
 pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
-      (15, _) => msg.content = reader |> @lib.read_string() |> Some
-      (16, _) => msg.generated_code_info = (reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
+      (2, _) => { msg.insertion_point = reader |> @lib.read_string() |> Some; true }
+      (15, _) => { msg.content = reader |> @lib.read_string() |> Some; true }
+      (16, _) => { msg.generated_code_info = (reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for CodeGeneratorResponse_File with fn write(self: CodeGeneratorResponse_File, writer : &@lib.Writer) -> Unit raise {
@@ -447,7 +422,7 @@ pub impl @lib.Write for CodeGeneratorResponse_File with fn write(self: CodeGener
   }
   if self.generated_code_info is Some(v) {
     writer |> @lib.write_varint(130UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -489,20 +464,15 @@ pub impl @json.FromJson for CodeGeneratorResponse_File with fn from_json(json: J
 }
 pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorResponse_File raise {
   let msg = CodeGeneratorResponse_File::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.insertion_point = reader |> @lib.async_read_string() |> Some
-      (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
-      (16, _) => msg.generated_code_info = (reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
+      (2, _) => { msg.insertion_point = reader |> @lib.async_read_string() |> Some; true }
+      (15, _) => { msg.content = reader |> @lib.async_read_string() |> Some; true }
+      (16, _) => { msg.generated_code_info = (reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for CodeGeneratorResponse_File with fn write(self: CodeGeneratorResponse_File, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -523,7 +493,7 @@ pub impl @lib.AsyncWrite for CodeGeneratorResponse_File with fn write(self: Code
   }
   if self.generated_code_info is Some(v) {
     writer |> @lib.async_write_varint(130UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -573,21 +543,16 @@ pub fn CodeGeneratorResponse::new(error? : String, supported_features? : UInt64,
 }
 pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.error = reader |> @lib.read_string() |> Some
-      (2, _) => msg.supported_features = reader |> @lib.read_uint64() |> Some
-      (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
-      (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
-      (15, _) => msg.file.push((reader |> @lib.read_message() : CodeGeneratorResponse_File))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.error = reader |> @lib.read_string() |> Some; true }
+      (2, _) => { msg.supported_features = reader |> @lib.read_uint64() |> Some; true }
+      (3, _) => { msg.minimum_edition = reader |> @lib.read_int32() |> Some; true }
+      (4, _) => { msg.maximum_edition = reader |> @lib.read_int32() |> Some; true }
+      (15, _) => { msg.file.push((reader |> @lib.read_message() : CodeGeneratorResponse_File)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for CodeGeneratorResponse with fn write(self: CodeGeneratorResponse, writer : &@lib.Writer) -> Unit raise {
@@ -613,7 +578,7 @@ pub impl @lib.Write for CodeGeneratorResponse with fn write(self: CodeGeneratorR
   }
   for item in self.file {
     writer |> @lib.write_varint(122UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -660,21 +625,16 @@ pub impl @json.FromJson for CodeGeneratorResponse with fn from_json(json: Json, 
 }
 pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> CodeGeneratorResponse raise {
   let msg = CodeGeneratorResponse::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.error = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.supported_features = reader |> @lib.async_read_uint64() |> Some
-      (3, _) => msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
-      (4, _) => msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
-      (15, _) => msg.file.push((reader |> @lib.async_read_message() : CodeGeneratorResponse_File))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.error = reader |> @lib.async_read_string() |> Some; true }
+      (2, _) => { msg.supported_features = reader |> @lib.async_read_uint64() |> Some; true }
+      (3, _) => { msg.minimum_edition = reader |> @lib.async_read_int32() |> Some; true }
+      (4, _) => { msg.maximum_edition = reader |> @lib.async_read_int32() |> Some; true }
+      (15, _) => { msg.file.push((reader |> @lib.async_read_message() : CodeGeneratorResponse_File)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for CodeGeneratorResponse with fn write(self: CodeGeneratorResponse, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -700,7 +660,7 @@ pub impl @lib.AsyncWrite for CodeGeneratorResponse with fn write(self: CodeGener
   }
   for item in self.file {
     writer |> @lib.async_write_varint(122UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }

--- a/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
@@ -26,13 +26,17 @@ pub fn Timestamp::new(seconds : Int64, nanos : Int) -> Timestamp {
 }
 pub impl @lib.Read for Timestamp with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Timestamp raise {
   let msg = Timestamp::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.seconds = reader |> @lib.read_int64(); true }
-      (2, _) => { msg.nanos = reader |> @lib.read_int32(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.seconds = reader |> @lib.read_int64()
+          (2, _) => msg.nanos = reader |> @lib.read_int32()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Timestamp with fn write(self: Timestamp, writer : &@lib.Writer) -> Unit raise {
@@ -47,13 +51,17 @@ pub impl @lib.Write for Timestamp with fn write(self: Timestamp, writer : &@lib.
 }
 pub impl @lib.AsyncRead for Timestamp with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Timestamp raise {
   let msg = Timestamp::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.seconds = reader |> @lib.async_read_int64(); true }
-      (2, _) => { msg.nanos = reader |> @lib.async_read_int32(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.seconds = reader |> @lib.async_read_int64()
+          (2, _) => msg.nanos = reader |> @lib.async_read_int32()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Timestamp with fn write(self: Timestamp, writer : &@lib.AsyncWriter) -> Unit raise {

--- a/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
@@ -26,15 +26,11 @@ pub fn Timestamp::new(seconds : Int64, nanos : Int) -> Timestamp {
 }
 pub impl @lib.Read for Timestamp with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Timestamp raise {
   let msg = Timestamp::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.seconds = reader |> @lib.read_int64()
-          (2, _) => msg.nanos = reader |> @lib.read_int32()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.seconds = reader |> @lib.read_int64()
+      (2, _) => msg.nanos = reader |> @lib.read_int32()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -51,15 +47,11 @@ pub impl @lib.Write for Timestamp with fn write(self: Timestamp, writer : &@lib.
 }
 pub impl @lib.AsyncRead for Timestamp with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Timestamp raise {
   let msg = Timestamp::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.seconds = reader |> @lib.async_read_int64()
-          (2, _) => msg.nanos = reader |> @lib.async_read_int32()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.seconds = reader |> @lib.async_read_int64()
+      (2, _) => msg.nanos = reader |> @lib.async_read_int32()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
@@ -26,18 +26,13 @@ pub fn Timestamp::new(seconds : Int64, nanos : Int) -> Timestamp {
 }
 pub impl @lib.Read for Timestamp with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Timestamp raise {
   let msg = Timestamp::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.seconds = reader |> @lib.read_int64()
-      (2, _) => msg.nanos = reader |> @lib.read_int32()
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.seconds = reader |> @lib.read_int64(); true }
+      (2, _) => { msg.nanos = reader |> @lib.read_int32(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Timestamp with fn write(self: Timestamp, writer : &@lib.Writer) -> Unit raise {
@@ -52,18 +47,13 @@ pub impl @lib.Write for Timestamp with fn write(self: Timestamp, writer : &@lib.
 }
 pub impl @lib.AsyncRead for Timestamp with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Timestamp raise {
   let msg = Timestamp::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.seconds = reader |> @lib.async_read_int64()
-      (2, _) => msg.nanos = reader |> @lib.async_read_int32()
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.seconds = reader |> @lib.async_read_int64(); true }
+      (2, _) => { msg.nanos = reader |> @lib.async_read_int32(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Timestamp with fn write(self: Timestamp, writer : &@lib.AsyncWriter) -> Unit raise {

--- a/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
+++ b/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
@@ -42,18 +42,14 @@ pub fn TreeNode::new(name : String, value? : Int, parent? : TreeNode, children :
 }
 pub impl @lib.Read for TreeNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> TreeNode raise {
   let msg = TreeNode::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.value = reader |> @lib.read_int32() |> Some
-          (3, _) => msg.parent = (reader |> @lib.read_message() : TreeNode) |> Some
-          (4, _) => msg.children.push((reader |> @lib.read_message() : TreeNode))
-          (5, _) => msg.sibling = (reader |> @lib.read_message() : TreeNode) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.value = reader |> @lib.read_int32() |> Some
+      (3, _) => msg.parent = (reader |> @lib.read_message() : TreeNode) |> Some
+      (4, _) => msg.children.push((reader |> @lib.read_message() : TreeNode))
+      (5, _) => msg.sibling = (reader |> @lib.read_message() : TreeNode) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -124,18 +120,14 @@ pub impl @json.FromJson for TreeNode with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for TreeNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> TreeNode raise {
   let msg = TreeNode::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) => msg.value = reader |> @lib.async_read_int32() |> Some
-          (3, _) => msg.parent = (reader |> @lib.async_read_message() : TreeNode) |> Some
-          (4, _) => msg.children.push((reader |> @lib.async_read_message() : TreeNode))
-          (5, _) => msg.sibling = (reader |> @lib.async_read_message() : TreeNode) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.value = reader |> @lib.async_read_int32() |> Some
+      (3, _) => msg.parent = (reader |> @lib.async_read_message() : TreeNode) |> Some
+      (4, _) => msg.children.push((reader |> @lib.async_read_message() : TreeNode))
+      (5, _) => msg.sibling = (reader |> @lib.async_read_message() : TreeNode) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -196,16 +188,12 @@ pub fn ListNode::new(data : String, next? : ListNode, prev? : ListNode) -> ListN
 }
 pub impl @lib.Read for ListNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ListNode raise {
   let msg = ListNode::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.data = reader |> @lib.read_string()
-          (2, _) => msg.next = (reader |> @lib.read_message() : ListNode) |> Some
-          (3, _) => msg.prev = (reader |> @lib.read_message() : ListNode) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.data = reader |> @lib.read_string()
+      (2, _) => msg.next = (reader |> @lib.read_message() : ListNode) |> Some
+      (3, _) => msg.prev = (reader |> @lib.read_message() : ListNode) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -256,16 +244,12 @@ pub impl @json.FromJson for ListNode with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for ListNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ListNode raise {
   let msg = ListNode::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.data = reader |> @lib.async_read_string()
-          (2, _) => msg.next = (reader |> @lib.async_read_message() : ListNode) |> Some
-          (3, _) => msg.prev = (reader |> @lib.async_read_message() : ListNode) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.data = reader |> @lib.async_read_string()
+      (2, _) => msg.next = (reader |> @lib.async_read_message() : ListNode) |> Some
+      (3, _) => msg.prev = (reader |> @lib.async_read_message() : ListNode) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -322,17 +306,13 @@ pub fn GraphNode::new(id : String, label? : String, neighbors : Array[GraphNode]
 }
 pub impl @lib.Read for GraphNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GraphNode raise {
   let msg = GraphNode::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.id = reader |> @lib.read_string()
-          (2, _) => msg.label = reader |> @lib.read_string() |> Some
-          (3, _) => msg.neighbors.push((reader |> @lib.read_message() : GraphNode))
-          (4, _) => msg.visited = reader |> @lib.read_bool() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.id = reader |> @lib.read_string()
+      (2, _) => msg.label = reader |> @lib.read_string() |> Some
+      (3, _) => msg.neighbors.push((reader |> @lib.read_message() : GraphNode))
+      (4, _) => msg.visited = reader |> @lib.read_bool() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -393,17 +373,13 @@ pub impl @json.FromJson for GraphNode with fn from_json(json: Json, path: @json.
 }
 pub impl @lib.AsyncRead for GraphNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GraphNode raise {
   let msg = GraphNode::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.id = reader |> @lib.async_read_string()
-          (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.neighbors.push((reader |> @lib.async_read_message() : GraphNode))
-          (4, _) => msg.visited = reader |> @lib.async_read_bool() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.id = reader |> @lib.async_read_string()
+      (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.neighbors.push((reader |> @lib.async_read_message() : GraphNode))
+      (4, _) => msg.visited = reader |> @lib.async_read_bool() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -461,16 +437,12 @@ pub fn NestedSelfRef_Inner::new(inner_name? : String, outer_ref? : NestedSelfRef
 }
 pub impl @lib.Read for NestedSelfRef_Inner with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> NestedSelfRef_Inner raise {
   let msg = NestedSelfRef_Inner::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.inner_name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.outer_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
-          (3, _) => msg.inner_ref = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.inner_name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.outer_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
+      (3, _) => msg.inner_ref = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -525,16 +497,12 @@ pub impl @json.FromJson for NestedSelfRef_Inner with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for NestedSelfRef_Inner with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> NestedSelfRef_Inner raise {
   let msg = NestedSelfRef_Inner::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.inner_name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.outer_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
-          (3, _) => msg.inner_ref = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.inner_name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.outer_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
+      (3, _) => msg.inner_ref = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -588,16 +556,12 @@ pub fn NestedSelfRef::new(name : String, inner? : NestedSelfRef_Inner, self_ref?
 }
 pub impl @lib.Read for NestedSelfRef with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> NestedSelfRef raise {
   let msg = NestedSelfRef::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.inner = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
-          (3, _) => msg.self_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.inner = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
+      (3, _) => msg.self_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -648,16 +612,12 @@ pub impl @json.FromJson for NestedSelfRef with fn from_json(json: Json, path: @j
 }
 pub impl @lib.AsyncRead for NestedSelfRef with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> NestedSelfRef raise {
   let msg = NestedSelfRef::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) => msg.inner = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
-          (3, _) => msg.self_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.inner = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
+      (3, _) => msg.self_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -720,18 +680,14 @@ pub fn Organization::new(name : String, description? : String, parent_org? : Org
 }
 pub impl @lib.Read for Organization with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Organization raise {
   let msg = Organization::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.description = reader |> @lib.read_string() |> Some
-          (3, _) => msg.parent_org = (reader |> @lib.read_message() : Organization) |> Some
-          (4, _) => msg.sub_orgs.push((reader |> @lib.read_message() : Organization))
-          (5, _) => msg.employees.push((reader |> @lib.read_message() : Employee))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.description = reader |> @lib.read_string() |> Some
+      (3, _) => msg.parent_org = (reader |> @lib.read_message() : Organization) |> Some
+      (4, _) => msg.sub_orgs.push((reader |> @lib.read_message() : Organization))
+      (5, _) => msg.employees.push((reader |> @lib.read_message() : Employee))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -802,18 +758,14 @@ pub impl @json.FromJson for Organization with fn from_json(json: Json, path: @js
 }
 pub impl @lib.AsyncRead for Organization with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Organization raise {
   let msg = Organization::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) => msg.description = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.parent_org = (reader |> @lib.async_read_message() : Organization) |> Some
-          (4, _) => msg.sub_orgs.push((reader |> @lib.async_read_message() : Organization))
-          (5, _) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.description = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.parent_org = (reader |> @lib.async_read_message() : Organization) |> Some
+      (4, _) => msg.sub_orgs.push((reader |> @lib.async_read_message() : Organization))
+      (5, _) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -884,18 +836,14 @@ pub fn Employee::new(name : String, id : String, organization? : Organization, m
 }
 pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Employee raise {
   let msg = Employee::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string()
-          (2, _) => msg.id = reader |> @lib.read_string()
-          (3, _) => msg.organization = (reader |> @lib.read_message() : Organization) |> Some
-          (4, _) => msg.manager = (reader |> @lib.read_message() : Employee) |> Some
-          (5, _) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string()
+      (2, _) => msg.id = reader |> @lib.read_string()
+      (3, _) => msg.organization = (reader |> @lib.read_message() : Organization) |> Some
+      (4, _) => msg.manager = (reader |> @lib.read_message() : Employee) |> Some
+      (5, _) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -962,18 +910,14 @@ pub impl @json.FromJson for Employee with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Employee raise {
   let msg = Employee::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string()
-          (2, _) => msg.id = reader |> @lib.async_read_string()
-          (3, _) => msg.organization = (reader |> @lib.async_read_message() : Organization) |> Some
-          (4, _) => msg.manager = (reader |> @lib.async_read_message() : Employee) |> Some
-          (5, _) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string()
+      (2, _) => msg.id = reader |> @lib.async_read_string()
+      (3, _) => msg.organization = (reader |> @lib.async_read_message() : Organization) |> Some
+      (4, _) => msg.manager = (reader |> @lib.async_read_message() : Employee) |> Some
+      (5, _) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
+++ b/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
@@ -42,16 +42,20 @@ pub fn TreeNode::new(name : String, value? : Int, parent? : TreeNode, children :
 }
 pub impl @lib.Read for TreeNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> TreeNode raise {
   let msg = TreeNode::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string(); true }
-      (2, _) => { msg.value = reader |> @lib.read_int32() |> Some; true }
-      (3, _) => { msg.parent = (reader |> @lib.read_message() : TreeNode) |> Some; true }
-      (4, _) => { msg.children.push((reader |> @lib.read_message() : TreeNode)); true }
-      (5, _) => { msg.sibling = (reader |> @lib.read_message() : TreeNode) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.value = reader |> @lib.read_int32() |> Some
+          (3, _) => msg.parent = (reader |> @lib.read_message() : TreeNode) |> Some
+          (4, _) => msg.children.push((reader |> @lib.read_message() : TreeNode))
+          (5, _) => msg.sibling = (reader |> @lib.read_message() : TreeNode) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for TreeNode with fn write(self: TreeNode, writer : &@lib.Writer) -> Unit raise {
@@ -120,16 +124,20 @@ pub impl @json.FromJson for TreeNode with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for TreeNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> TreeNode raise {
   let msg = TreeNode::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.value = reader |> @lib.async_read_int32() |> Some; true }
-      (3, _) => { msg.parent = (reader |> @lib.async_read_message() : TreeNode) |> Some; true }
-      (4, _) => { msg.children.push((reader |> @lib.async_read_message() : TreeNode)); true }
-      (5, _) => { msg.sibling = (reader |> @lib.async_read_message() : TreeNode) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) => msg.value = reader |> @lib.async_read_int32() |> Some
+          (3, _) => msg.parent = (reader |> @lib.async_read_message() : TreeNode) |> Some
+          (4, _) => msg.children.push((reader |> @lib.async_read_message() : TreeNode))
+          (5, _) => msg.sibling = (reader |> @lib.async_read_message() : TreeNode) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for TreeNode with fn write(self: TreeNode, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -188,14 +196,18 @@ pub fn ListNode::new(data : String, next? : ListNode, prev? : ListNode) -> ListN
 }
 pub impl @lib.Read for ListNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ListNode raise {
   let msg = ListNode::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.data = reader |> @lib.read_string(); true }
-      (2, _) => { msg.next = (reader |> @lib.read_message() : ListNode) |> Some; true }
-      (3, _) => { msg.prev = (reader |> @lib.read_message() : ListNode) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.data = reader |> @lib.read_string()
+          (2, _) => msg.next = (reader |> @lib.read_message() : ListNode) |> Some
+          (3, _) => msg.prev = (reader |> @lib.read_message() : ListNode) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for ListNode with fn write(self: ListNode, writer : &@lib.Writer) -> Unit raise {
@@ -244,14 +256,18 @@ pub impl @json.FromJson for ListNode with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for ListNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ListNode raise {
   let msg = ListNode::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.data = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.next = (reader |> @lib.async_read_message() : ListNode) |> Some; true }
-      (3, _) => { msg.prev = (reader |> @lib.async_read_message() : ListNode) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.data = reader |> @lib.async_read_string()
+          (2, _) => msg.next = (reader |> @lib.async_read_message() : ListNode) |> Some
+          (3, _) => msg.prev = (reader |> @lib.async_read_message() : ListNode) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for ListNode with fn write(self: ListNode, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -306,15 +322,19 @@ pub fn GraphNode::new(id : String, label? : String, neighbors : Array[GraphNode]
 }
 pub impl @lib.Read for GraphNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GraphNode raise {
   let msg = GraphNode::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.id = reader |> @lib.read_string(); true }
-      (2, _) => { msg.label = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.neighbors.push((reader |> @lib.read_message() : GraphNode)); true }
-      (4, _) => { msg.visited = reader |> @lib.read_bool() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.id = reader |> @lib.read_string()
+          (2, _) => msg.label = reader |> @lib.read_string() |> Some
+          (3, _) => msg.neighbors.push((reader |> @lib.read_message() : GraphNode))
+          (4, _) => msg.visited = reader |> @lib.read_bool() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for GraphNode with fn write(self: GraphNode, writer : &@lib.Writer) -> Unit raise {
@@ -373,15 +393,19 @@ pub impl @json.FromJson for GraphNode with fn from_json(json: Json, path: @json.
 }
 pub impl @lib.AsyncRead for GraphNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GraphNode raise {
   let msg = GraphNode::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.id = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.label = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.neighbors.push((reader |> @lib.async_read_message() : GraphNode)); true }
-      (4, _) => { msg.visited = reader |> @lib.async_read_bool() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.id = reader |> @lib.async_read_string()
+          (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.neighbors.push((reader |> @lib.async_read_message() : GraphNode))
+          (4, _) => msg.visited = reader |> @lib.async_read_bool() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for GraphNode with fn write(self: GraphNode, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -437,14 +461,18 @@ pub fn NestedSelfRef_Inner::new(inner_name? : String, outer_ref? : NestedSelfRef
 }
 pub impl @lib.Read for NestedSelfRef_Inner with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> NestedSelfRef_Inner raise {
   let msg = NestedSelfRef_Inner::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.inner_name = reader |> @lib.read_string() |> Some; true }
-      (2, _) => { msg.outer_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some; true }
-      (3, _) => { msg.inner_ref = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.inner_name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.outer_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
+          (3, _) => msg.inner_ref = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for NestedSelfRef_Inner with fn write(self: NestedSelfRef_Inner, writer : &@lib.Writer) -> Unit raise {
@@ -497,14 +525,18 @@ pub impl @json.FromJson for NestedSelfRef_Inner with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for NestedSelfRef_Inner with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> NestedSelfRef_Inner raise {
   let msg = NestedSelfRef_Inner::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.inner_name = reader |> @lib.async_read_string() |> Some; true }
-      (2, _) => { msg.outer_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some; true }
-      (3, _) => { msg.inner_ref = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.inner_name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.outer_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
+          (3, _) => msg.inner_ref = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for NestedSelfRef_Inner with fn write(self: NestedSelfRef_Inner, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -556,14 +588,18 @@ pub fn NestedSelfRef::new(name : String, inner? : NestedSelfRef_Inner, self_ref?
 }
 pub impl @lib.Read for NestedSelfRef with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> NestedSelfRef raise {
   let msg = NestedSelfRef::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string(); true }
-      (2, _) => { msg.inner = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some; true }
-      (3, _) => { msg.self_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.inner = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
+          (3, _) => msg.self_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for NestedSelfRef with fn write(self: NestedSelfRef, writer : &@lib.Writer) -> Unit raise {
@@ -612,14 +648,18 @@ pub impl @json.FromJson for NestedSelfRef with fn from_json(json: Json, path: @j
 }
 pub impl @lib.AsyncRead for NestedSelfRef with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> NestedSelfRef raise {
   let msg = NestedSelfRef::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.inner = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some; true }
-      (3, _) => { msg.self_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) => msg.inner = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
+          (3, _) => msg.self_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for NestedSelfRef with fn write(self: NestedSelfRef, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -680,16 +720,20 @@ pub fn Organization::new(name : String, description? : String, parent_org? : Org
 }
 pub impl @lib.Read for Organization with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Organization raise {
   let msg = Organization::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string(); true }
-      (2, _) => { msg.description = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.parent_org = (reader |> @lib.read_message() : Organization) |> Some; true }
-      (4, _) => { msg.sub_orgs.push((reader |> @lib.read_message() : Organization)); true }
-      (5, _) => { msg.employees.push((reader |> @lib.read_message() : Employee)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.description = reader |> @lib.read_string() |> Some
+          (3, _) => msg.parent_org = (reader |> @lib.read_message() : Organization) |> Some
+          (4, _) => msg.sub_orgs.push((reader |> @lib.read_message() : Organization))
+          (5, _) => msg.employees.push((reader |> @lib.read_message() : Employee))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Organization with fn write(self: Organization, writer : &@lib.Writer) -> Unit raise {
@@ -758,16 +802,20 @@ pub impl @json.FromJson for Organization with fn from_json(json: Json, path: @js
 }
 pub impl @lib.AsyncRead for Organization with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Organization raise {
   let msg = Organization::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.description = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.parent_org = (reader |> @lib.async_read_message() : Organization) |> Some; true }
-      (4, _) => { msg.sub_orgs.push((reader |> @lib.async_read_message() : Organization)); true }
-      (5, _) => { msg.employees.push((reader |> @lib.async_read_message() : Employee)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) => msg.description = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.parent_org = (reader |> @lib.async_read_message() : Organization) |> Some
+          (4, _) => msg.sub_orgs.push((reader |> @lib.async_read_message() : Organization))
+          (5, _) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Organization with fn write(self: Organization, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -836,16 +884,20 @@ pub fn Employee::new(name : String, id : String, organization? : Organization, m
 }
 pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Employee raise {
   let msg = Employee::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string(); true }
-      (2, _) => { msg.id = reader |> @lib.read_string(); true }
-      (3, _) => { msg.organization = (reader |> @lib.read_message() : Organization) |> Some; true }
-      (4, _) => { msg.manager = (reader |> @lib.read_message() : Employee) |> Some; true }
-      (5, _) => { msg.subordinates.push((reader |> @lib.read_message() : Employee)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string()
+          (2, _) => msg.id = reader |> @lib.read_string()
+          (3, _) => msg.organization = (reader |> @lib.read_message() : Organization) |> Some
+          (4, _) => msg.manager = (reader |> @lib.read_message() : Employee) |> Some
+          (5, _) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Writer) -> Unit raise {
@@ -910,16 +962,20 @@ pub impl @json.FromJson for Employee with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Employee raise {
   let msg = Employee::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.id = reader |> @lib.async_read_string(); true }
-      (3, _) => { msg.organization = (reader |> @lib.async_read_message() : Organization) |> Some; true }
-      (4, _) => { msg.manager = (reader |> @lib.async_read_message() : Employee) |> Some; true }
-      (5, _) => { msg.subordinates.push((reader |> @lib.async_read_message() : Employee)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string()
+          (2, _) => msg.id = reader |> @lib.async_read_string()
+          (3, _) => msg.organization = (reader |> @lib.async_read_message() : Organization) |> Some
+          (4, _) => msg.manager = (reader |> @lib.async_read_message() : Employee) |> Some
+          (5, _) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@lib.AsyncWriter) -> Unit raise {

--- a/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
+++ b/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
@@ -42,21 +42,16 @@ pub fn TreeNode::new(name : String, value? : Int, parent? : TreeNode, children :
 }
 pub impl @lib.Read for TreeNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> TreeNode raise {
   let msg = TreeNode::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string()
-      (2, _) => msg.value = reader |> @lib.read_int32() |> Some
-      (3, _) => msg.parent = (reader |> @lib.read_message() : TreeNode) |> Some
-      (4, _) => msg.children.push((reader |> @lib.read_message() : TreeNode))
-      (5, _) => msg.sibling = (reader |> @lib.read_message() : TreeNode) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string(); true }
+      (2, _) => { msg.value = reader |> @lib.read_int32() |> Some; true }
+      (3, _) => { msg.parent = (reader |> @lib.read_message() : TreeNode) |> Some; true }
+      (4, _) => { msg.children.push((reader |> @lib.read_message() : TreeNode)); true }
+      (5, _) => { msg.sibling = (reader |> @lib.read_message() : TreeNode) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for TreeNode with fn write(self: TreeNode, writer : &@lib.Writer) -> Unit raise {
@@ -69,17 +64,17 @@ pub impl @lib.Write for TreeNode with fn write(self: TreeNode, writer : &@lib.Wr
   }
   if self.parent is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.children {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.sibling is Some(v) {
     writer |> @lib.write_varint(42UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -125,21 +120,16 @@ pub impl @json.FromJson for TreeNode with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for TreeNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> TreeNode raise {
   let msg = TreeNode::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, _) => msg.value = reader |> @lib.async_read_int32() |> Some
-      (3, _) => msg.parent = (reader |> @lib.async_read_message() : TreeNode) |> Some
-      (4, _) => msg.children.push((reader |> @lib.async_read_message() : TreeNode))
-      (5, _) => msg.sibling = (reader |> @lib.async_read_message() : TreeNode) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.value = reader |> @lib.async_read_int32() |> Some; true }
+      (3, _) => { msg.parent = (reader |> @lib.async_read_message() : TreeNode) |> Some; true }
+      (4, _) => { msg.children.push((reader |> @lib.async_read_message() : TreeNode)); true }
+      (5, _) => { msg.sibling = (reader |> @lib.async_read_message() : TreeNode) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for TreeNode with fn write(self: TreeNode, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -152,17 +142,17 @@ pub impl @lib.AsyncWrite for TreeNode with fn write(self: TreeNode, writer : &@l
   }
   if self.parent is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.children {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.sibling is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -198,19 +188,14 @@ pub fn ListNode::new(data : String, next? : ListNode, prev? : ListNode) -> ListN
 }
 pub impl @lib.Read for ListNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ListNode raise {
   let msg = ListNode::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.data = reader |> @lib.read_string()
-      (2, _) => msg.next = (reader |> @lib.read_message() : ListNode) |> Some
-      (3, _) => msg.prev = (reader |> @lib.read_message() : ListNode) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.data = reader |> @lib.read_string(); true }
+      (2, _) => { msg.next = (reader |> @lib.read_message() : ListNode) |> Some; true }
+      (3, _) => { msg.prev = (reader |> @lib.read_message() : ListNode) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for ListNode with fn write(self: ListNode, writer : &@lib.Writer) -> Unit raise {
@@ -218,12 +203,12 @@ pub impl @lib.Write for ListNode with fn write(self: ListNode, writer : &@lib.Wr
   writer |> @lib.write_string(self.data)
   if self.next is Some(v) {
     writer |> @lib.write_varint(18UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.prev is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -259,19 +244,14 @@ pub impl @json.FromJson for ListNode with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for ListNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ListNode raise {
   let msg = ListNode::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.data = reader |> @lib.async_read_string()
-      (2, _) => msg.next = (reader |> @lib.async_read_message() : ListNode) |> Some
-      (3, _) => msg.prev = (reader |> @lib.async_read_message() : ListNode) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.data = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.next = (reader |> @lib.async_read_message() : ListNode) |> Some; true }
+      (3, _) => { msg.prev = (reader |> @lib.async_read_message() : ListNode) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for ListNode with fn write(self: ListNode, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -279,12 +259,12 @@ pub impl @lib.AsyncWrite for ListNode with fn write(self: ListNode, writer : &@l
   writer |> @lib.async_write_string(self.data)
   if self.next is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.prev is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -326,20 +306,15 @@ pub fn GraphNode::new(id : String, label? : String, neighbors : Array[GraphNode]
 }
 pub impl @lib.Read for GraphNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GraphNode raise {
   let msg = GraphNode::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.id = reader |> @lib.read_string()
-      (2, _) => msg.label = reader |> @lib.read_string() |> Some
-      (3, _) => msg.neighbors.push((reader |> @lib.read_message() : GraphNode))
-      (4, _) => msg.visited = reader |> @lib.read_bool() |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.id = reader |> @lib.read_string(); true }
+      (2, _) => { msg.label = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.neighbors.push((reader |> @lib.read_message() : GraphNode)); true }
+      (4, _) => { msg.visited = reader |> @lib.read_bool() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for GraphNode with fn write(self: GraphNode, writer : &@lib.Writer) -> Unit raise {
@@ -352,7 +327,7 @@ pub impl @lib.Write for GraphNode with fn write(self: GraphNode, writer : &@lib.
   }
   for item in self.neighbors {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.visited is Some(v) {
@@ -398,20 +373,15 @@ pub impl @json.FromJson for GraphNode with fn from_json(json: Json, path: @json.
 }
 pub impl @lib.AsyncRead for GraphNode with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GraphNode raise {
   let msg = GraphNode::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.id = reader |> @lib.async_read_string()
-      (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.neighbors.push((reader |> @lib.async_read_message() : GraphNode))
-      (4, _) => msg.visited = reader |> @lib.async_read_bool() |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.id = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.label = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.neighbors.push((reader |> @lib.async_read_message() : GraphNode)); true }
+      (4, _) => { msg.visited = reader |> @lib.async_read_bool() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for GraphNode with fn write(self: GraphNode, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -424,7 +394,7 @@ pub impl @lib.AsyncWrite for GraphNode with fn write(self: GraphNode, writer : &
   }
   for item in self.neighbors {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.visited is Some(v) {
@@ -467,19 +437,14 @@ pub fn NestedSelfRef_Inner::new(inner_name? : String, outer_ref? : NestedSelfRef
 }
 pub impl @lib.Read for NestedSelfRef_Inner with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> NestedSelfRef_Inner raise {
   let msg = NestedSelfRef_Inner::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.inner_name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.outer_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
-      (3, _) => msg.inner_ref = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.inner_name = reader |> @lib.read_string() |> Some; true }
+      (2, _) => { msg.outer_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some; true }
+      (3, _) => { msg.inner_ref = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for NestedSelfRef_Inner with fn write(self: NestedSelfRef_Inner, writer : &@lib.Writer) -> Unit raise {
@@ -490,12 +455,12 @@ pub impl @lib.Write for NestedSelfRef_Inner with fn write(self: NestedSelfRef_In
   }
   if self.outer_ref is Some(v) {
     writer |> @lib.write_varint(18UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.inner_ref is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -532,19 +497,14 @@ pub impl @json.FromJson for NestedSelfRef_Inner with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for NestedSelfRef_Inner with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> NestedSelfRef_Inner raise {
   let msg = NestedSelfRef_Inner::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.inner_name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.outer_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
-      (3, _) => msg.inner_ref = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.inner_name = reader |> @lib.async_read_string() |> Some; true }
+      (2, _) => { msg.outer_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some; true }
+      (3, _) => { msg.inner_ref = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for NestedSelfRef_Inner with fn write(self: NestedSelfRef_Inner, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -555,12 +515,12 @@ pub impl @lib.AsyncWrite for NestedSelfRef_Inner with fn write(self: NestedSelfR
   }
   if self.outer_ref is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.inner_ref is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -596,19 +556,14 @@ pub fn NestedSelfRef::new(name : String, inner? : NestedSelfRef_Inner, self_ref?
 }
 pub impl @lib.Read for NestedSelfRef with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> NestedSelfRef raise {
   let msg = NestedSelfRef::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string()
-      (2, _) => msg.inner = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
-      (3, _) => msg.self_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string(); true }
+      (2, _) => { msg.inner = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some; true }
+      (3, _) => { msg.self_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for NestedSelfRef with fn write(self: NestedSelfRef, writer : &@lib.Writer) -> Unit raise {
@@ -616,12 +571,12 @@ pub impl @lib.Write for NestedSelfRef with fn write(self: NestedSelfRef, writer 
   writer |> @lib.write_string(self.name)
   if self.inner is Some(v) {
     writer |> @lib.write_varint(18UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.self_ref is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -657,19 +612,14 @@ pub impl @json.FromJson for NestedSelfRef with fn from_json(json: Json, path: @j
 }
 pub impl @lib.AsyncRead for NestedSelfRef with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> NestedSelfRef raise {
   let msg = NestedSelfRef::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, _) => msg.inner = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
-      (3, _) => msg.self_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.inner = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some; true }
+      (3, _) => { msg.self_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for NestedSelfRef with fn write(self: NestedSelfRef, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -677,12 +627,12 @@ pub impl @lib.AsyncWrite for NestedSelfRef with fn write(self: NestedSelfRef, wr
   writer |> @lib.async_write_string(self.name)
   if self.inner is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.self_ref is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -730,21 +680,16 @@ pub fn Organization::new(name : String, description? : String, parent_org? : Org
 }
 pub impl @lib.Read for Organization with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Organization raise {
   let msg = Organization::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string()
-      (2, _) => msg.description = reader |> @lib.read_string() |> Some
-      (3, _) => msg.parent_org = (reader |> @lib.read_message() : Organization) |> Some
-      (4, _) => msg.sub_orgs.push((reader |> @lib.read_message() : Organization))
-      (5, _) => msg.employees.push((reader |> @lib.read_message() : Employee))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string(); true }
+      (2, _) => { msg.description = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.parent_org = (reader |> @lib.read_message() : Organization) |> Some; true }
+      (4, _) => { msg.sub_orgs.push((reader |> @lib.read_message() : Organization)); true }
+      (5, _) => { msg.employees.push((reader |> @lib.read_message() : Employee)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Organization with fn write(self: Organization, writer : &@lib.Writer) -> Unit raise {
@@ -757,17 +702,17 @@ pub impl @lib.Write for Organization with fn write(self: Organization, writer : 
   }
   if self.parent_org is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.sub_orgs {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.employees {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -813,21 +758,16 @@ pub impl @json.FromJson for Organization with fn from_json(json: Json, path: @js
 }
 pub impl @lib.AsyncRead for Organization with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Organization raise {
   let msg = Organization::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, _) => msg.description = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.parent_org = (reader |> @lib.async_read_message() : Organization) |> Some
-      (4, _) => msg.sub_orgs.push((reader |> @lib.async_read_message() : Organization))
-      (5, _) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.description = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.parent_org = (reader |> @lib.async_read_message() : Organization) |> Some; true }
+      (4, _) => { msg.sub_orgs.push((reader |> @lib.async_read_message() : Organization)); true }
+      (5, _) => { msg.employees.push((reader |> @lib.async_read_message() : Employee)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Organization with fn write(self: Organization, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -840,17 +780,17 @@ pub impl @lib.AsyncWrite for Organization with fn write(self: Organization, writ
   }
   if self.parent_org is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.sub_orgs {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.employees {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -896,21 +836,16 @@ pub fn Employee::new(name : String, id : String, organization? : Organization, m
 }
 pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Employee raise {
   let msg = Employee::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string()
-      (2, _) => msg.id = reader |> @lib.read_string()
-      (3, _) => msg.organization = (reader |> @lib.read_message() : Organization) |> Some
-      (4, _) => msg.manager = (reader |> @lib.read_message() : Employee) |> Some
-      (5, _) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string(); true }
+      (2, _) => { msg.id = reader |> @lib.read_string(); true }
+      (3, _) => { msg.organization = (reader |> @lib.read_message() : Organization) |> Some; true }
+      (4, _) => { msg.manager = (reader |> @lib.read_message() : Employee) |> Some; true }
+      (5, _) => { msg.subordinates.push((reader |> @lib.read_message() : Employee)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Writer) -> Unit raise {
@@ -920,17 +855,17 @@ pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Wr
   writer |> @lib.write_string(self.id)
   if self.organization is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.manager is Some(v) {
     writer |> @lib.write_varint(34UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.subordinates {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -975,21 +910,16 @@ pub impl @json.FromJson for Employee with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Employee raise {
   let msg = Employee::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, _) => msg.id = reader |> @lib.async_read_string()
-      (3, _) => msg.organization = (reader |> @lib.async_read_message() : Organization) |> Some
-      (4, _) => msg.manager = (reader |> @lib.async_read_message() : Employee) |> Some
-      (5, _) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.id = reader |> @lib.async_read_string(); true }
+      (3, _) => { msg.organization = (reader |> @lib.async_read_message() : Organization) |> Some; true }
+      (4, _) => { msg.manager = (reader |> @lib.async_read_message() : Employee) |> Some; true }
+      (5, _) => { msg.subordinates.push((reader |> @lib.async_read_message() : Employee)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -999,17 +929,17 @@ pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@l
   writer |> @lib.async_write_string(self.id)
   if self.organization is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.manager is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.subordinates {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }

--- a/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
+++ b/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
@@ -40,16 +40,20 @@ pub fn User::new(user_id : String, name : String, email? : String, orders : Arra
 }
 pub impl @lib.Read for User with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> User raise {
   let msg = User::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.user_id = reader |> @lib.read_string(); true }
-      (2, _) => { msg.name = reader |> @lib.read_string(); true }
-      (3, _) => { msg.email = reader |> @lib.read_string() |> Some; true }
-      (4, _) => { msg.orders.push((reader |> @lib.read_message() : Order)); true }
-      (5, _) => { msg.friends.push((reader |> @lib.read_message() : User)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.user_id = reader |> @lib.read_string()
+          (2, _) => msg.name = reader |> @lib.read_string()
+          (3, _) => msg.email = reader |> @lib.read_string() |> Some
+          (4, _) => msg.orders.push((reader |> @lib.read_message() : Order))
+          (5, _) => msg.friends.push((reader |> @lib.read_message() : User))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for User with fn write(self: User, writer : &@lib.Writer) -> Unit raise {
@@ -114,16 +118,20 @@ pub impl @json.FromJson for User with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for User with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> User raise {
   let msg = User::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.user_id = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.name = reader |> @lib.async_read_string(); true }
-      (3, _) => { msg.email = reader |> @lib.async_read_string() |> Some; true }
-      (4, _) => { msg.orders.push((reader |> @lib.async_read_message() : Order)); true }
-      (5, _) => { msg.friends.push((reader |> @lib.async_read_message() : User)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.user_id = reader |> @lib.async_read_string()
+          (2, _) => msg.name = reader |> @lib.async_read_string()
+          (3, _) => msg.email = reader |> @lib.async_read_string() |> Some
+          (4, _) => msg.orders.push((reader |> @lib.async_read_message() : Order))
+          (5, _) => msg.friends.push((reader |> @lib.async_read_message() : User))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for User with fn write(self: User, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -189,16 +197,20 @@ pub fn Order::new(order_id : String, product_name : String, amount? : Double, cu
 }
 pub impl @lib.Read for Order with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Order raise {
   let msg = Order::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.order_id = reader |> @lib.read_string(); true }
-      (2, _) => { msg.product_name = reader |> @lib.read_string(); true }
-      (3, _) => { msg.amount = reader |> @lib.read_double() |> Some; true }
-      (4, _) => { msg.customer = (reader |> @lib.read_message() : User) |> Some; true }
-      (5, _) => { msg.related_orders.push((reader |> @lib.read_message() : Order)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.order_id = reader |> @lib.read_string()
+          (2, _) => msg.product_name = reader |> @lib.read_string()
+          (3, _) => msg.amount = reader |> @lib.read_double() |> Some
+          (4, _) => msg.customer = (reader |> @lib.read_message() : User) |> Some
+          (5, _) => msg.related_orders.push((reader |> @lib.read_message() : Order))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Order with fn write(self: Order, writer : &@lib.Writer) -> Unit raise {
@@ -263,16 +275,20 @@ pub impl @json.FromJson for Order with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Order with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Order raise {
   let msg = Order::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.order_id = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.product_name = reader |> @lib.async_read_string(); true }
-      (3, _) => { msg.amount = reader |> @lib.async_read_double() |> Some; true }
-      (4, _) => { msg.customer = (reader |> @lib.async_read_message() : User) |> Some; true }
-      (5, _) => { msg.related_orders.push((reader |> @lib.async_read_message() : Order)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.order_id = reader |> @lib.async_read_string()
+          (2, _) => msg.product_name = reader |> @lib.async_read_string()
+          (3, _) => msg.amount = reader |> @lib.async_read_double() |> Some
+          (4, _) => msg.customer = (reader |> @lib.async_read_message() : User) |> Some
+          (5, _) => msg.related_orders.push((reader |> @lib.async_read_message() : Order))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Order with fn write(self: Order, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -338,16 +354,20 @@ pub fn Department::new(dept_id : String, name : String, employees : Array[Employ
 }
 pub impl @lib.Read for Department with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Department raise {
   let msg = Department::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.dept_id = reader |> @lib.read_string(); true }
-      (2, _) => { msg.name = reader |> @lib.read_string(); true }
-      (3, _) => { msg.employees.push((reader |> @lib.read_message() : Employee)); true }
-      (4, _) => { msg.projects.push((reader |> @lib.read_message() : Project)); true }
-      (5, _) => { msg.parent_dept = (reader |> @lib.read_message() : Department) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.dept_id = reader |> @lib.read_string()
+          (2, _) => msg.name = reader |> @lib.read_string()
+          (3, _) => msg.employees.push((reader |> @lib.read_message() : Employee))
+          (4, _) => msg.projects.push((reader |> @lib.read_message() : Project))
+          (5, _) => msg.parent_dept = (reader |> @lib.read_message() : Department) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Department with fn write(self: Department, writer : &@lib.Writer) -> Unit raise {
@@ -412,16 +432,20 @@ pub impl @json.FromJson for Department with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for Department with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Department raise {
   let msg = Department::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.dept_id = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.name = reader |> @lib.async_read_string(); true }
-      (3, _) => { msg.employees.push((reader |> @lib.async_read_message() : Employee)); true }
-      (4, _) => { msg.projects.push((reader |> @lib.async_read_message() : Project)); true }
-      (5, _) => { msg.parent_dept = (reader |> @lib.async_read_message() : Department) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.dept_id = reader |> @lib.async_read_string()
+          (2, _) => msg.name = reader |> @lib.async_read_string()
+          (3, _) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
+          (4, _) => msg.projects.push((reader |> @lib.async_read_message() : Project))
+          (5, _) => msg.parent_dept = (reader |> @lib.async_read_message() : Department) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Department with fn write(self: Department, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -493,17 +517,21 @@ pub fn Employee::new(emp_id : String, name : String, department? : Department, p
 }
 pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Employee raise {
   let msg = Employee::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.emp_id = reader |> @lib.read_string(); true }
-      (2, _) => { msg.name = reader |> @lib.read_string(); true }
-      (3, _) => { msg.department = (reader |> @lib.read_message() : Department) |> Some; true }
-      (4, _) => { msg.projects.push((reader |> @lib.read_message() : Project)); true }
-      (5, _) => { msg.supervisor = (reader |> @lib.read_message() : Employee) |> Some; true }
-      (6, _) => { msg.subordinates.push((reader |> @lib.read_message() : Employee)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.emp_id = reader |> @lib.read_string()
+          (2, _) => msg.name = reader |> @lib.read_string()
+          (3, _) => msg.department = (reader |> @lib.read_message() : Department) |> Some
+          (4, _) => msg.projects.push((reader |> @lib.read_message() : Project))
+          (5, _) => msg.supervisor = (reader |> @lib.read_message() : Employee) |> Some
+          (6, _) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Writer) -> Unit raise {
@@ -578,17 +606,21 @@ pub impl @json.FromJson for Employee with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Employee raise {
   let msg = Employee::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.emp_id = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.name = reader |> @lib.async_read_string(); true }
-      (3, _) => { msg.department = (reader |> @lib.async_read_message() : Department) |> Some; true }
-      (4, _) => { msg.projects.push((reader |> @lib.async_read_message() : Project)); true }
-      (5, _) => { msg.supervisor = (reader |> @lib.async_read_message() : Employee) |> Some; true }
-      (6, _) => { msg.subordinates.push((reader |> @lib.async_read_message() : Employee)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.emp_id = reader |> @lib.async_read_string()
+          (2, _) => msg.name = reader |> @lib.async_read_string()
+          (3, _) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
+          (4, _) => msg.projects.push((reader |> @lib.async_read_message() : Project))
+          (5, _) => msg.supervisor = (reader |> @lib.async_read_message() : Employee) |> Some
+          (6, _) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -671,18 +703,22 @@ pub fn Project::new(project_id : String, title : String, description? : String, 
 }
 pub impl @lib.Read for Project with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Project raise {
   let msg = Project::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.project_id = reader |> @lib.read_string(); true }
-      (2, _) => { msg.title = reader |> @lib.read_string(); true }
-      (3, _) => { msg.description = reader |> @lib.read_string() |> Some; true }
-      (4, _) => { msg.department = (reader |> @lib.read_message() : Department) |> Some; true }
-      (5, _) => { msg.members.push((reader |> @lib.read_message() : Employee)); true }
-      (6, _) => { msg.dependencies.push((reader |> @lib.read_message() : Project)); true }
-      (7, _) => { msg.dependents.push((reader |> @lib.read_message() : Project)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.project_id = reader |> @lib.read_string()
+          (2, _) => msg.title = reader |> @lib.read_string()
+          (3, _) => msg.description = reader |> @lib.read_string() |> Some
+          (4, _) => msg.department = (reader |> @lib.read_message() : Department) |> Some
+          (5, _) => msg.members.push((reader |> @lib.read_message() : Employee))
+          (6, _) => msg.dependencies.push((reader |> @lib.read_message() : Project))
+          (7, _) => msg.dependents.push((reader |> @lib.read_message() : Project))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Project with fn write(self: Project, writer : &@lib.Writer) -> Unit raise {
@@ -767,18 +803,22 @@ pub impl @json.FromJson for Project with fn from_json(json: Json, path: @json.Js
 }
 pub impl @lib.AsyncRead for Project with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Project raise {
   let msg = Project::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.project_id = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.title = reader |> @lib.async_read_string(); true }
-      (3, _) => { msg.description = reader |> @lib.async_read_string() |> Some; true }
-      (4, _) => { msg.department = (reader |> @lib.async_read_message() : Department) |> Some; true }
-      (5, _) => { msg.members.push((reader |> @lib.async_read_message() : Employee)); true }
-      (6, _) => { msg.dependencies.push((reader |> @lib.async_read_message() : Project)); true }
-      (7, _) => { msg.dependents.push((reader |> @lib.async_read_message() : Project)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.project_id = reader |> @lib.async_read_string()
+          (2, _) => msg.title = reader |> @lib.async_read_string()
+          (3, _) => msg.description = reader |> @lib.async_read_string() |> Some
+          (4, _) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
+          (5, _) => msg.members.push((reader |> @lib.async_read_message() : Employee))
+          (6, _) => msg.dependencies.push((reader |> @lib.async_read_message() : Project))
+          (7, _) => msg.dependents.push((reader |> @lib.async_read_message() : Project))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Project with fn write(self: Project, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -856,16 +896,20 @@ pub fn Node_Connection::new(connection_id : String, type_? : String, source? : N
 }
 pub impl @lib.Read for Node_Connection with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Node_Connection raise {
   let msg = Node_Connection::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.connection_id = reader |> @lib.read_string(); true }
-      (2, _) => { msg.type_ = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.source = (reader |> @lib.read_message() : Node) |> Some; true }
-      (4, _) => { msg.target = (reader |> @lib.read_message() : Node) |> Some; true }
-      (5, _) => { msg.weight = (reader |> @lib.read_message() : Weight) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.connection_id = reader |> @lib.read_string()
+          (2, _) => msg.type_ = reader |> @lib.read_string() |> Some
+          (3, _) => msg.source = (reader |> @lib.read_message() : Node) |> Some
+          (4, _) => msg.target = (reader |> @lib.read_message() : Node) |> Some
+          (5, _) => msg.weight = (reader |> @lib.read_message() : Weight) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Node_Connection with fn write(self: Node_Connection, writer : &@lib.Writer) -> Unit raise {
@@ -934,16 +978,20 @@ pub impl @json.FromJson for Node_Connection with fn from_json(json: Json, path: 
 }
 pub impl @lib.AsyncRead for Node_Connection with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Node_Connection raise {
   let msg = Node_Connection::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.connection_id = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.type_ = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.source = (reader |> @lib.async_read_message() : Node) |> Some; true }
-      (4, _) => { msg.target = (reader |> @lib.async_read_message() : Node) |> Some; true }
-      (5, _) => { msg.weight = (reader |> @lib.async_read_message() : Weight) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.connection_id = reader |> @lib.async_read_string()
+          (2, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.source = (reader |> @lib.async_read_message() : Node) |> Some
+          (4, _) => msg.target = (reader |> @lib.async_read_message() : Node) |> Some
+          (5, _) => msg.weight = (reader |> @lib.async_read_message() : Weight) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Node_Connection with fn write(self: Node_Connection, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1008,15 +1056,19 @@ pub fn Node::new(id : String, data? : String, connections : Array[Node_Connectio
 }
 pub impl @lib.Read for Node with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Node raise {
   let msg = Node::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.id = reader |> @lib.read_string(); true }
-      (2, _) => { msg.data = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.connections.push((reader |> @lib.read_message() : Node_Connection)); true }
-      (4, _) => { msg.neighbors.push((reader |> @lib.read_message() : Node)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.id = reader |> @lib.read_string()
+          (2, _) => msg.data = reader |> @lib.read_string() |> Some
+          (3, _) => msg.connections.push((reader |> @lib.read_message() : Node_Connection))
+          (4, _) => msg.neighbors.push((reader |> @lib.read_message() : Node))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Node with fn write(self: Node, writer : &@lib.Writer) -> Unit raise {
@@ -1075,15 +1127,19 @@ pub impl @json.FromJson for Node with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Node with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Node raise {
   let msg = Node::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.id = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.data = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.connections.push((reader |> @lib.async_read_message() : Node_Connection)); true }
-      (4, _) => { msg.neighbors.push((reader |> @lib.async_read_message() : Node)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.id = reader |> @lib.async_read_string()
+          (2, _) => msg.data = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.connections.push((reader |> @lib.async_read_message() : Node_Connection))
+          (4, _) => msg.neighbors.push((reader |> @lib.async_read_message() : Node))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Node with fn write(self: Node, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1143,15 +1199,19 @@ pub fn Weight::new(value : Double, unit? : String, connection? : Node_Connection
 }
 pub impl @lib.Read for Weight with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Weight raise {
   let msg = Weight::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.value = reader |> @lib.read_double(); true }
-      (2, _) => { msg.unit = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.connection = (reader |> @lib.read_message() : Node_Connection) |> Some; true }
-      (4, _) => { msg.related_nodes.push((reader |> @lib.read_message() : Node)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.read_double()
+          (2, _) => msg.unit = reader |> @lib.read_string() |> Some
+          (3, _) => msg.connection = (reader |> @lib.read_message() : Node_Connection) |> Some
+          (4, _) => msg.related_nodes.push((reader |> @lib.read_message() : Node))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Weight with fn write(self: Weight, writer : &@lib.Writer) -> Unit raise {
@@ -1210,15 +1270,19 @@ pub impl @json.FromJson for Weight with fn from_json(json: Json, path: @json.Jso
 }
 pub impl @lib.AsyncRead for Weight with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Weight raise {
   let msg = Weight::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.value = reader |> @lib.async_read_double(); true }
-      (2, _) => { msg.unit = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.connection = (reader |> @lib.async_read_message() : Node_Connection) |> Some; true }
-      (4, _) => { msg.related_nodes.push((reader |> @lib.async_read_message() : Node)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.value = reader |> @lib.async_read_double()
+          (2, _) => msg.unit = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.connection = (reader |> @lib.async_read_message() : Node_Connection) |> Some
+          (4, _) => msg.related_nodes.push((reader |> @lib.async_read_message() : Node))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Weight with fn write(self: Weight, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1278,15 +1342,19 @@ pub fn Graph::new(graph_id : String, name? : String, vertices : Array[Vertex], e
 }
 pub impl @lib.Read for Graph with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Graph raise {
   let msg = Graph::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.graph_id = reader |> @lib.read_string(); true }
-      (2, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.vertices.push((reader |> @lib.read_message() : Vertex)); true }
-      (4, _) => { msg.edges.push((reader |> @lib.read_message() : Edge)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.graph_id = reader |> @lib.read_string()
+          (2, _) => msg.name = reader |> @lib.read_string() |> Some
+          (3, _) => msg.vertices.push((reader |> @lib.read_message() : Vertex))
+          (4, _) => msg.edges.push((reader |> @lib.read_message() : Edge))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Graph with fn write(self: Graph, writer : &@lib.Writer) -> Unit raise {
@@ -1345,15 +1413,19 @@ pub impl @json.FromJson for Graph with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Graph with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Graph raise {
   let msg = Graph::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.graph_id = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.vertices.push((reader |> @lib.async_read_message() : Vertex)); true }
-      (4, _) => { msg.edges.push((reader |> @lib.async_read_message() : Edge)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.graph_id = reader |> @lib.async_read_string()
+          (2, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.vertices.push((reader |> @lib.async_read_message() : Vertex))
+          (4, _) => msg.edges.push((reader |> @lib.async_read_message() : Edge))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Graph with fn write(self: Graph, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1425,17 +1497,21 @@ pub fn Vertex::new(vertex_id : String, label? : String, graph? : Graph, incoming
 }
 pub impl @lib.Read for Vertex with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Vertex raise {
   let msg = Vertex::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.vertex_id = reader |> @lib.read_string(); true }
-      (2, _) => { msg.label = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.graph = (reader |> @lib.read_message() : Graph) |> Some; true }
-      (4, _) => { msg.incoming_edges.push((reader |> @lib.read_message() : Edge)); true }
-      (5, _) => { msg.outgoing_edges.push((reader |> @lib.read_message() : Edge)); true }
-      (6, _) => { msg.adjacent_vertices.push((reader |> @lib.read_message() : Vertex)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.vertex_id = reader |> @lib.read_string()
+          (2, _) => msg.label = reader |> @lib.read_string() |> Some
+          (3, _) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
+          (4, _) => msg.incoming_edges.push((reader |> @lib.read_message() : Edge))
+          (5, _) => msg.outgoing_edges.push((reader |> @lib.read_message() : Edge))
+          (6, _) => msg.adjacent_vertices.push((reader |> @lib.read_message() : Vertex))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Vertex with fn write(self: Vertex, writer : &@lib.Writer) -> Unit raise {
@@ -1514,17 +1590,21 @@ pub impl @json.FromJson for Vertex with fn from_json(json: Json, path: @json.Jso
 }
 pub impl @lib.AsyncRead for Vertex with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Vertex raise {
   let msg = Vertex::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.vertex_id = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.label = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some; true }
-      (4, _) => { msg.incoming_edges.push((reader |> @lib.async_read_message() : Edge)); true }
-      (5, _) => { msg.outgoing_edges.push((reader |> @lib.async_read_message() : Edge)); true }
-      (6, _) => { msg.adjacent_vertices.push((reader |> @lib.async_read_message() : Vertex)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.vertex_id = reader |> @lib.async_read_string()
+          (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
+          (4, _) => msg.incoming_edges.push((reader |> @lib.async_read_message() : Edge))
+          (5, _) => msg.outgoing_edges.push((reader |> @lib.async_read_message() : Edge))
+          (6, _) => msg.adjacent_vertices.push((reader |> @lib.async_read_message() : Vertex))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Vertex with fn write(self: Vertex, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1606,17 +1686,21 @@ pub fn Edge::new(edge_id : String, weight? : Double, graph? : Graph, source_vert
 }
 pub impl @lib.Read for Edge with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Edge raise {
   let msg = Edge::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.edge_id = reader |> @lib.read_string(); true }
-      (2, _) => { msg.weight = reader |> @lib.read_double() |> Some; true }
-      (3, _) => { msg.graph = (reader |> @lib.read_message() : Graph) |> Some; true }
-      (4, _) => { msg.source_vertex = (reader |> @lib.read_message() : Vertex) |> Some; true }
-      (5, _) => { msg.target_vertex = (reader |> @lib.read_message() : Vertex) |> Some; true }
-      (6, _) => { msg.parallel_edges.push((reader |> @lib.read_message() : Edge)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.edge_id = reader |> @lib.read_string()
+          (2, _) => msg.weight = reader |> @lib.read_double() |> Some
+          (3, _) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
+          (4, _) => msg.source_vertex = (reader |> @lib.read_message() : Vertex) |> Some
+          (5, _) => msg.target_vertex = (reader |> @lib.read_message() : Vertex) |> Some
+          (6, _) => msg.parallel_edges.push((reader |> @lib.read_message() : Edge))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for Edge with fn write(self: Edge, writer : &@lib.Writer) -> Unit raise {
@@ -1695,17 +1779,21 @@ pub impl @json.FromJson for Edge with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Edge with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Edge raise {
   let msg = Edge::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.edge_id = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.weight = reader |> @lib.async_read_double() |> Some; true }
-      (3, _) => { msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some; true }
-      (4, _) => { msg.source_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some; true }
-      (5, _) => { msg.target_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some; true }
-      (6, _) => { msg.parallel_edges.push((reader |> @lib.async_read_message() : Edge)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.edge_id = reader |> @lib.async_read_string()
+          (2, _) => msg.weight = reader |> @lib.async_read_double() |> Some
+          (3, _) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
+          (4, _) => msg.source_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
+          (5, _) => msg.target_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
+          (6, _) => msg.parallel_edges.push((reader |> @lib.async_read_message() : Edge))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for Edge with fn write(self: Edge, writer : &@lib.AsyncWriter) -> Unit raise {

--- a/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
+++ b/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
@@ -40,18 +40,14 @@ pub fn User::new(user_id : String, name : String, email? : String, orders : Arra
 }
 pub impl @lib.Read for User with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> User raise {
   let msg = User::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.user_id = reader |> @lib.read_string()
-          (2, _) => msg.name = reader |> @lib.read_string()
-          (3, _) => msg.email = reader |> @lib.read_string() |> Some
-          (4, _) => msg.orders.push((reader |> @lib.read_message() : Order))
-          (5, _) => msg.friends.push((reader |> @lib.read_message() : User))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.user_id = reader |> @lib.read_string()
+      (2, _) => msg.name = reader |> @lib.read_string()
+      (3, _) => msg.email = reader |> @lib.read_string() |> Some
+      (4, _) => msg.orders.push((reader |> @lib.read_message() : Order))
+      (5, _) => msg.friends.push((reader |> @lib.read_message() : User))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -118,18 +114,14 @@ pub impl @json.FromJson for User with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for User with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> User raise {
   let msg = User::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.user_id = reader |> @lib.async_read_string()
-          (2, _) => msg.name = reader |> @lib.async_read_string()
-          (3, _) => msg.email = reader |> @lib.async_read_string() |> Some
-          (4, _) => msg.orders.push((reader |> @lib.async_read_message() : Order))
-          (5, _) => msg.friends.push((reader |> @lib.async_read_message() : User))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.user_id = reader |> @lib.async_read_string()
+      (2, _) => msg.name = reader |> @lib.async_read_string()
+      (3, _) => msg.email = reader |> @lib.async_read_string() |> Some
+      (4, _) => msg.orders.push((reader |> @lib.async_read_message() : Order))
+      (5, _) => msg.friends.push((reader |> @lib.async_read_message() : User))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -197,18 +189,14 @@ pub fn Order::new(order_id : String, product_name : String, amount? : Double, cu
 }
 pub impl @lib.Read for Order with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Order raise {
   let msg = Order::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.order_id = reader |> @lib.read_string()
-          (2, _) => msg.product_name = reader |> @lib.read_string()
-          (3, _) => msg.amount = reader |> @lib.read_double() |> Some
-          (4, _) => msg.customer = (reader |> @lib.read_message() : User) |> Some
-          (5, _) => msg.related_orders.push((reader |> @lib.read_message() : Order))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.order_id = reader |> @lib.read_string()
+      (2, _) => msg.product_name = reader |> @lib.read_string()
+      (3, _) => msg.amount = reader |> @lib.read_double() |> Some
+      (4, _) => msg.customer = (reader |> @lib.read_message() : User) |> Some
+      (5, _) => msg.related_orders.push((reader |> @lib.read_message() : Order))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -275,18 +263,14 @@ pub impl @json.FromJson for Order with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Order with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Order raise {
   let msg = Order::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.order_id = reader |> @lib.async_read_string()
-          (2, _) => msg.product_name = reader |> @lib.async_read_string()
-          (3, _) => msg.amount = reader |> @lib.async_read_double() |> Some
-          (4, _) => msg.customer = (reader |> @lib.async_read_message() : User) |> Some
-          (5, _) => msg.related_orders.push((reader |> @lib.async_read_message() : Order))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.order_id = reader |> @lib.async_read_string()
+      (2, _) => msg.product_name = reader |> @lib.async_read_string()
+      (3, _) => msg.amount = reader |> @lib.async_read_double() |> Some
+      (4, _) => msg.customer = (reader |> @lib.async_read_message() : User) |> Some
+      (5, _) => msg.related_orders.push((reader |> @lib.async_read_message() : Order))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -354,18 +338,14 @@ pub fn Department::new(dept_id : String, name : String, employees : Array[Employ
 }
 pub impl @lib.Read for Department with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Department raise {
   let msg = Department::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.dept_id = reader |> @lib.read_string()
-          (2, _) => msg.name = reader |> @lib.read_string()
-          (3, _) => msg.employees.push((reader |> @lib.read_message() : Employee))
-          (4, _) => msg.projects.push((reader |> @lib.read_message() : Project))
-          (5, _) => msg.parent_dept = (reader |> @lib.read_message() : Department) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.dept_id = reader |> @lib.read_string()
+      (2, _) => msg.name = reader |> @lib.read_string()
+      (3, _) => msg.employees.push((reader |> @lib.read_message() : Employee))
+      (4, _) => msg.projects.push((reader |> @lib.read_message() : Project))
+      (5, _) => msg.parent_dept = (reader |> @lib.read_message() : Department) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -432,18 +412,14 @@ pub impl @json.FromJson for Department with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for Department with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Department raise {
   let msg = Department::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.dept_id = reader |> @lib.async_read_string()
-          (2, _) => msg.name = reader |> @lib.async_read_string()
-          (3, _) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
-          (4, _) => msg.projects.push((reader |> @lib.async_read_message() : Project))
-          (5, _) => msg.parent_dept = (reader |> @lib.async_read_message() : Department) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.dept_id = reader |> @lib.async_read_string()
+      (2, _) => msg.name = reader |> @lib.async_read_string()
+      (3, _) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
+      (4, _) => msg.projects.push((reader |> @lib.async_read_message() : Project))
+      (5, _) => msg.parent_dept = (reader |> @lib.async_read_message() : Department) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -517,19 +493,15 @@ pub fn Employee::new(emp_id : String, name : String, department? : Department, p
 }
 pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Employee raise {
   let msg = Employee::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.emp_id = reader |> @lib.read_string()
-          (2, _) => msg.name = reader |> @lib.read_string()
-          (3, _) => msg.department = (reader |> @lib.read_message() : Department) |> Some
-          (4, _) => msg.projects.push((reader |> @lib.read_message() : Project))
-          (5, _) => msg.supervisor = (reader |> @lib.read_message() : Employee) |> Some
-          (6, _) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.emp_id = reader |> @lib.read_string()
+      (2, _) => msg.name = reader |> @lib.read_string()
+      (3, _) => msg.department = (reader |> @lib.read_message() : Department) |> Some
+      (4, _) => msg.projects.push((reader |> @lib.read_message() : Project))
+      (5, _) => msg.supervisor = (reader |> @lib.read_message() : Employee) |> Some
+      (6, _) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -606,19 +578,15 @@ pub impl @json.FromJson for Employee with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Employee raise {
   let msg = Employee::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.emp_id = reader |> @lib.async_read_string()
-          (2, _) => msg.name = reader |> @lib.async_read_string()
-          (3, _) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
-          (4, _) => msg.projects.push((reader |> @lib.async_read_message() : Project))
-          (5, _) => msg.supervisor = (reader |> @lib.async_read_message() : Employee) |> Some
-          (6, _) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.emp_id = reader |> @lib.async_read_string()
+      (2, _) => msg.name = reader |> @lib.async_read_string()
+      (3, _) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
+      (4, _) => msg.projects.push((reader |> @lib.async_read_message() : Project))
+      (5, _) => msg.supervisor = (reader |> @lib.async_read_message() : Employee) |> Some
+      (6, _) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -703,20 +671,16 @@ pub fn Project::new(project_id : String, title : String, description? : String, 
 }
 pub impl @lib.Read for Project with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Project raise {
   let msg = Project::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.project_id = reader |> @lib.read_string()
-          (2, _) => msg.title = reader |> @lib.read_string()
-          (3, _) => msg.description = reader |> @lib.read_string() |> Some
-          (4, _) => msg.department = (reader |> @lib.read_message() : Department) |> Some
-          (5, _) => msg.members.push((reader |> @lib.read_message() : Employee))
-          (6, _) => msg.dependencies.push((reader |> @lib.read_message() : Project))
-          (7, _) => msg.dependents.push((reader |> @lib.read_message() : Project))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.project_id = reader |> @lib.read_string()
+      (2, _) => msg.title = reader |> @lib.read_string()
+      (3, _) => msg.description = reader |> @lib.read_string() |> Some
+      (4, _) => msg.department = (reader |> @lib.read_message() : Department) |> Some
+      (5, _) => msg.members.push((reader |> @lib.read_message() : Employee))
+      (6, _) => msg.dependencies.push((reader |> @lib.read_message() : Project))
+      (7, _) => msg.dependents.push((reader |> @lib.read_message() : Project))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -803,20 +767,16 @@ pub impl @json.FromJson for Project with fn from_json(json: Json, path: @json.Js
 }
 pub impl @lib.AsyncRead for Project with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Project raise {
   let msg = Project::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.project_id = reader |> @lib.async_read_string()
-          (2, _) => msg.title = reader |> @lib.async_read_string()
-          (3, _) => msg.description = reader |> @lib.async_read_string() |> Some
-          (4, _) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
-          (5, _) => msg.members.push((reader |> @lib.async_read_message() : Employee))
-          (6, _) => msg.dependencies.push((reader |> @lib.async_read_message() : Project))
-          (7, _) => msg.dependents.push((reader |> @lib.async_read_message() : Project))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.project_id = reader |> @lib.async_read_string()
+      (2, _) => msg.title = reader |> @lib.async_read_string()
+      (3, _) => msg.description = reader |> @lib.async_read_string() |> Some
+      (4, _) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
+      (5, _) => msg.members.push((reader |> @lib.async_read_message() : Employee))
+      (6, _) => msg.dependencies.push((reader |> @lib.async_read_message() : Project))
+      (7, _) => msg.dependents.push((reader |> @lib.async_read_message() : Project))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -896,18 +856,14 @@ pub fn Node_Connection::new(connection_id : String, type_? : String, source? : N
 }
 pub impl @lib.Read for Node_Connection with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Node_Connection raise {
   let msg = Node_Connection::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.connection_id = reader |> @lib.read_string()
-          (2, _) => msg.type_ = reader |> @lib.read_string() |> Some
-          (3, _) => msg.source = (reader |> @lib.read_message() : Node) |> Some
-          (4, _) => msg.target = (reader |> @lib.read_message() : Node) |> Some
-          (5, _) => msg.weight = (reader |> @lib.read_message() : Weight) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.connection_id = reader |> @lib.read_string()
+      (2, _) => msg.type_ = reader |> @lib.read_string() |> Some
+      (3, _) => msg.source = (reader |> @lib.read_message() : Node) |> Some
+      (4, _) => msg.target = (reader |> @lib.read_message() : Node) |> Some
+      (5, _) => msg.weight = (reader |> @lib.read_message() : Weight) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -978,18 +934,14 @@ pub impl @json.FromJson for Node_Connection with fn from_json(json: Json, path: 
 }
 pub impl @lib.AsyncRead for Node_Connection with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Node_Connection raise {
   let msg = Node_Connection::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.connection_id = reader |> @lib.async_read_string()
-          (2, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.source = (reader |> @lib.async_read_message() : Node) |> Some
-          (4, _) => msg.target = (reader |> @lib.async_read_message() : Node) |> Some
-          (5, _) => msg.weight = (reader |> @lib.async_read_message() : Weight) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.connection_id = reader |> @lib.async_read_string()
+      (2, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.source = (reader |> @lib.async_read_message() : Node) |> Some
+      (4, _) => msg.target = (reader |> @lib.async_read_message() : Node) |> Some
+      (5, _) => msg.weight = (reader |> @lib.async_read_message() : Weight) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1056,17 +1008,13 @@ pub fn Node::new(id : String, data? : String, connections : Array[Node_Connectio
 }
 pub impl @lib.Read for Node with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Node raise {
   let msg = Node::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.id = reader |> @lib.read_string()
-          (2, _) => msg.data = reader |> @lib.read_string() |> Some
-          (3, _) => msg.connections.push((reader |> @lib.read_message() : Node_Connection))
-          (4, _) => msg.neighbors.push((reader |> @lib.read_message() : Node))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.id = reader |> @lib.read_string()
+      (2, _) => msg.data = reader |> @lib.read_string() |> Some
+      (3, _) => msg.connections.push((reader |> @lib.read_message() : Node_Connection))
+      (4, _) => msg.neighbors.push((reader |> @lib.read_message() : Node))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1127,17 +1075,13 @@ pub impl @json.FromJson for Node with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Node with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Node raise {
   let msg = Node::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.id = reader |> @lib.async_read_string()
-          (2, _) => msg.data = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.connections.push((reader |> @lib.async_read_message() : Node_Connection))
-          (4, _) => msg.neighbors.push((reader |> @lib.async_read_message() : Node))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.id = reader |> @lib.async_read_string()
+      (2, _) => msg.data = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.connections.push((reader |> @lib.async_read_message() : Node_Connection))
+      (4, _) => msg.neighbors.push((reader |> @lib.async_read_message() : Node))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1199,17 +1143,13 @@ pub fn Weight::new(value : Double, unit? : String, connection? : Node_Connection
 }
 pub impl @lib.Read for Weight with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Weight raise {
   let msg = Weight::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.read_double()
-          (2, _) => msg.unit = reader |> @lib.read_string() |> Some
-          (3, _) => msg.connection = (reader |> @lib.read_message() : Node_Connection) |> Some
-          (4, _) => msg.related_nodes.push((reader |> @lib.read_message() : Node))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.read_double()
+      (2, _) => msg.unit = reader |> @lib.read_string() |> Some
+      (3, _) => msg.connection = (reader |> @lib.read_message() : Node_Connection) |> Some
+      (4, _) => msg.related_nodes.push((reader |> @lib.read_message() : Node))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1270,17 +1210,13 @@ pub impl @json.FromJson for Weight with fn from_json(json: Json, path: @json.Jso
 }
 pub impl @lib.AsyncRead for Weight with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Weight raise {
   let msg = Weight::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.value = reader |> @lib.async_read_double()
-          (2, _) => msg.unit = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.connection = (reader |> @lib.async_read_message() : Node_Connection) |> Some
-          (4, _) => msg.related_nodes.push((reader |> @lib.async_read_message() : Node))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.value = reader |> @lib.async_read_double()
+      (2, _) => msg.unit = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.connection = (reader |> @lib.async_read_message() : Node_Connection) |> Some
+      (4, _) => msg.related_nodes.push((reader |> @lib.async_read_message() : Node))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1342,17 +1278,13 @@ pub fn Graph::new(graph_id : String, name? : String, vertices : Array[Vertex], e
 }
 pub impl @lib.Read for Graph with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Graph raise {
   let msg = Graph::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.graph_id = reader |> @lib.read_string()
-          (2, _) => msg.name = reader |> @lib.read_string() |> Some
-          (3, _) => msg.vertices.push((reader |> @lib.read_message() : Vertex))
-          (4, _) => msg.edges.push((reader |> @lib.read_message() : Edge))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.graph_id = reader |> @lib.read_string()
+      (2, _) => msg.name = reader |> @lib.read_string() |> Some
+      (3, _) => msg.vertices.push((reader |> @lib.read_message() : Vertex))
+      (4, _) => msg.edges.push((reader |> @lib.read_message() : Edge))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1413,17 +1345,13 @@ pub impl @json.FromJson for Graph with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Graph with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Graph raise {
   let msg = Graph::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.graph_id = reader |> @lib.async_read_string()
-          (2, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.vertices.push((reader |> @lib.async_read_message() : Vertex))
-          (4, _) => msg.edges.push((reader |> @lib.async_read_message() : Edge))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.graph_id = reader |> @lib.async_read_string()
+      (2, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.vertices.push((reader |> @lib.async_read_message() : Vertex))
+      (4, _) => msg.edges.push((reader |> @lib.async_read_message() : Edge))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1497,19 +1425,15 @@ pub fn Vertex::new(vertex_id : String, label? : String, graph? : Graph, incoming
 }
 pub impl @lib.Read for Vertex with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Vertex raise {
   let msg = Vertex::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.vertex_id = reader |> @lib.read_string()
-          (2, _) => msg.label = reader |> @lib.read_string() |> Some
-          (3, _) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
-          (4, _) => msg.incoming_edges.push((reader |> @lib.read_message() : Edge))
-          (5, _) => msg.outgoing_edges.push((reader |> @lib.read_message() : Edge))
-          (6, _) => msg.adjacent_vertices.push((reader |> @lib.read_message() : Vertex))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.vertex_id = reader |> @lib.read_string()
+      (2, _) => msg.label = reader |> @lib.read_string() |> Some
+      (3, _) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
+      (4, _) => msg.incoming_edges.push((reader |> @lib.read_message() : Edge))
+      (5, _) => msg.outgoing_edges.push((reader |> @lib.read_message() : Edge))
+      (6, _) => msg.adjacent_vertices.push((reader |> @lib.read_message() : Vertex))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1590,19 +1514,15 @@ pub impl @json.FromJson for Vertex with fn from_json(json: Json, path: @json.Jso
 }
 pub impl @lib.AsyncRead for Vertex with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Vertex raise {
   let msg = Vertex::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.vertex_id = reader |> @lib.async_read_string()
-          (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
-          (4, _) => msg.incoming_edges.push((reader |> @lib.async_read_message() : Edge))
-          (5, _) => msg.outgoing_edges.push((reader |> @lib.async_read_message() : Edge))
-          (6, _) => msg.adjacent_vertices.push((reader |> @lib.async_read_message() : Vertex))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.vertex_id = reader |> @lib.async_read_string()
+      (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
+      (4, _) => msg.incoming_edges.push((reader |> @lib.async_read_message() : Edge))
+      (5, _) => msg.outgoing_edges.push((reader |> @lib.async_read_message() : Edge))
+      (6, _) => msg.adjacent_vertices.push((reader |> @lib.async_read_message() : Vertex))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1686,19 +1606,15 @@ pub fn Edge::new(edge_id : String, weight? : Double, graph? : Graph, source_vert
 }
 pub impl @lib.Read for Edge with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Edge raise {
   let msg = Edge::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.edge_id = reader |> @lib.read_string()
-          (2, _) => msg.weight = reader |> @lib.read_double() |> Some
-          (3, _) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
-          (4, _) => msg.source_vertex = (reader |> @lib.read_message() : Vertex) |> Some
-          (5, _) => msg.target_vertex = (reader |> @lib.read_message() : Vertex) |> Some
-          (6, _) => msg.parallel_edges.push((reader |> @lib.read_message() : Edge))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.edge_id = reader |> @lib.read_string()
+      (2, _) => msg.weight = reader |> @lib.read_double() |> Some
+      (3, _) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
+      (4, _) => msg.source_vertex = (reader |> @lib.read_message() : Vertex) |> Some
+      (5, _) => msg.target_vertex = (reader |> @lib.read_message() : Vertex) |> Some
+      (6, _) => msg.parallel_edges.push((reader |> @lib.read_message() : Edge))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1779,19 +1695,15 @@ pub impl @json.FromJson for Edge with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Edge with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Edge raise {
   let msg = Edge::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.edge_id = reader |> @lib.async_read_string()
-          (2, _) => msg.weight = reader |> @lib.async_read_double() |> Some
-          (3, _) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
-          (4, _) => msg.source_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
-          (5, _) => msg.target_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
-          (6, _) => msg.parallel_edges.push((reader |> @lib.async_read_message() : Edge))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.edge_id = reader |> @lib.async_read_string()
+      (2, _) => msg.weight = reader |> @lib.async_read_double() |> Some
+      (3, _) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
+      (4, _) => msg.source_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
+      (5, _) => msg.target_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
+      (6, _) => msg.parallel_edges.push((reader |> @lib.async_read_message() : Edge))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
+++ b/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
@@ -40,21 +40,16 @@ pub fn User::new(user_id : String, name : String, email? : String, orders : Arra
 }
 pub impl @lib.Read for User with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> User raise {
   let msg = User::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.user_id = reader |> @lib.read_string()
-      (2, _) => msg.name = reader |> @lib.read_string()
-      (3, _) => msg.email = reader |> @lib.read_string() |> Some
-      (4, _) => msg.orders.push((reader |> @lib.read_message() : Order))
-      (5, _) => msg.friends.push((reader |> @lib.read_message() : User))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.user_id = reader |> @lib.read_string(); true }
+      (2, _) => { msg.name = reader |> @lib.read_string(); true }
+      (3, _) => { msg.email = reader |> @lib.read_string() |> Some; true }
+      (4, _) => { msg.orders.push((reader |> @lib.read_message() : Order)); true }
+      (5, _) => { msg.friends.push((reader |> @lib.read_message() : User)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for User with fn write(self: User, writer : &@lib.Writer) -> Unit raise {
@@ -69,12 +64,12 @@ pub impl @lib.Write for User with fn write(self: User, writer : &@lib.Writer) ->
   }
   for item in self.orders {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.friends {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -119,21 +114,16 @@ pub impl @json.FromJson for User with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for User with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> User raise {
   let msg = User::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.user_id = reader |> @lib.async_read_string()
-      (2, _) => msg.name = reader |> @lib.async_read_string()
-      (3, _) => msg.email = reader |> @lib.async_read_string() |> Some
-      (4, _) => msg.orders.push((reader |> @lib.async_read_message() : Order))
-      (5, _) => msg.friends.push((reader |> @lib.async_read_message() : User))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.user_id = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.name = reader |> @lib.async_read_string(); true }
+      (3, _) => { msg.email = reader |> @lib.async_read_string() |> Some; true }
+      (4, _) => { msg.orders.push((reader |> @lib.async_read_message() : Order)); true }
+      (5, _) => { msg.friends.push((reader |> @lib.async_read_message() : User)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for User with fn write(self: User, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -148,12 +138,12 @@ pub impl @lib.AsyncWrite for User with fn write(self: User, writer : &@lib.Async
   }
   for item in self.orders {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.friends {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -199,21 +189,16 @@ pub fn Order::new(order_id : String, product_name : String, amount? : Double, cu
 }
 pub impl @lib.Read for Order with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Order raise {
   let msg = Order::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.order_id = reader |> @lib.read_string()
-      (2, _) => msg.product_name = reader |> @lib.read_string()
-      (3, _) => msg.amount = reader |> @lib.read_double() |> Some
-      (4, _) => msg.customer = (reader |> @lib.read_message() : User) |> Some
-      (5, _) => msg.related_orders.push((reader |> @lib.read_message() : Order))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.order_id = reader |> @lib.read_string(); true }
+      (2, _) => { msg.product_name = reader |> @lib.read_string(); true }
+      (3, _) => { msg.amount = reader |> @lib.read_double() |> Some; true }
+      (4, _) => { msg.customer = (reader |> @lib.read_message() : User) |> Some; true }
+      (5, _) => { msg.related_orders.push((reader |> @lib.read_message() : Order)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Order with fn write(self: Order, writer : &@lib.Writer) -> Unit raise {
@@ -228,12 +213,12 @@ pub impl @lib.Write for Order with fn write(self: Order, writer : &@lib.Writer) 
   }
   if self.customer is Some(v) {
     writer |> @lib.write_varint(34UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.related_orders {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -278,21 +263,16 @@ pub impl @json.FromJson for Order with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Order with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Order raise {
   let msg = Order::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.order_id = reader |> @lib.async_read_string()
-      (2, _) => msg.product_name = reader |> @lib.async_read_string()
-      (3, _) => msg.amount = reader |> @lib.async_read_double() |> Some
-      (4, _) => msg.customer = (reader |> @lib.async_read_message() : User) |> Some
-      (5, _) => msg.related_orders.push((reader |> @lib.async_read_message() : Order))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.order_id = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.product_name = reader |> @lib.async_read_string(); true }
+      (3, _) => { msg.amount = reader |> @lib.async_read_double() |> Some; true }
+      (4, _) => { msg.customer = (reader |> @lib.async_read_message() : User) |> Some; true }
+      (5, _) => { msg.related_orders.push((reader |> @lib.async_read_message() : Order)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Order with fn write(self: Order, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -307,12 +287,12 @@ pub impl @lib.AsyncWrite for Order with fn write(self: Order, writer : &@lib.Asy
   }
   if self.customer is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.related_orders {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -358,21 +338,16 @@ pub fn Department::new(dept_id : String, name : String, employees : Array[Employ
 }
 pub impl @lib.Read for Department with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Department raise {
   let msg = Department::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.dept_id = reader |> @lib.read_string()
-      (2, _) => msg.name = reader |> @lib.read_string()
-      (3, _) => msg.employees.push((reader |> @lib.read_message() : Employee))
-      (4, _) => msg.projects.push((reader |> @lib.read_message() : Project))
-      (5, _) => msg.parent_dept = (reader |> @lib.read_message() : Department) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.dept_id = reader |> @lib.read_string(); true }
+      (2, _) => { msg.name = reader |> @lib.read_string(); true }
+      (3, _) => { msg.employees.push((reader |> @lib.read_message() : Employee)); true }
+      (4, _) => { msg.projects.push((reader |> @lib.read_message() : Project)); true }
+      (5, _) => { msg.parent_dept = (reader |> @lib.read_message() : Department) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Department with fn write(self: Department, writer : &@lib.Writer) -> Unit raise {
@@ -382,17 +357,17 @@ pub impl @lib.Write for Department with fn write(self: Department, writer : &@li
   writer |> @lib.write_string(self.name)
   for item in self.employees {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.projects {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.parent_dept is Some(v) {
     writer |> @lib.write_varint(42UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -437,21 +412,16 @@ pub impl @json.FromJson for Department with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for Department with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Department raise {
   let msg = Department::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.dept_id = reader |> @lib.async_read_string()
-      (2, _) => msg.name = reader |> @lib.async_read_string()
-      (3, _) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
-      (4, _) => msg.projects.push((reader |> @lib.async_read_message() : Project))
-      (5, _) => msg.parent_dept = (reader |> @lib.async_read_message() : Department) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.dept_id = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.name = reader |> @lib.async_read_string(); true }
+      (3, _) => { msg.employees.push((reader |> @lib.async_read_message() : Employee)); true }
+      (4, _) => { msg.projects.push((reader |> @lib.async_read_message() : Project)); true }
+      (5, _) => { msg.parent_dept = (reader |> @lib.async_read_message() : Department) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Department with fn write(self: Department, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -461,17 +431,17 @@ pub impl @lib.AsyncWrite for Department with fn write(self: Department, writer :
   writer |> @lib.async_write_string(self.name)
   for item in self.employees {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.projects {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.parent_dept is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -523,22 +493,17 @@ pub fn Employee::new(emp_id : String, name : String, department? : Department, p
 }
 pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Employee raise {
   let msg = Employee::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.emp_id = reader |> @lib.read_string()
-      (2, _) => msg.name = reader |> @lib.read_string()
-      (3, _) => msg.department = (reader |> @lib.read_message() : Department) |> Some
-      (4, _) => msg.projects.push((reader |> @lib.read_message() : Project))
-      (5, _) => msg.supervisor = (reader |> @lib.read_message() : Employee) |> Some
-      (6, _) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.emp_id = reader |> @lib.read_string(); true }
+      (2, _) => { msg.name = reader |> @lib.read_string(); true }
+      (3, _) => { msg.department = (reader |> @lib.read_message() : Department) |> Some; true }
+      (4, _) => { msg.projects.push((reader |> @lib.read_message() : Project)); true }
+      (5, _) => { msg.supervisor = (reader |> @lib.read_message() : Employee) |> Some; true }
+      (6, _) => { msg.subordinates.push((reader |> @lib.read_message() : Employee)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Writer) -> Unit raise {
@@ -548,22 +513,22 @@ pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Wr
   writer |> @lib.write_string(self.name)
   if self.department is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.projects {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.supervisor is Some(v) {
     writer |> @lib.write_varint(42UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.subordinates {
     writer |> @lib.write_varint(50UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -613,22 +578,17 @@ pub impl @json.FromJson for Employee with fn from_json(json: Json, path: @json.J
 }
 pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Employee raise {
   let msg = Employee::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.emp_id = reader |> @lib.async_read_string()
-      (2, _) => msg.name = reader |> @lib.async_read_string()
-      (3, _) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
-      (4, _) => msg.projects.push((reader |> @lib.async_read_message() : Project))
-      (5, _) => msg.supervisor = (reader |> @lib.async_read_message() : Employee) |> Some
-      (6, _) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.emp_id = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.name = reader |> @lib.async_read_string(); true }
+      (3, _) => { msg.department = (reader |> @lib.async_read_message() : Department) |> Some; true }
+      (4, _) => { msg.projects.push((reader |> @lib.async_read_message() : Project)); true }
+      (5, _) => { msg.supervisor = (reader |> @lib.async_read_message() : Employee) |> Some; true }
+      (6, _) => { msg.subordinates.push((reader |> @lib.async_read_message() : Employee)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -638,22 +598,22 @@ pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@l
   writer |> @lib.async_write_string(self.name)
   if self.department is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.projects {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.supervisor is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.subordinates {
     writer |> @lib.async_write_varint(50UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -711,23 +671,18 @@ pub fn Project::new(project_id : String, title : String, description? : String, 
 }
 pub impl @lib.Read for Project with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Project raise {
   let msg = Project::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.project_id = reader |> @lib.read_string()
-      (2, _) => msg.title = reader |> @lib.read_string()
-      (3, _) => msg.description = reader |> @lib.read_string() |> Some
-      (4, _) => msg.department = (reader |> @lib.read_message() : Department) |> Some
-      (5, _) => msg.members.push((reader |> @lib.read_message() : Employee))
-      (6, _) => msg.dependencies.push((reader |> @lib.read_message() : Project))
-      (7, _) => msg.dependents.push((reader |> @lib.read_message() : Project))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.project_id = reader |> @lib.read_string(); true }
+      (2, _) => { msg.title = reader |> @lib.read_string(); true }
+      (3, _) => { msg.description = reader |> @lib.read_string() |> Some; true }
+      (4, _) => { msg.department = (reader |> @lib.read_message() : Department) |> Some; true }
+      (5, _) => { msg.members.push((reader |> @lib.read_message() : Employee)); true }
+      (6, _) => { msg.dependencies.push((reader |> @lib.read_message() : Project)); true }
+      (7, _) => { msg.dependents.push((reader |> @lib.read_message() : Project)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Project with fn write(self: Project, writer : &@lib.Writer) -> Unit raise {
@@ -742,22 +697,22 @@ pub impl @lib.Write for Project with fn write(self: Project, writer : &@lib.Writ
   }
   if self.department is Some(v) {
     writer |> @lib.write_varint(34UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.members {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.dependencies {
     writer |> @lib.write_varint(50UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.dependents {
     writer |> @lib.write_varint(58UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -812,23 +767,18 @@ pub impl @json.FromJson for Project with fn from_json(json: Json, path: @json.Js
 }
 pub impl @lib.AsyncRead for Project with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Project raise {
   let msg = Project::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.project_id = reader |> @lib.async_read_string()
-      (2, _) => msg.title = reader |> @lib.async_read_string()
-      (3, _) => msg.description = reader |> @lib.async_read_string() |> Some
-      (4, _) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
-      (5, _) => msg.members.push((reader |> @lib.async_read_message() : Employee))
-      (6, _) => msg.dependencies.push((reader |> @lib.async_read_message() : Project))
-      (7, _) => msg.dependents.push((reader |> @lib.async_read_message() : Project))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.project_id = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.title = reader |> @lib.async_read_string(); true }
+      (3, _) => { msg.description = reader |> @lib.async_read_string() |> Some; true }
+      (4, _) => { msg.department = (reader |> @lib.async_read_message() : Department) |> Some; true }
+      (5, _) => { msg.members.push((reader |> @lib.async_read_message() : Employee)); true }
+      (6, _) => { msg.dependencies.push((reader |> @lib.async_read_message() : Project)); true }
+      (7, _) => { msg.dependents.push((reader |> @lib.async_read_message() : Project)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Project with fn write(self: Project, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -843,22 +793,22 @@ pub impl @lib.AsyncWrite for Project with fn write(self: Project, writer : &@lib
   }
   if self.department is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.members {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.dependencies {
     writer |> @lib.async_write_varint(50UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.dependents {
     writer |> @lib.async_write_varint(58UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -906,21 +856,16 @@ pub fn Node_Connection::new(connection_id : String, type_? : String, source? : N
 }
 pub impl @lib.Read for Node_Connection with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Node_Connection raise {
   let msg = Node_Connection::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.connection_id = reader |> @lib.read_string()
-      (2, _) => msg.type_ = reader |> @lib.read_string() |> Some
-      (3, _) => msg.source = (reader |> @lib.read_message() : Node) |> Some
-      (4, _) => msg.target = (reader |> @lib.read_message() : Node) |> Some
-      (5, _) => msg.weight = (reader |> @lib.read_message() : Weight) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.connection_id = reader |> @lib.read_string(); true }
+      (2, _) => { msg.type_ = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.source = (reader |> @lib.read_message() : Node) |> Some; true }
+      (4, _) => { msg.target = (reader |> @lib.read_message() : Node) |> Some; true }
+      (5, _) => { msg.weight = (reader |> @lib.read_message() : Weight) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Node_Connection with fn write(self: Node_Connection, writer : &@lib.Writer) -> Unit raise {
@@ -933,17 +878,17 @@ pub impl @lib.Write for Node_Connection with fn write(self: Node_Connection, wri
   }
   if self.source is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.target is Some(v) {
     writer |> @lib.write_varint(34UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.weight is Some(v) {
     writer |> @lib.write_varint(42UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -989,21 +934,16 @@ pub impl @json.FromJson for Node_Connection with fn from_json(json: Json, path: 
 }
 pub impl @lib.AsyncRead for Node_Connection with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Node_Connection raise {
   let msg = Node_Connection::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.connection_id = reader |> @lib.async_read_string()
-      (2, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.source = (reader |> @lib.async_read_message() : Node) |> Some
-      (4, _) => msg.target = (reader |> @lib.async_read_message() : Node) |> Some
-      (5, _) => msg.weight = (reader |> @lib.async_read_message() : Weight) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.connection_id = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.type_ = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.source = (reader |> @lib.async_read_message() : Node) |> Some; true }
+      (4, _) => { msg.target = (reader |> @lib.async_read_message() : Node) |> Some; true }
+      (5, _) => { msg.weight = (reader |> @lib.async_read_message() : Weight) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Node_Connection with fn write(self: Node_Connection, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1016,17 +956,17 @@ pub impl @lib.AsyncWrite for Node_Connection with fn write(self: Node_Connection
   }
   if self.source is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.target is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.weight is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -1068,20 +1008,15 @@ pub fn Node::new(id : String, data? : String, connections : Array[Node_Connectio
 }
 pub impl @lib.Read for Node with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Node raise {
   let msg = Node::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.id = reader |> @lib.read_string()
-      (2, _) => msg.data = reader |> @lib.read_string() |> Some
-      (3, _) => msg.connections.push((reader |> @lib.read_message() : Node_Connection))
-      (4, _) => msg.neighbors.push((reader |> @lib.read_message() : Node))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.id = reader |> @lib.read_string(); true }
+      (2, _) => { msg.data = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.connections.push((reader |> @lib.read_message() : Node_Connection)); true }
+      (4, _) => { msg.neighbors.push((reader |> @lib.read_message() : Node)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Node with fn write(self: Node, writer : &@lib.Writer) -> Unit raise {
@@ -1094,12 +1029,12 @@ pub impl @lib.Write for Node with fn write(self: Node, writer : &@lib.Writer) ->
   }
   for item in self.connections {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.neighbors {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -1140,20 +1075,15 @@ pub impl @json.FromJson for Node with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Node with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Node raise {
   let msg = Node::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.id = reader |> @lib.async_read_string()
-      (2, _) => msg.data = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.connections.push((reader |> @lib.async_read_message() : Node_Connection))
-      (4, _) => msg.neighbors.push((reader |> @lib.async_read_message() : Node))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.id = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.data = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.connections.push((reader |> @lib.async_read_message() : Node_Connection)); true }
+      (4, _) => { msg.neighbors.push((reader |> @lib.async_read_message() : Node)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Node with fn write(self: Node, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1166,12 +1096,12 @@ pub impl @lib.AsyncWrite for Node with fn write(self: Node, writer : &@lib.Async
   }
   for item in self.connections {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.neighbors {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -1213,20 +1143,15 @@ pub fn Weight::new(value : Double, unit? : String, connection? : Node_Connection
 }
 pub impl @lib.Read for Weight with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Weight raise {
   let msg = Weight::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.value = reader |> @lib.read_double()
-      (2, _) => msg.unit = reader |> @lib.read_string() |> Some
-      (3, _) => msg.connection = (reader |> @lib.read_message() : Node_Connection) |> Some
-      (4, _) => msg.related_nodes.push((reader |> @lib.read_message() : Node))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.value = reader |> @lib.read_double(); true }
+      (2, _) => { msg.unit = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.connection = (reader |> @lib.read_message() : Node_Connection) |> Some; true }
+      (4, _) => { msg.related_nodes.push((reader |> @lib.read_message() : Node)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Weight with fn write(self: Weight, writer : &@lib.Writer) -> Unit raise {
@@ -1239,12 +1164,12 @@ pub impl @lib.Write for Weight with fn write(self: Weight, writer : &@lib.Writer
   }
   if self.connection is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.related_nodes {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -1285,20 +1210,15 @@ pub impl @json.FromJson for Weight with fn from_json(json: Json, path: @json.Jso
 }
 pub impl @lib.AsyncRead for Weight with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Weight raise {
   let msg = Weight::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.value = reader |> @lib.async_read_double()
-      (2, _) => msg.unit = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.connection = (reader |> @lib.async_read_message() : Node_Connection) |> Some
-      (4, _) => msg.related_nodes.push((reader |> @lib.async_read_message() : Node))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.value = reader |> @lib.async_read_double(); true }
+      (2, _) => { msg.unit = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.connection = (reader |> @lib.async_read_message() : Node_Connection) |> Some; true }
+      (4, _) => { msg.related_nodes.push((reader |> @lib.async_read_message() : Node)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Weight with fn write(self: Weight, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1311,12 +1231,12 @@ pub impl @lib.AsyncWrite for Weight with fn write(self: Weight, writer : &@lib.A
   }
   if self.connection is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.related_nodes {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -1358,20 +1278,15 @@ pub fn Graph::new(graph_id : String, name? : String, vertices : Array[Vertex], e
 }
 pub impl @lib.Read for Graph with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Graph raise {
   let msg = Graph::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.graph_id = reader |> @lib.read_string()
-      (2, _) => msg.name = reader |> @lib.read_string() |> Some
-      (3, _) => msg.vertices.push((reader |> @lib.read_message() : Vertex))
-      (4, _) => msg.edges.push((reader |> @lib.read_message() : Edge))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.graph_id = reader |> @lib.read_string(); true }
+      (2, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.vertices.push((reader |> @lib.read_message() : Vertex)); true }
+      (4, _) => { msg.edges.push((reader |> @lib.read_message() : Edge)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Graph with fn write(self: Graph, writer : &@lib.Writer) -> Unit raise {
@@ -1384,12 +1299,12 @@ pub impl @lib.Write for Graph with fn write(self: Graph, writer : &@lib.Writer) 
   }
   for item in self.vertices {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.edges {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -1430,20 +1345,15 @@ pub impl @json.FromJson for Graph with fn from_json(json: Json, path: @json.Json
 }
 pub impl @lib.AsyncRead for Graph with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Graph raise {
   let msg = Graph::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.graph_id = reader |> @lib.async_read_string()
-      (2, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.vertices.push((reader |> @lib.async_read_message() : Vertex))
-      (4, _) => msg.edges.push((reader |> @lib.async_read_message() : Edge))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.graph_id = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.vertices.push((reader |> @lib.async_read_message() : Vertex)); true }
+      (4, _) => { msg.edges.push((reader |> @lib.async_read_message() : Edge)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Graph with fn write(self: Graph, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1456,12 +1366,12 @@ pub impl @lib.AsyncWrite for Graph with fn write(self: Graph, writer : &@lib.Asy
   }
   for item in self.vertices {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.edges {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -1515,22 +1425,17 @@ pub fn Vertex::new(vertex_id : String, label? : String, graph? : Graph, incoming
 }
 pub impl @lib.Read for Vertex with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Vertex raise {
   let msg = Vertex::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.vertex_id = reader |> @lib.read_string()
-      (2, _) => msg.label = reader |> @lib.read_string() |> Some
-      (3, _) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
-      (4, _) => msg.incoming_edges.push((reader |> @lib.read_message() : Edge))
-      (5, _) => msg.outgoing_edges.push((reader |> @lib.read_message() : Edge))
-      (6, _) => msg.adjacent_vertices.push((reader |> @lib.read_message() : Vertex))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.vertex_id = reader |> @lib.read_string(); true }
+      (2, _) => { msg.label = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.graph = (reader |> @lib.read_message() : Graph) |> Some; true }
+      (4, _) => { msg.incoming_edges.push((reader |> @lib.read_message() : Edge)); true }
+      (5, _) => { msg.outgoing_edges.push((reader |> @lib.read_message() : Edge)); true }
+      (6, _) => { msg.adjacent_vertices.push((reader |> @lib.read_message() : Vertex)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Vertex with fn write(self: Vertex, writer : &@lib.Writer) -> Unit raise {
@@ -1543,22 +1448,22 @@ pub impl @lib.Write for Vertex with fn write(self: Vertex, writer : &@lib.Writer
   }
   if self.graph is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.incoming_edges {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.outgoing_edges {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.adjacent_vertices {
     writer |> @lib.write_varint(50UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -1609,22 +1514,17 @@ pub impl @json.FromJson for Vertex with fn from_json(json: Json, path: @json.Jso
 }
 pub impl @lib.AsyncRead for Vertex with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Vertex raise {
   let msg = Vertex::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.vertex_id = reader |> @lib.async_read_string()
-      (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
-      (4, _) => msg.incoming_edges.push((reader |> @lib.async_read_message() : Edge))
-      (5, _) => msg.outgoing_edges.push((reader |> @lib.async_read_message() : Edge))
-      (6, _) => msg.adjacent_vertices.push((reader |> @lib.async_read_message() : Vertex))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.vertex_id = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.label = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some; true }
+      (4, _) => { msg.incoming_edges.push((reader |> @lib.async_read_message() : Edge)); true }
+      (5, _) => { msg.outgoing_edges.push((reader |> @lib.async_read_message() : Edge)); true }
+      (6, _) => { msg.adjacent_vertices.push((reader |> @lib.async_read_message() : Vertex)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Vertex with fn write(self: Vertex, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1637,22 +1537,22 @@ pub impl @lib.AsyncWrite for Vertex with fn write(self: Vertex, writer : &@lib.A
   }
   if self.graph is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.incoming_edges {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.outgoing_edges {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.adjacent_vertices {
     writer |> @lib.async_write_varint(50UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -1706,22 +1606,17 @@ pub fn Edge::new(edge_id : String, weight? : Double, graph? : Graph, source_vert
 }
 pub impl @lib.Read for Edge with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> Edge raise {
   let msg = Edge::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.edge_id = reader |> @lib.read_string()
-      (2, _) => msg.weight = reader |> @lib.read_double() |> Some
-      (3, _) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
-      (4, _) => msg.source_vertex = (reader |> @lib.read_message() : Vertex) |> Some
-      (5, _) => msg.target_vertex = (reader |> @lib.read_message() : Vertex) |> Some
-      (6, _) => msg.parallel_edges.push((reader |> @lib.read_message() : Edge))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.edge_id = reader |> @lib.read_string(); true }
+      (2, _) => { msg.weight = reader |> @lib.read_double() |> Some; true }
+      (3, _) => { msg.graph = (reader |> @lib.read_message() : Graph) |> Some; true }
+      (4, _) => { msg.source_vertex = (reader |> @lib.read_message() : Vertex) |> Some; true }
+      (5, _) => { msg.target_vertex = (reader |> @lib.read_message() : Vertex) |> Some; true }
+      (6, _) => { msg.parallel_edges.push((reader |> @lib.read_message() : Edge)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for Edge with fn write(self: Edge, writer : &@lib.Writer) -> Unit raise {
@@ -1734,22 +1629,22 @@ pub impl @lib.Write for Edge with fn write(self: Edge, writer : &@lib.Writer) ->
   }
   if self.graph is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.source_vertex is Some(v) {
     writer |> @lib.write_varint(34UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.target_vertex is Some(v) {
     writer |> @lib.write_varint(42UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.parallel_edges {
     writer |> @lib.write_varint(50UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -1800,22 +1695,17 @@ pub impl @json.FromJson for Edge with fn from_json(json: Json, path: @json.JsonP
 }
 pub impl @lib.AsyncRead for Edge with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> Edge raise {
   let msg = Edge::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.edge_id = reader |> @lib.async_read_string()
-      (2, _) => msg.weight = reader |> @lib.async_read_double() |> Some
-      (3, _) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
-      (4, _) => msg.source_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
-      (5, _) => msg.target_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
-      (6, _) => msg.parallel_edges.push((reader |> @lib.async_read_message() : Edge))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.edge_id = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.weight = reader |> @lib.async_read_double() |> Some; true }
+      (3, _) => { msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some; true }
+      (4, _) => { msg.source_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some; true }
+      (5, _) => { msg.target_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some; true }
+      (6, _) => { msg.parallel_edges.push((reader |> @lib.async_read_message() : Edge)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for Edge with fn write(self: Edge, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1828,22 +1718,22 @@ pub impl @lib.AsyncWrite for Edge with fn write(self: Edge, writer : &@lib.Async
   }
   if self.graph is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.source_vertex is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.target_vertex is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.parallel_edges {
     writer |> @lib.async_write_varint(50UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -162,23 +162,18 @@ pub fn FileDescriptorSet::new(file : Array[FileDescriptorProto]) -> FileDescript
 }
 pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.file.push((reader |> @lib.read_message() : FileDescriptorProto)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FileDescriptorSet with fn write(self: FileDescriptorSet, writer : &@lib.Writer) -> Unit raise {
   for item in self.file {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -205,23 +200,18 @@ pub impl @json.FromJson for FileDescriptorSet with fn from_json(json: Json, path
 }
 pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.file.push((reader |> @lib.async_read_message() : FileDescriptorProto))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.file.push((reader |> @lib.async_read_message() : FileDescriptorProto)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FileDescriptorSet with fn write(self: FileDescriptorSet, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.file {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -325,32 +315,27 @@ pub fn FileDescriptorProto::new(name? : String, package_? : String, dependency :
 }
 pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
-      (3, _) => msg.dependency.push(reader |> @lib.read_string())
-      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
-      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
-      (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
-      (4, _) => msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
-      (5, _) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
-      (6, _) => msg.service.push((reader |> @lib.read_message() : ServiceDescriptorProto))
-      (7, _) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
-      (8, _) => msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
-      (9, _) => msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo) |> Some
-      (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
-      (14, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
+      (2, _) => { msg.package_ = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.dependency.push(reader |> @lib.read_string()); true }
+      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
+      (10, 0) => { msg.public_dependency.push(reader |> @lib.read_int32()); true }
+      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
+      (11, 0) => { msg.weak_dependency.push(reader |> @lib.read_int32()); true }
+      (15, _) => { msg.option_dependency.push(reader |> @lib.read_string()); true }
+      (4, _) => { msg.message_type.push((reader |> @lib.read_message() : DescriptorProto)); true }
+      (5, _) => { msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto)); true }
+      (6, _) => { msg.service.push((reader |> @lib.read_message() : ServiceDescriptorProto)); true }
+      (7, _) => { msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto)); true }
+      (8, _) => { msg.options = (reader |> @lib.read_message() : FileOptions) |> Some; true }
+      (9, _) => { msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo) |> Some; true }
+      (12, _) => { msg.syntax = reader |> @lib.read_string() |> Some; true }
+      (14, _) => { msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FileDescriptorProto with fn write(self: FileDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -386,32 +371,32 @@ pub impl @lib.Write for FileDescriptorProto with fn write(self: FileDescriptorPr
   }
   for item in self.message_type {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.enum_type {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.service {
     writer |> @lib.write_varint(50UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.extension {
     writer |> @lib.write_varint(58UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(66UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.source_code_info is Some(v) {
     writer |> @lib.write_varint(74UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.syntax is Some(v) {
@@ -513,32 +498,27 @@ pub impl @json.FromJson for FileDescriptorProto with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
-      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (10, 0) => msg.public_dependency.push(reader |> @lib.async_read_int32())
-      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
-      (15, _) => msg.option_dependency.push(reader |> @lib.async_read_string())
-      (4, _) => msg.message_type.push((reader |> @lib.async_read_message() : DescriptorProto))
-      (5, _) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
-      (6, _) => msg.service.push((reader |> @lib.async_read_message() : ServiceDescriptorProto))
-      (7, _) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-      (8, _) => msg.options = (reader |> @lib.async_read_message() : FileOptions) |> Some
-      (9, _) => msg.source_code_info = (reader |> @lib.async_read_message() : SourceCodeInfo) |> Some
-      (12, _) => msg.syntax = reader |> @lib.async_read_string() |> Some
-      (14, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
+      (2, _) => { msg.package_ = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.dependency.push(reader |> @lib.async_read_string()); true }
+      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
+      (10, 0) => { msg.public_dependency.push(reader |> @lib.async_read_int32()); true }
+      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
+      (11, 0) => { msg.weak_dependency.push(reader |> @lib.async_read_int32()); true }
+      (15, _) => { msg.option_dependency.push(reader |> @lib.async_read_string()); true }
+      (4, _) => { msg.message_type.push((reader |> @lib.async_read_message() : DescriptorProto)); true }
+      (5, _) => { msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto)); true }
+      (6, _) => { msg.service.push((reader |> @lib.async_read_message() : ServiceDescriptorProto)); true }
+      (7, _) => { msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto)); true }
+      (8, _) => { msg.options = (reader |> @lib.async_read_message() : FileOptions) |> Some; true }
+      (9, _) => { msg.source_code_info = (reader |> @lib.async_read_message() : SourceCodeInfo) |> Some; true }
+      (12, _) => { msg.syntax = reader |> @lib.async_read_string() |> Some; true }
+      (14, _) => { msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FileDescriptorProto with fn write(self: FileDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -574,32 +554,32 @@ pub impl @lib.AsyncWrite for FileDescriptorProto with fn write(self: FileDescrip
   }
   for item in self.message_type {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.enum_type {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.service {
     writer |> @lib.async_write_varint(50UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.extension {
     writer |> @lib.async_write_varint(58UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(66UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.source_code_info is Some(v) {
     writer |> @lib.async_write_varint(74UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.syntax is Some(v) {
@@ -647,19 +627,14 @@ pub fn DescriptorProto_ExtensionRange::new(start? : Int, end? : Int, options? : 
 }
 pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-      (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-      (3, _) => msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.start = reader |> @lib.read_int32() |> Some; true }
+      (2, _) => { msg.end = reader |> @lib.read_int32() |> Some; true }
+      (3, _) => { msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for DescriptorProto_ExtensionRange with fn write(self: DescriptorProto_ExtensionRange, writer : &@lib.Writer) -> Unit raise {
@@ -675,7 +650,7 @@ pub impl @lib.Write for DescriptorProto_ExtensionRange with fn write(self: Descr
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -712,19 +687,14 @@ pub impl @json.FromJson for DescriptorProto_ExtensionRange with fn from_json(jso
 }
 pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-      (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-      (3, _) => msg.options = (reader |> @lib.async_read_message() : ExtensionRangeOptions) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.start = reader |> @lib.async_read_int32() |> Some; true }
+      (2, _) => { msg.end = reader |> @lib.async_read_int32() |> Some; true }
+      (3, _) => { msg.options = (reader |> @lib.async_read_message() : ExtensionRangeOptions) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for DescriptorProto_ExtensionRange with fn write(self: DescriptorProto_ExtensionRange, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -740,7 +710,7 @@ pub impl @lib.AsyncWrite for DescriptorProto_ExtensionRange with fn write(self: 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -772,18 +742,13 @@ pub fn DescriptorProto_ReservedRange::new(start? : Int, end? : Int) -> Descripto
 }
 pub impl @lib.Read for DescriptorProto_ReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-      (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.start = reader |> @lib.read_int32() |> Some; true }
+      (2, _) => { msg.end = reader |> @lib.read_int32() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for DescriptorProto_ReservedRange with fn write(self: DescriptorProto_ReservedRange, writer : &@lib.Writer) -> Unit raise {
@@ -826,18 +791,13 @@ pub impl @json.FromJson for DescriptorProto_ReservedRange with fn from_json(json
 }
 pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-      (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.start = reader |> @lib.async_read_int32() |> Some; true }
+      (2, _) => { msg.end = reader |> @lib.async_read_int32() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for DescriptorProto_ReservedRange with fn write(self: DescriptorProto_ReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -934,27 +894,22 @@ pub fn DescriptorProto::new(name? : String, field : Array[FieldDescriptorProto],
 }
 pub impl @lib.Read for DescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
-      (6, _) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
-      (3, _) => msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto))
-      (4, _) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
-      (5, _) => msg.extension_range.push((reader |> @lib.read_message() : DescriptorProto_ExtensionRange))
-      (8, _) => msg.oneof_decl.push((reader |> @lib.read_message() : OneofDescriptorProto))
-      (7, _) => msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
-      (9, _) => msg.reserved_range.push((reader |> @lib.read_message() : DescriptorProto_ReservedRange))
-      (10, _) => msg.reserved_name.push(reader |> @lib.read_string())
-      (11, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
+      (2, _) => { msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto)); true }
+      (6, _) => { msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto)); true }
+      (3, _) => { msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto)); true }
+      (4, _) => { msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto)); true }
+      (5, _) => { msg.extension_range.push((reader |> @lib.read_message() : DescriptorProto_ExtensionRange)); true }
+      (8, _) => { msg.oneof_decl.push((reader |> @lib.read_message() : OneofDescriptorProto)); true }
+      (7, _) => { msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some; true }
+      (9, _) => { msg.reserved_range.push((reader |> @lib.read_message() : DescriptorProto_ReservedRange)); true }
+      (10, _) => { msg.reserved_name.push(reader |> @lib.read_string()); true }
+      (11, _) => { msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for DescriptorProto with fn write(self: DescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -965,42 +920,42 @@ pub impl @lib.Write for DescriptorProto with fn write(self: DescriptorProto, wri
   }
   for item in self.field {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.extension {
     writer |> @lib.write_varint(50UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.nested_type {
     writer |> @lib.write_varint(26UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.enum_type {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.extension_range {
     writer |> @lib.write_varint(42UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.oneof_decl {
     writer |> @lib.write_varint(66UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(58UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.reserved_range {
     writer |> @lib.write_varint(74UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.reserved_name {
@@ -1087,27 +1042,22 @@ pub impl @json.FromJson for DescriptorProto with fn from_json(json: Json, path: 
 }
 pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.field.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-      (6, _) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-      (3, _) => msg.nested_type.push((reader |> @lib.async_read_message() : DescriptorProto))
-      (4, _) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
-      (5, _) => msg.extension_range.push((reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange))
-      (8, _) => msg.oneof_decl.push((reader |> @lib.async_read_message() : OneofDescriptorProto))
-      (7, _) => msg.options = (reader |> @lib.async_read_message() : MessageOptions) |> Some
-      (9, _) => msg.reserved_range.push((reader |> @lib.async_read_message() : DescriptorProto_ReservedRange))
-      (10, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
-      (11, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
+      (2, _) => { msg.field.push((reader |> @lib.async_read_message() : FieldDescriptorProto)); true }
+      (6, _) => { msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto)); true }
+      (3, _) => { msg.nested_type.push((reader |> @lib.async_read_message() : DescriptorProto)); true }
+      (4, _) => { msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto)); true }
+      (5, _) => { msg.extension_range.push((reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange)); true }
+      (8, _) => { msg.oneof_decl.push((reader |> @lib.async_read_message() : OneofDescriptorProto)); true }
+      (7, _) => { msg.options = (reader |> @lib.async_read_message() : MessageOptions) |> Some; true }
+      (9, _) => { msg.reserved_range.push((reader |> @lib.async_read_message() : DescriptorProto_ReservedRange)); true }
+      (10, _) => { msg.reserved_name.push(reader |> @lib.async_read_string()); true }
+      (11, _) => { msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for DescriptorProto with fn write(self: DescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1118,42 +1068,42 @@ pub impl @lib.AsyncWrite for DescriptorProto with fn write(self: DescriptorProto
   }
   for item in self.field {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.extension {
     writer |> @lib.async_write_varint(50UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.nested_type {
     writer |> @lib.async_write_varint(26UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.enum_type {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.extension_range {
     writer |> @lib.async_write_varint(42UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.oneof_decl {
     writer |> @lib.async_write_varint(66UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(58UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.reserved_range {
     writer |> @lib.async_write_varint(74UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.reserved_name {
@@ -1251,21 +1201,16 @@ pub fn ExtensionRangeOptions_Declaration::new(number? : Int, full_name? : String
 }
 pub impl @lib.Read for ExtensionRangeOptions_Declaration with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.number = reader |> @lib.read_int32() |> Some
-      (2, _) => msg.full_name = reader |> @lib.read_string() |> Some
-      (3, _) => msg.type_ = reader |> @lib.read_string() |> Some
-      (5, _) => msg.reserved = reader |> @lib.read_bool() |> Some
-      (6, _) => msg.repeated = reader |> @lib.read_bool() |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.number = reader |> @lib.read_int32() |> Some; true }
+      (2, _) => { msg.full_name = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.type_ = reader |> @lib.read_string() |> Some; true }
+      (5, _) => { msg.reserved = reader |> @lib.read_bool() |> Some; true }
+      (6, _) => { msg.repeated = reader |> @lib.read_bool() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for ExtensionRangeOptions_Declaration with fn write(self: ExtensionRangeOptions_Declaration, writer : &@lib.Writer) -> Unit raise {
@@ -1338,21 +1283,16 @@ pub impl @json.FromJson for ExtensionRangeOptions_Declaration with fn from_json(
 }
 pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-      (2, _) => msg.full_name = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
-      (5, _) => msg.reserved = reader |> @lib.async_read_bool() |> Some
-      (6, _) => msg.repeated = reader |> @lib.async_read_bool() |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.number = reader |> @lib.async_read_int32() |> Some; true }
+      (2, _) => { msg.full_name = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.type_ = reader |> @lib.async_read_string() |> Some; true }
+      (5, _) => { msg.reserved = reader |> @lib.async_read_bool() |> Some; true }
+      (6, _) => { msg.repeated = reader |> @lib.async_read_bool() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for ExtensionRangeOptions_Declaration with fn write(self: ExtensionRangeOptions_Declaration, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1422,36 +1362,31 @@ pub fn ExtensionRangeOptions::new(uninterpreted_option : Array[UninterpretedOpti
 }
 pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-      (2, _) => msg.declaration.push((reader |> @lib.read_message() : ExtensionRangeOptions_Declaration))
-      (50, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (3, _) => msg.verification = reader |> @lib.read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
+      (2, _) => { msg.declaration.push((reader |> @lib.read_message() : ExtensionRangeOptions_Declaration)); true }
+      (50, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
+      (3, _) => { msg.verification = reader |> @lib.read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for ExtensionRangeOptions with fn write(self: ExtensionRangeOptions, writer : &@lib.Writer) -> Unit raise {
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.declaration {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(402UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.verification is Some(v) {
@@ -1498,36 +1433,31 @@ pub impl @json.FromJson for ExtensionRangeOptions with fn from_json(json: Json, 
 }
 pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-      (2, _) => msg.declaration.push((reader |> @lib.async_read_message() : ExtensionRangeOptions_Declaration))
-      (50, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (3, _) => msg.verification = reader |> @lib.async_read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
+      (2, _) => { msg.declaration.push((reader |> @lib.async_read_message() : ExtensionRangeOptions_Declaration)); true }
+      (50, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
+      (3, _) => { msg.verification = reader |> @lib.async_read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for ExtensionRangeOptions with fn write(self: ExtensionRangeOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.declaration {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(402UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.verification is Some(v) {
@@ -1796,27 +1726,22 @@ pub fn FieldDescriptorProto::new(name? : String, number? : Int, label? : FieldDe
 }
 pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (3, _) => msg.number = reader |> @lib.read_int32() |> Some
-      (4, _) => msg.label = reader |> @lib.read_enum() |> FieldDescriptorProto_Label::from_enum |> Some
-      (5, _) => msg.type_ = reader |> @lib.read_enum() |> FieldDescriptorProto_Type::from_enum |> Some
-      (6, _) => msg.type_name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.extendee = reader |> @lib.read_string() |> Some
-      (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
-      (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
-      (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
-      (8, _) => msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
-      (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.number = reader |> @lib.read_int32() |> Some; true }
+      (4, _) => { msg.label = reader |> @lib.read_enum() |> FieldDescriptorProto_Label::from_enum |> Some; true }
+      (5, _) => { msg.type_ = reader |> @lib.read_enum() |> FieldDescriptorProto_Type::from_enum |> Some; true }
+      (6, _) => { msg.type_name = reader |> @lib.read_string() |> Some; true }
+      (2, _) => { msg.extendee = reader |> @lib.read_string() |> Some; true }
+      (7, _) => { msg.default_value = reader |> @lib.read_string() |> Some; true }
+      (9, _) => { msg.oneof_index = reader |> @lib.read_int32() |> Some; true }
+      (10, _) => { msg.json_name = reader |> @lib.read_string() |> Some; true }
+      (8, _) => { msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some; true }
+      (17, _) => { msg.proto3_optional = reader |> @lib.read_bool() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FieldDescriptorProto with fn write(self: FieldDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -1867,7 +1792,7 @@ pub impl @lib.Write for FieldDescriptorProto with fn write(self: FieldDescriptor
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(66UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.proto3_optional is Some(v) {
@@ -1949,27 +1874,22 @@ pub impl @json.FromJson for FieldDescriptorProto with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-      (4, _) => msg.label = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Label::from_enum |> Some
-      (5, _) => msg.type_ = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Type::from_enum |> Some
-      (6, _) => msg.type_name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.extendee = reader |> @lib.async_read_string() |> Some
-      (7, _) => msg.default_value = reader |> @lib.async_read_string() |> Some
-      (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
-      (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
-      (8, _) => msg.options = (reader |> @lib.async_read_message() : FieldOptions) |> Some
-      (17, _) => msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.number = reader |> @lib.async_read_int32() |> Some; true }
+      (4, _) => { msg.label = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Label::from_enum |> Some; true }
+      (5, _) => { msg.type_ = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Type::from_enum |> Some; true }
+      (6, _) => { msg.type_name = reader |> @lib.async_read_string() |> Some; true }
+      (2, _) => { msg.extendee = reader |> @lib.async_read_string() |> Some; true }
+      (7, _) => { msg.default_value = reader |> @lib.async_read_string() |> Some; true }
+      (9, _) => { msg.oneof_index = reader |> @lib.async_read_int32() |> Some; true }
+      (10, _) => { msg.json_name = reader |> @lib.async_read_string() |> Some; true }
+      (8, _) => { msg.options = (reader |> @lib.async_read_message() : FieldOptions) |> Some; true }
+      (17, _) => { msg.proto3_optional = reader |> @lib.async_read_bool() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FieldDescriptorProto with fn write(self: FieldDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2020,7 +1940,7 @@ pub impl @lib.AsyncWrite for FieldDescriptorProto with fn write(self: FieldDescr
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(66UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.proto3_optional is Some(v) {
@@ -2057,18 +1977,13 @@ pub fn OneofDescriptorProto::new(name? : String, options? : OneofOptions) -> One
 }
 pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
+      (2, _) => { msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for OneofDescriptorProto with fn write(self: OneofDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -2079,7 +1994,7 @@ pub impl @lib.Write for OneofDescriptorProto with fn write(self: OneofDescriptor
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(18UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -2111,18 +2026,13 @@ pub impl @json.FromJson for OneofDescriptorProto with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.options = (reader |> @lib.async_read_message() : OneofOptions) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
+      (2, _) => { msg.options = (reader |> @lib.async_read_message() : OneofOptions) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for OneofDescriptorProto with fn write(self: OneofDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2133,7 +2043,7 @@ pub impl @lib.AsyncWrite for OneofDescriptorProto with fn write(self: OneofDescr
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -2165,18 +2075,13 @@ pub fn EnumDescriptorProto_EnumReservedRange::new(start? : Int, end? : Int) -> E
 }
 pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-      (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.start = reader |> @lib.read_int32() |> Some; true }
+      (2, _) => { msg.end = reader |> @lib.read_int32() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for EnumDescriptorProto_EnumReservedRange with fn write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.Writer) -> Unit raise {
@@ -2219,18 +2124,13 @@ pub impl @json.FromJson for EnumDescriptorProto_EnumReservedRange with fn from_j
 }
 pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-      (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.start = reader |> @lib.async_read_int32() |> Some; true }
+      (2, _) => { msg.end = reader |> @lib.async_read_int32() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for EnumDescriptorProto_EnumReservedRange with fn write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2297,22 +2197,17 @@ pub fn EnumDescriptorProto::new(name? : String, value : Array[EnumValueDescripto
 }
 pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.value.push((reader |> @lib.read_message() : EnumValueDescriptorProto))
-      (3, _) => msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
-      (4, _) => msg.reserved_range.push((reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange))
-      (5, _) => msg.reserved_name.push(reader |> @lib.read_string())
-      (6, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
+      (2, _) => { msg.value.push((reader |> @lib.read_message() : EnumValueDescriptorProto)); true }
+      (3, _) => { msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some; true }
+      (4, _) => { msg.reserved_range.push((reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange)); true }
+      (5, _) => { msg.reserved_name.push(reader |> @lib.read_string()); true }
+      (6, _) => { msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for EnumDescriptorProto with fn write(self: EnumDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -2323,17 +2218,17 @@ pub impl @lib.Write for EnumDescriptorProto with fn write(self: EnumDescriptorPr
   }
   for item in self.value {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.reserved_range {
     writer |> @lib.write_varint(34UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   for item in self.reserved_name {
@@ -2395,22 +2290,17 @@ pub impl @json.FromJson for EnumDescriptorProto with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.value.push((reader |> @lib.async_read_message() : EnumValueDescriptorProto))
-      (3, _) => msg.options = (reader |> @lib.async_read_message() : EnumOptions) |> Some
-      (4, _) => msg.reserved_range.push((reader |> @lib.async_read_message() : EnumDescriptorProto_EnumReservedRange))
-      (5, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
-      (6, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
+      (2, _) => { msg.value.push((reader |> @lib.async_read_message() : EnumValueDescriptorProto)); true }
+      (3, _) => { msg.options = (reader |> @lib.async_read_message() : EnumOptions) |> Some; true }
+      (4, _) => { msg.reserved_range.push((reader |> @lib.async_read_message() : EnumDescriptorProto_EnumReservedRange)); true }
+      (5, _) => { msg.reserved_name.push(reader |> @lib.async_read_string()); true }
+      (6, _) => { msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for EnumDescriptorProto with fn write(self: EnumDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2421,17 +2311,17 @@ pub impl @lib.AsyncWrite for EnumDescriptorProto with fn write(self: EnumDescrip
   }
   for item in self.value {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.reserved_range {
     writer |> @lib.async_write_varint(34UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   for item in self.reserved_name {
@@ -2479,19 +2369,14 @@ pub fn EnumValueDescriptorProto::new(name? : String, number? : Int, options? : E
 }
 pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.number = reader |> @lib.read_int32() |> Some
-      (3, _) => msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
+      (2, _) => { msg.number = reader |> @lib.read_int32() |> Some; true }
+      (3, _) => { msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for EnumValueDescriptorProto with fn write(self: EnumValueDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -2507,7 +2392,7 @@ pub impl @lib.Write for EnumValueDescriptorProto with fn write(self: EnumValueDe
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -2544,19 +2429,14 @@ pub impl @json.FromJson for EnumValueDescriptorProto with fn from_json(json: Jso
 }
 pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-      (3, _) => msg.options = (reader |> @lib.async_read_message() : EnumValueOptions) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
+      (2, _) => { msg.number = reader |> @lib.async_read_int32() |> Some; true }
+      (3, _) => { msg.options = (reader |> @lib.async_read_message() : EnumValueOptions) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for EnumValueDescriptorProto with fn write(self: EnumValueDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2572,7 +2452,7 @@ pub impl @lib.AsyncWrite for EnumValueDescriptorProto with fn write(self: EnumVa
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -2610,19 +2490,14 @@ pub fn ServiceDescriptorProto::new(name? : String, method_ : Array[MethodDescrip
 }
 pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.method_.push((reader |> @lib.read_message() : MethodDescriptorProto))
-      (3, _) => msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
+      (2, _) => { msg.method_.push((reader |> @lib.read_message() : MethodDescriptorProto)); true }
+      (3, _) => { msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for ServiceDescriptorProto with fn write(self: ServiceDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -2633,12 +2508,12 @@ pub impl @lib.Write for ServiceDescriptorProto with fn write(self: ServiceDescri
   }
   for item in self.method_ {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -2675,19 +2550,14 @@ pub impl @json.FromJson for ServiceDescriptorProto with fn from_json(json: Json,
 }
 pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.method_.push((reader |> @lib.async_read_message() : MethodDescriptorProto))
-      (3, _) => msg.options = (reader |> @lib.async_read_message() : ServiceOptions) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
+      (2, _) => { msg.method_.push((reader |> @lib.async_read_message() : MethodDescriptorProto)); true }
+      (3, _) => { msg.options = (reader |> @lib.async_read_message() : ServiceOptions) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for ServiceDescriptorProto with fn write(self: ServiceDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2698,12 +2568,12 @@ pub impl @lib.AsyncWrite for ServiceDescriptorProto with fn write(self: ServiceD
   }
   for item in self.method_ {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -2759,22 +2629,17 @@ pub fn MethodDescriptorProto::new(name? : String, input_type? : String, output_t
 }
 pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
-      (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
-      (4, _) => msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
-      (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
-      (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
+      (2, _) => { msg.input_type = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.output_type = reader |> @lib.read_string() |> Some; true }
+      (4, _) => { msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some; true }
+      (5, _) => { msg.client_streaming = reader |> @lib.read_bool() |> Some; true }
+      (6, _) => { msg.server_streaming = reader |> @lib.read_bool() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for MethodDescriptorProto with fn write(self: MethodDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -2795,7 +2660,7 @@ pub impl @lib.Write for MethodDescriptorProto with fn write(self: MethodDescript
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(34UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.client_streaming is Some(v) {
@@ -2857,22 +2722,17 @@ pub impl @json.FromJson for MethodDescriptorProto with fn from_json(json: Json, 
 }
 pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
-      (4, _) => msg.options = (reader |> @lib.async_read_message() : MethodOptions) |> Some
-      (5, _) => msg.client_streaming = reader |> @lib.async_read_bool() |> Some
-      (6, _) => msg.server_streaming = reader |> @lib.async_read_bool() |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
+      (2, _) => { msg.input_type = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.output_type = reader |> @lib.async_read_string() |> Some; true }
+      (4, _) => { msg.options = (reader |> @lib.async_read_message() : MethodOptions) |> Some; true }
+      (5, _) => { msg.client_streaming = reader |> @lib.async_read_bool() |> Some; true }
+      (6, _) => { msg.server_streaming = reader |> @lib.async_read_bool() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for MethodDescriptorProto with fn write(self: MethodDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2893,7 +2753,7 @@ pub impl @lib.AsyncWrite for MethodDescriptorProto with fn write(self: MethodDes
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.client_streaming is Some(v) {
@@ -3093,37 +2953,32 @@ pub fn FileOptions::new(java_package? : String, java_outer_classname? : String, 
 }
 pub impl @lib.Read for FileOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileOptions raise {
   let msg = FileOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.java_package = reader |> @lib.read_string() |> Some
-      (8, _) => msg.java_outer_classname = reader |> @lib.read_string() |> Some
-      (10, _) => msg.java_multiple_files = reader |> @lib.read_bool() |> Some
-      (20, _) => msg.java_generate_equals_and_hash = reader |> @lib.read_bool() |> Some
-      (27, _) => msg.java_string_check_utf8 = reader |> @lib.read_bool() |> Some
-      (9, _) => msg.optimize_for = reader |> @lib.read_enum() |> FileOptions_OptimizeMode::from_enum |> Some
-      (11, _) => msg.go_package = reader |> @lib.read_string() |> Some
-      (16, _) => msg.cc_generic_services = reader |> @lib.read_bool() |> Some
-      (17, _) => msg.java_generic_services = reader |> @lib.read_bool() |> Some
-      (18, _) => msg.py_generic_services = reader |> @lib.read_bool() |> Some
-      (23, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (31, _) => msg.cc_enable_arenas = reader |> @lib.read_bool() |> Some
-      (36, _) => msg.objc_class_prefix = reader |> @lib.read_string() |> Some
-      (37, _) => msg.csharp_namespace = reader |> @lib.read_string() |> Some
-      (39, _) => msg.swift_prefix = reader |> @lib.read_string() |> Some
-      (40, _) => msg.php_class_prefix = reader |> @lib.read_string() |> Some
-      (41, _) => msg.php_namespace = reader |> @lib.read_string() |> Some
-      (44, _) => msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
-      (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
-      (50, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.java_package = reader |> @lib.read_string() |> Some; true }
+      (8, _) => { msg.java_outer_classname = reader |> @lib.read_string() |> Some; true }
+      (10, _) => { msg.java_multiple_files = reader |> @lib.read_bool() |> Some; true }
+      (20, _) => { msg.java_generate_equals_and_hash = reader |> @lib.read_bool() |> Some; true }
+      (27, _) => { msg.java_string_check_utf8 = reader |> @lib.read_bool() |> Some; true }
+      (9, _) => { msg.optimize_for = reader |> @lib.read_enum() |> FileOptions_OptimizeMode::from_enum |> Some; true }
+      (11, _) => { msg.go_package = reader |> @lib.read_string() |> Some; true }
+      (16, _) => { msg.cc_generic_services = reader |> @lib.read_bool() |> Some; true }
+      (17, _) => { msg.java_generic_services = reader |> @lib.read_bool() |> Some; true }
+      (18, _) => { msg.py_generic_services = reader |> @lib.read_bool() |> Some; true }
+      (23, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
+      (31, _) => { msg.cc_enable_arenas = reader |> @lib.read_bool() |> Some; true }
+      (36, _) => { msg.objc_class_prefix = reader |> @lib.read_string() |> Some; true }
+      (37, _) => { msg.csharp_namespace = reader |> @lib.read_string() |> Some; true }
+      (39, _) => { msg.swift_prefix = reader |> @lib.read_string() |> Some; true }
+      (40, _) => { msg.php_class_prefix = reader |> @lib.read_string() |> Some; true }
+      (41, _) => { msg.php_namespace = reader |> @lib.read_string() |> Some; true }
+      (44, _) => { msg.php_metadata_namespace = reader |> @lib.read_string() |> Some; true }
+      (45, _) => { msg.ruby_package = reader |> @lib.read_string() |> Some; true }
+      (50, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FileOptions with fn write(self: FileOptions, writer : &@lib.Writer) -> Unit raise {
@@ -3224,12 +3079,12 @@ pub impl @lib.Write for FileOptions with fn write(self: FileOptions, writer : &@
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(402UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -3356,37 +3211,32 @@ pub impl @json.FromJson for FileOptions with fn from_json(json: Json, path: @jso
 }
 pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileOptions raise {
   let msg = FileOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.java_package = reader |> @lib.async_read_string() |> Some
-      (8, _) => msg.java_outer_classname = reader |> @lib.async_read_string() |> Some
-      (10, _) => msg.java_multiple_files = reader |> @lib.async_read_bool() |> Some
-      (20, _) => msg.java_generate_equals_and_hash = reader |> @lib.async_read_bool() |> Some
-      (27, _) => msg.java_string_check_utf8 = reader |> @lib.async_read_bool() |> Some
-      (9, _) => msg.optimize_for = reader |> @lib.async_read_enum() |> FileOptions_OptimizeMode::from_enum |> Some
-      (11, _) => msg.go_package = reader |> @lib.async_read_string() |> Some
-      (16, _) => msg.cc_generic_services = reader |> @lib.async_read_bool() |> Some
-      (17, _) => msg.java_generic_services = reader |> @lib.async_read_bool() |> Some
-      (18, _) => msg.py_generic_services = reader |> @lib.async_read_bool() |> Some
-      (23, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (31, _) => msg.cc_enable_arenas = reader |> @lib.async_read_bool() |> Some
-      (36, _) => msg.objc_class_prefix = reader |> @lib.async_read_string() |> Some
-      (37, _) => msg.csharp_namespace = reader |> @lib.async_read_string() |> Some
-      (39, _) => msg.swift_prefix = reader |> @lib.async_read_string() |> Some
-      (40, _) => msg.php_class_prefix = reader |> @lib.async_read_string() |> Some
-      (41, _) => msg.php_namespace = reader |> @lib.async_read_string() |> Some
-      (44, _) => msg.php_metadata_namespace = reader |> @lib.async_read_string() |> Some
-      (45, _) => msg.ruby_package = reader |> @lib.async_read_string() |> Some
-      (50, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.java_package = reader |> @lib.async_read_string() |> Some; true }
+      (8, _) => { msg.java_outer_classname = reader |> @lib.async_read_string() |> Some; true }
+      (10, _) => { msg.java_multiple_files = reader |> @lib.async_read_bool() |> Some; true }
+      (20, _) => { msg.java_generate_equals_and_hash = reader |> @lib.async_read_bool() |> Some; true }
+      (27, _) => { msg.java_string_check_utf8 = reader |> @lib.async_read_bool() |> Some; true }
+      (9, _) => { msg.optimize_for = reader |> @lib.async_read_enum() |> FileOptions_OptimizeMode::from_enum |> Some; true }
+      (11, _) => { msg.go_package = reader |> @lib.async_read_string() |> Some; true }
+      (16, _) => { msg.cc_generic_services = reader |> @lib.async_read_bool() |> Some; true }
+      (17, _) => { msg.java_generic_services = reader |> @lib.async_read_bool() |> Some; true }
+      (18, _) => { msg.py_generic_services = reader |> @lib.async_read_bool() |> Some; true }
+      (23, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
+      (31, _) => { msg.cc_enable_arenas = reader |> @lib.async_read_bool() |> Some; true }
+      (36, _) => { msg.objc_class_prefix = reader |> @lib.async_read_string() |> Some; true }
+      (37, _) => { msg.csharp_namespace = reader |> @lib.async_read_string() |> Some; true }
+      (39, _) => { msg.swift_prefix = reader |> @lib.async_read_string() |> Some; true }
+      (40, _) => { msg.php_class_prefix = reader |> @lib.async_read_string() |> Some; true }
+      (41, _) => { msg.php_namespace = reader |> @lib.async_read_string() |> Some; true }
+      (44, _) => { msg.php_metadata_namespace = reader |> @lib.async_read_string() |> Some; true }
+      (45, _) => { msg.ruby_package = reader |> @lib.async_read_string() |> Some; true }
+      (50, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FileOptions with fn write(self: FileOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -3487,12 +3337,12 @@ pub impl @lib.AsyncWrite for FileOptions with fn write(self: FileOptions, writer
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(402UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -3554,23 +3404,18 @@ pub fn MessageOptions::new(message_set_wire_format? : Bool, no_standard_descript
 }
 pub impl @lib.Read for MessageOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MessageOptions raise {
   let msg = MessageOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.message_set_wire_format = reader |> @lib.read_bool() |> Some
-      (2, _) => msg.no_standard_descriptor_accessor = reader |> @lib.read_bool() |> Some
-      (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (7, _) => msg.map_entry = reader |> @lib.read_bool() |> Some
-      (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
-      (12, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.message_set_wire_format = reader |> @lib.read_bool() |> Some; true }
+      (2, _) => { msg.no_standard_descriptor_accessor = reader |> @lib.read_bool() |> Some; true }
+      (3, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
+      (7, _) => { msg.map_entry = reader |> @lib.read_bool() |> Some; true }
+      (11, _) => { msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some; true }
+      (12, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for MessageOptions with fn write(self: MessageOptions, writer : &@lib.Writer) -> Unit raise {
@@ -3601,12 +3446,12 @@ pub impl @lib.Write for MessageOptions with fn write(self: MessageOptions, write
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(98UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -3663,23 +3508,18 @@ pub impl @json.FromJson for MessageOptions with fn from_json(json: Json, path: @
 }
 pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MessageOptions raise {
   let msg = MessageOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.message_set_wire_format = reader |> @lib.async_read_bool() |> Some
-      (2, _) => msg.no_standard_descriptor_accessor = reader |> @lib.async_read_bool() |> Some
-      (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (7, _) => msg.map_entry = reader |> @lib.async_read_bool() |> Some
-      (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
-      (12, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.message_set_wire_format = reader |> @lib.async_read_bool() |> Some; true }
+      (2, _) => { msg.no_standard_descriptor_accessor = reader |> @lib.async_read_bool() |> Some; true }
+      (3, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
+      (7, _) => { msg.map_entry = reader |> @lib.async_read_bool() |> Some; true }
+      (11, _) => { msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some; true }
+      (12, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for MessageOptions with fn write(self: MessageOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -3710,12 +3550,12 @@ pub impl @lib.AsyncWrite for MessageOptions with fn write(self: MessageOptions, 
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(98UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -3965,18 +3805,13 @@ pub fn FieldOptions_EditionDefault::new(edition? : Edition, value? : String) -> 
 }
 pub impl @lib.Read for FieldOptions_EditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (3, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      (2, _) => msg.value = reader |> @lib.read_string() |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (3, _) => { msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
+      (2, _) => { msg.value = reader |> @lib.read_string() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FieldOptions_EditionDefault with fn write(self: FieldOptions_EditionDefault, writer : &@lib.Writer) -> Unit raise {
@@ -4019,18 +3854,13 @@ pub impl @json.FromJson for FieldOptions_EditionDefault with fn from_json(json: 
 }
 pub impl @lib.AsyncRead for FieldOptions_EditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (3, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-      (2, _) => msg.value = reader |> @lib.async_read_string() |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (3, _) => { msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
+      (2, _) => { msg.value = reader |> @lib.async_read_string() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FieldOptions_EditionDefault with fn write(self: FieldOptions_EditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -4085,20 +3915,15 @@ pub fn FieldOptions_FeatureSupport::new(edition_introduced? : Edition, edition_d
 }
 pub impl @lib.Read for FieldOptions_FeatureSupport with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.edition_introduced = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      (2, _) => msg.edition_deprecated = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      (3, _) => msg.deprecation_warning = reader |> @lib.read_string() |> Some
-      (4, _) => msg.edition_removed = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.edition_introduced = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
+      (2, _) => { msg.edition_deprecated = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
+      (3, _) => { msg.deprecation_warning = reader |> @lib.read_string() |> Some; true }
+      (4, _) => { msg.edition_removed = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FieldOptions_FeatureSupport with fn write(self: FieldOptions_FeatureSupport, writer : &@lib.Writer) -> Unit raise {
@@ -4161,20 +3986,15 @@ pub impl @json.FromJson for FieldOptions_FeatureSupport with fn from_json(json: 
 }
 pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.edition_introduced = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-      (2, _) => msg.edition_deprecated = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-      (3, _) => msg.deprecation_warning = reader |> @lib.async_read_string() |> Some
-      (4, _) => msg.edition_removed = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.edition_introduced = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
+      (2, _) => { msg.edition_deprecated = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
+      (3, _) => { msg.deprecation_warning = reader |> @lib.async_read_string() |> Some; true }
+      (4, _) => { msg.edition_removed = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FieldOptions_FeatureSupport with fn write(self: FieldOptions_FeatureSupport, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -4299,31 +4119,26 @@ pub fn FieldOptions::new(ctype? : FieldOptions_CType, packed? : Bool, jstype? : 
 }
 pub impl @lib.Read for FieldOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions raise {
   let msg = FieldOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.ctype = reader |> @lib.read_enum() |> FieldOptions_CType::from_enum |> Some
-      (2, _) => msg.packed = reader |> @lib.read_bool() |> Some
-      (6, _) => msg.jstype = reader |> @lib.read_enum() |> FieldOptions_JSType::from_enum |> Some
-      (5, _) => msg.lazy_ = reader |> @lib.read_bool() |> Some
-      (15, _) => msg.unverified_lazy = reader |> @lib.read_bool() |> Some
-      (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (10, _) => msg.weak = reader |> @lib.read_bool() |> Some
-      (16, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-      (17, _) => msg.retention = reader |> @lib.read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
-      (19, 2) => { let packed = reader |> @lib.read_packed(@lib.read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
-      (19, 0) => msg.targets.push(reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum)
-      (20, _) => msg.edition_defaults.push((reader |> @lib.read_message() : FieldOptions_EditionDefault))
-      (21, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (22, _) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.ctype = reader |> @lib.read_enum() |> FieldOptions_CType::from_enum |> Some; true }
+      (2, _) => { msg.packed = reader |> @lib.read_bool() |> Some; true }
+      (6, _) => { msg.jstype = reader |> @lib.read_enum() |> FieldOptions_JSType::from_enum |> Some; true }
+      (5, _) => { msg.lazy_ = reader |> @lib.read_bool() |> Some; true }
+      (15, _) => { msg.unverified_lazy = reader |> @lib.read_bool() |> Some; true }
+      (3, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
+      (10, _) => { msg.weak = reader |> @lib.read_bool() |> Some; true }
+      (16, _) => { msg.debug_redact = reader |> @lib.read_bool() |> Some; true }
+      (17, _) => { msg.retention = reader |> @lib.read_enum() |> FieldOptions_OptionRetention::from_enum |> Some; true }
+      (19, 2) => { let packed = reader |> @lib.read_packed(@lib.read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) }; true }
+      (19, 0) => { msg.targets.push(reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum); true }
+      (20, _) => { msg.edition_defaults.push((reader |> @lib.read_message() : FieldOptions_EditionDefault)); true }
+      (21, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
+      (22, _) => { msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FieldOptions with fn write(self: FieldOptions, writer : &@lib.Writer) -> Unit raise {
@@ -4379,22 +4194,22 @@ pub impl @lib.Write for FieldOptions with fn write(self: FieldOptions, writer : 
   }
   for item in self.edition_defaults {
     writer |> @lib.write_varint(162UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(170UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.feature_support is Some(v) {
     writer |> @lib.write_varint(178UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -4486,31 +4301,26 @@ pub impl @json.FromJson for FieldOptions with fn from_json(json: Json, path: @js
 }
 pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions raise {
   let msg = FieldOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.ctype = reader |> @lib.async_read_enum() |> FieldOptions_CType::from_enum |> Some
-      (2, _) => msg.packed = reader |> @lib.async_read_bool() |> Some
-      (6, _) => msg.jstype = reader |> @lib.async_read_enum() |> FieldOptions_JSType::from_enum |> Some
-      (5, _) => msg.lazy_ = reader |> @lib.async_read_bool() |> Some
-      (15, _) => msg.unverified_lazy = reader |> @lib.async_read_bool() |> Some
-      (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (10, _) => msg.weak = reader |> @lib.async_read_bool() |> Some
-      (16, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-      (17, _) => msg.retention = reader |> @lib.async_read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
-      (19, 2) => { let packed = reader |> @lib.async_read_packed(@lib.async_read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
-      (19, 0) => msg.targets.push(reader |> @lib.async_read_enum() |> FieldOptions_OptionTargetType::from_enum)
-      (20, _) => msg.edition_defaults.push((reader |> @lib.async_read_message() : FieldOptions_EditionDefault))
-      (21, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (22, _) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.ctype = reader |> @lib.async_read_enum() |> FieldOptions_CType::from_enum |> Some; true }
+      (2, _) => { msg.packed = reader |> @lib.async_read_bool() |> Some; true }
+      (6, _) => { msg.jstype = reader |> @lib.async_read_enum() |> FieldOptions_JSType::from_enum |> Some; true }
+      (5, _) => { msg.lazy_ = reader |> @lib.async_read_bool() |> Some; true }
+      (15, _) => { msg.unverified_lazy = reader |> @lib.async_read_bool() |> Some; true }
+      (3, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
+      (10, _) => { msg.weak = reader |> @lib.async_read_bool() |> Some; true }
+      (16, _) => { msg.debug_redact = reader |> @lib.async_read_bool() |> Some; true }
+      (17, _) => { msg.retention = reader |> @lib.async_read_enum() |> FieldOptions_OptionRetention::from_enum |> Some; true }
+      (19, 2) => { let packed = reader |> @lib.async_read_packed(@lib.async_read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) }; true }
+      (19, 0) => { msg.targets.push(reader |> @lib.async_read_enum() |> FieldOptions_OptionTargetType::from_enum); true }
+      (20, _) => { msg.edition_defaults.push((reader |> @lib.async_read_message() : FieldOptions_EditionDefault)); true }
+      (21, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
+      (22, _) => { msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FieldOptions with fn write(self: FieldOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -4566,22 +4376,22 @@ pub impl @lib.AsyncWrite for FieldOptions with fn write(self: FieldOptions, writ
   }
   for item in self.edition_defaults {
     writer |> @lib.async_write_varint(162UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(170UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.feature_support is Some(v) {
     writer |> @lib.async_write_varint(178UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -4613,29 +4423,24 @@ pub fn OneofOptions::new(features? : FeatureSet, uninterpreted_option : Array[Un
 }
 pub impl @lib.Read for OneofOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> OneofOptions raise {
   let msg = OneofOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for OneofOptions with fn write(self: OneofOptions, writer : &@lib.Writer) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.write_varint(10UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -4667,29 +4472,24 @@ pub impl @json.FromJson for OneofOptions with fn from_json(json: Json, path: @js
 }
 pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> OneofOptions raise {
   let msg = OneofOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for OneofOptions with fn write(self: OneofOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -4739,21 +4539,16 @@ pub fn EnumOptions::new(allow_alias? : Bool, deprecated? : Bool, deprecated_lega
 }
 pub impl @lib.Read for EnumOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumOptions raise {
   let msg = EnumOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (2, _) => msg.allow_alias = reader |> @lib.read_bool() |> Some
-      (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
-      (7, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (2, _) => { msg.allow_alias = reader |> @lib.read_bool() |> Some; true }
+      (3, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
+      (6, _) => { msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some; true }
+      (7, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for EnumOptions with fn write(self: EnumOptions, writer : &@lib.Writer) -> Unit raise {
@@ -4774,12 +4569,12 @@ pub impl @lib.Write for EnumOptions with fn write(self: EnumOptions, writer : &@
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(58UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -4826,21 +4621,16 @@ pub impl @json.FromJson for EnumOptions with fn from_json(json: Json, path: @jso
 }
 pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumOptions raise {
   let msg = EnumOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (2, _) => msg.allow_alias = reader |> @lib.async_read_bool() |> Some
-      (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
-      (7, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (2, _) => { msg.allow_alias = reader |> @lib.async_read_bool() |> Some; true }
+      (3, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
+      (6, _) => { msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some; true }
+      (7, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for EnumOptions with fn write(self: EnumOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -4861,12 +4651,12 @@ pub impl @lib.AsyncWrite for EnumOptions with fn write(self: EnumOptions, writer
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(58UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -4916,21 +4706,16 @@ pub fn EnumValueOptions::new(deprecated? : Bool, features? : FeatureSet, debug_r
 }
 pub impl @lib.Read for EnumValueOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (2, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-      (4, _) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
+      (2, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
+      (3, _) => { msg.debug_redact = reader |> @lib.read_bool() |> Some; true }
+      (4, _) => { msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for EnumValueOptions with fn write(self: EnumValueOptions, writer : &@lib.Writer) -> Unit raise {
@@ -4941,7 +4726,7 @@ pub impl @lib.Write for EnumValueOptions with fn write(self: EnumValueOptions, w
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(18UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.debug_redact is Some(v) {
@@ -4951,12 +4736,12 @@ pub impl @lib.Write for EnumValueOptions with fn write(self: EnumValueOptions, w
   }
   if self.feature_support is Some(v) {
     writer |> @lib.write_varint(34UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -5003,21 +4788,16 @@ pub impl @json.FromJson for EnumValueOptions with fn from_json(json: Json, path:
 }
 pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (2, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-      (4, _) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
+      (2, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
+      (3, _) => { msg.debug_redact = reader |> @lib.async_read_bool() |> Some; true }
+      (4, _) => { msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for EnumValueOptions with fn write(self: EnumValueOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -5028,7 +4808,7 @@ pub impl @lib.AsyncWrite for EnumValueOptions with fn write(self: EnumValueOptio
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.debug_redact is Some(v) {
@@ -5038,12 +4818,12 @@ pub impl @lib.AsyncWrite for EnumValueOptions with fn write(self: EnumValueOptio
   }
   if self.feature_support is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -5081,25 +4861,20 @@ pub fn ServiceOptions::new(features? : FeatureSet, deprecated? : Bool, uninterpr
 }
 pub impl @lib.Read for ServiceOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (34, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (34, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
+      (33, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for ServiceOptions with fn write(self: ServiceOptions, writer : &@lib.Writer) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.write_varint(274UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.deprecated is Some(v) {
@@ -5109,7 +4884,7 @@ pub impl @lib.Write for ServiceOptions with fn write(self: ServiceOptions, write
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -5146,25 +4921,20 @@ pub impl @json.FromJson for ServiceOptions with fn from_json(json: Json, path: @
 }
 pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (34, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (34, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
+      (33, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for ServiceOptions with fn write(self: ServiceOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(274UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.deprecated is Some(v) {
@@ -5174,7 +4944,7 @@ pub impl @lib.AsyncWrite for ServiceOptions with fn write(self: ServiceOptions, 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -5262,20 +5032,15 @@ pub fn MethodOptions::new(deprecated? : Bool, idempotency_level? : MethodOptions
 }
 pub impl @lib.Read for MethodOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MethodOptions raise {
   let msg = MethodOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (34, _) => msg.idempotency_level = reader |> @lib.read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
-      (35, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (33, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
+      (34, _) => { msg.idempotency_level = reader |> @lib.read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some; true }
+      (35, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for MethodOptions with fn write(self: MethodOptions, writer : &@lib.Writer) -> Unit raise {
@@ -5291,12 +5056,12 @@ pub impl @lib.Write for MethodOptions with fn write(self: MethodOptions, writer 
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(282UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -5338,20 +5103,15 @@ pub impl @json.FromJson for MethodOptions with fn from_json(json: Json, path: @j
 }
 pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MethodOptions raise {
   let msg = MethodOptions::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (34, _) => msg.idempotency_level = reader |> @lib.async_read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
-      (35, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (33, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
+      (34, _) => { msg.idempotency_level = reader |> @lib.async_read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some; true }
+      (35, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
+      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for MethodOptions with fn write(self: MethodOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -5367,12 +5127,12 @@ pub impl @lib.AsyncWrite for MethodOptions with fn write(self: MethodOptions, wr
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(282UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -5400,18 +5160,13 @@ pub fn UninterpretedOption_NamePart::new(name_part : String, is_extension : Bool
 }
 pub impl @lib.Read for UninterpretedOption_NamePart with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.name_part = reader |> @lib.read_string()
-      (2, _) => msg.is_extension = reader |> @lib.read_bool()
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.name_part = reader |> @lib.read_string(); true }
+      (2, _) => { msg.is_extension = reader |> @lib.read_bool(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for UninterpretedOption_NamePart with fn write(self: UninterpretedOption_NamePart, writer : &@lib.Writer) -> Unit raise {
@@ -5446,18 +5201,13 @@ pub impl @json.FromJson for UninterpretedOption_NamePart with fn from_json(json:
 }
 pub impl @lib.AsyncRead for UninterpretedOption_NamePart with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.name_part = reader |> @lib.async_read_string()
-      (2, _) => msg.is_extension = reader |> @lib.async_read_bool()
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.name_part = reader |> @lib.async_read_string(); true }
+      (2, _) => { msg.is_extension = reader |> @lib.async_read_bool(); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for UninterpretedOption_NamePart with fn write(self: UninterpretedOption_NamePart, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -5524,29 +5274,24 @@ pub fn UninterpretedOption::new(name : Array[UninterpretedOption_NamePart], iden
 }
 pub impl @lib.Read for UninterpretedOption with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (2, _) => msg.name.push((reader |> @lib.read_message() : UninterpretedOption_NamePart))
-      (3, _) => msg.identifier_value = reader |> @lib.read_string() |> Some
-      (4, _) => msg.positive_int_value = reader |> @lib.read_uint64() |> Some
-      (5, _) => msg.negative_int_value = reader |> @lib.read_int64() |> Some
-      (6, _) => msg.double_value = reader |> @lib.read_double() |> Some
-      (7, _) => msg.string_value = reader |> @lib.read_bytes() |> Some
-      (8, _) => msg.aggregate_value = reader |> @lib.read_string() |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (2, _) => { msg.name.push((reader |> @lib.read_message() : UninterpretedOption_NamePart)); true }
+      (3, _) => { msg.identifier_value = reader |> @lib.read_string() |> Some; true }
+      (4, _) => { msg.positive_int_value = reader |> @lib.read_uint64() |> Some; true }
+      (5, _) => { msg.negative_int_value = reader |> @lib.read_int64() |> Some; true }
+      (6, _) => { msg.double_value = reader |> @lib.read_double() |> Some; true }
+      (7, _) => { msg.string_value = reader |> @lib.read_bytes() |> Some; true }
+      (8, _) => { msg.aggregate_value = reader |> @lib.read_string() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for UninterpretedOption with fn write(self: UninterpretedOption, writer : &@lib.Writer) -> Unit raise {
   for item in self.name {
     writer |> @lib.write_varint(18UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.identifier_value is Some(v) {
@@ -5633,29 +5378,24 @@ pub impl @json.FromJson for UninterpretedOption with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (2, _) => msg.name.push((reader |> @lib.async_read_message() : UninterpretedOption_NamePart))
-      (3, _) => msg.identifier_value = reader |> @lib.async_read_string() |> Some
-      (4, _) => msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some
-      (5, _) => msg.negative_int_value = reader |> @lib.async_read_int64() |> Some
-      (6, _) => msg.double_value = reader |> @lib.async_read_double() |> Some
-      (7, _) => msg.string_value = reader |> @lib.async_read_bytes() |> Some
-      (8, _) => msg.aggregate_value = reader |> @lib.async_read_string() |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (2, _) => { msg.name.push((reader |> @lib.async_read_message() : UninterpretedOption_NamePart)); true }
+      (3, _) => { msg.identifier_value = reader |> @lib.async_read_string() |> Some; true }
+      (4, _) => { msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some; true }
+      (5, _) => { msg.negative_int_value = reader |> @lib.async_read_int64() |> Some; true }
+      (6, _) => { msg.double_value = reader |> @lib.async_read_double() |> Some; true }
+      (7, _) => { msg.string_value = reader |> @lib.async_read_bytes() |> Some; true }
+      (8, _) => { msg.aggregate_value = reader |> @lib.async_read_string() |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for UninterpretedOption with fn write(self: UninterpretedOption, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.name {
     writer |> @lib.async_write_varint(18UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.identifier_value is Some(v) {
@@ -6152,24 +5892,19 @@ pub fn FeatureSet::new(field_presence? : FeatureSet_FieldPresence, enum_type? : 
 }
 pub impl @lib.Read for FeatureSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSet raise {
   let msg = FeatureSet::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.field_presence = reader |> @lib.read_enum() |> FeatureSet_FieldPresence::from_enum |> Some
-      (2, _) => msg.enum_type = reader |> @lib.read_enum() |> FeatureSet_EnumType::from_enum |> Some
-      (3, _) => msg.repeated_field_encoding = reader |> @lib.read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some
-      (4, _) => msg.utf8_validation = reader |> @lib.read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some
-      (5, _) => msg.message_encoding = reader |> @lib.read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some
-      (6, _) => msg.json_format = reader |> @lib.read_enum() |> FeatureSet_JsonFormat::from_enum |> Some
-      (7, _) => msg.enforce_naming_style = reader |> @lib.read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some
-      (8, _) => msg.default_symbol_visibility = reader |> @lib.read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.field_presence = reader |> @lib.read_enum() |> FeatureSet_FieldPresence::from_enum |> Some; true }
+      (2, _) => { msg.enum_type = reader |> @lib.read_enum() |> FeatureSet_EnumType::from_enum |> Some; true }
+      (3, _) => { msg.repeated_field_encoding = reader |> @lib.read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some; true }
+      (4, _) => { msg.utf8_validation = reader |> @lib.read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some; true }
+      (5, _) => { msg.message_encoding = reader |> @lib.read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some; true }
+      (6, _) => { msg.json_format = reader |> @lib.read_enum() |> FeatureSet_JsonFormat::from_enum |> Some; true }
+      (7, _) => { msg.enforce_naming_style = reader |> @lib.read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some; true }
+      (8, _) => { msg.default_symbol_visibility = reader |> @lib.read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FeatureSet with fn write(self: FeatureSet, writer : &@lib.Writer) -> Unit raise {
@@ -6272,24 +6007,19 @@ pub impl @json.FromJson for FeatureSet with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for FeatureSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSet raise {
   let msg = FeatureSet::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.field_presence = reader |> @lib.async_read_enum() |> FeatureSet_FieldPresence::from_enum |> Some
-      (2, _) => msg.enum_type = reader |> @lib.async_read_enum() |> FeatureSet_EnumType::from_enum |> Some
-      (3, _) => msg.repeated_field_encoding = reader |> @lib.async_read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some
-      (4, _) => msg.utf8_validation = reader |> @lib.async_read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some
-      (5, _) => msg.message_encoding = reader |> @lib.async_read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some
-      (6, _) => msg.json_format = reader |> @lib.async_read_enum() |> FeatureSet_JsonFormat::from_enum |> Some
-      (7, _) => msg.enforce_naming_style = reader |> @lib.async_read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some
-      (8, _) => msg.default_symbol_visibility = reader |> @lib.async_read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.field_presence = reader |> @lib.async_read_enum() |> FeatureSet_FieldPresence::from_enum |> Some; true }
+      (2, _) => { msg.enum_type = reader |> @lib.async_read_enum() |> FeatureSet_EnumType::from_enum |> Some; true }
+      (3, _) => { msg.repeated_field_encoding = reader |> @lib.async_read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some; true }
+      (4, _) => { msg.utf8_validation = reader |> @lib.async_read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some; true }
+      (5, _) => { msg.message_encoding = reader |> @lib.async_read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some; true }
+      (6, _) => { msg.json_format = reader |> @lib.async_read_enum() |> FeatureSet_JsonFormat::from_enum |> Some; true }
+      (7, _) => { msg.enforce_naming_style = reader |> @lib.async_read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some; true }
+      (8, _) => { msg.default_symbol_visibility = reader |> @lib.async_read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FeatureSet with fn write(self: FeatureSet, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -6368,19 +6098,14 @@ pub fn FeatureSetDefaults_FeatureSetEditionDefault::new(edition? : Edition, over
 }
 pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (3, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      (4, _) => msg.overridable_features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (5, _) => msg.fixed_features = (reader |> @lib.read_message() : FeatureSet) |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (3, _) => { msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
+      (4, _) => { msg.overridable_features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
+      (5, _) => { msg.fixed_features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with fn write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.Writer) -> Unit raise {
@@ -6391,12 +6116,12 @@ pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with fn writ
   }
   if self.overridable_features is Some(v) {
     writer |> @lib.write_varint(34UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
   if self.fixed_features is Some(v) {
     writer |> @lib.write_varint(42UL);
-    writer |> @lib.write_uint32(@lib.size_of(v)); @lib.Write::write(v, writer)
+    writer |> @lib.write_message(v)
 
   }
 }
@@ -6433,19 +6158,14 @@ pub impl @json.FromJson for FeatureSetDefaults_FeatureSetEditionDefault with fn 
 }
 pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (3, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-      (4, _) => msg.overridable_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (5, _) => msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (3, _) => { msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
+      (4, _) => { msg.overridable_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
+      (5, _) => { msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FeatureSetDefaults_FeatureSetEditionDefault with fn write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -6456,12 +6176,12 @@ pub impl @lib.AsyncWrite for FeatureSetDefaults_FeatureSetEditionDefault with fn
   }
   if self.overridable_features is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
   if self.fixed_features is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-    writer |> @lib.async_write_uint32(@lib.size_of(v)); @lib.AsyncWrite::write(v, writer)
+    writer |> @lib.async_write_message(v)
 
   }
 }
@@ -6499,25 +6219,20 @@ pub fn FeatureSetDefaults::new(defaults : Array[FeatureSetDefaults_FeatureSetEdi
 }
 pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.defaults.push((reader |> @lib.read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
-      (4, _) => msg.minimum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      (5, _) => msg.maximum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.defaults.push((reader |> @lib.read_message() : FeatureSetDefaults_FeatureSetEditionDefault)); true }
+      (4, _) => { msg.minimum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
+      (5, _) => { msg.maximum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for FeatureSetDefaults with fn write(self: FeatureSetDefaults, writer : &@lib.Writer) -> Unit raise {
   for item in self.defaults {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
   if self.minimum_edition is Some(v) {
@@ -6564,25 +6279,20 @@ pub impl @json.FromJson for FeatureSetDefaults with fn from_json(json: Json, pat
 }
 pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.defaults.push((reader |> @lib.async_read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
-      (4, _) => msg.minimum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-      (5, _) => msg.maximum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.defaults.push((reader |> @lib.async_read_message() : FeatureSetDefaults_FeatureSetEditionDefault)); true }
+      (4, _) => { msg.minimum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
+      (5, _) => { msg.maximum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for FeatureSetDefaults with fn write(self: FeatureSetDefaults, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.defaults {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
   if self.minimum_edition is Some(v) {
@@ -6642,23 +6352,18 @@ pub fn SourceCodeInfo_Location::new(path : Array[Int], span : Array[Int], leadin
 }
 pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (1, 0) => msg.path.push(reader |> @lib.read_int32())
-      (2, 2) => { msg.span.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (2, 0) => msg.span.push(reader |> @lib.read_int32())
-      (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
-      (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
-      (6, _) => msg.leading_detached_comments.push(reader |> @lib.read_string())
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
+      (1, 0) => { msg.path.push(reader |> @lib.read_int32()); true }
+      (2, 2) => { msg.span.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
+      (2, 0) => { msg.span.push(reader |> @lib.read_int32()); true }
+      (3, _) => { msg.leading_comments = reader |> @lib.read_string() |> Some; true }
+      (4, _) => { msg.trailing_comments = reader |> @lib.read_string() |> Some; true }
+      (6, _) => { msg.leading_detached_comments.push(reader |> @lib.read_string()); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for SourceCodeInfo_Location with fn write(self: SourceCodeInfo_Location, writer : &@lib.Writer) -> Unit raise {
@@ -6739,23 +6444,18 @@ pub impl @json.FromJson for SourceCodeInfo_Location with fn from_json(json: Json
 }
 pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
-      (2, 2) => { msg.span.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
-      (3, _) => msg.leading_comments = reader |> @lib.async_read_string() |> Some
-      (4, _) => msg.trailing_comments = reader |> @lib.async_read_string() |> Some
-      (6, _) => msg.leading_detached_comments.push(reader |> @lib.async_read_string())
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
+      (1, 0) => { msg.path.push(reader |> @lib.async_read_int32()); true }
+      (2, 2) => { msg.span.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
+      (2, 0) => { msg.span.push(reader |> @lib.async_read_int32()); true }
+      (3, _) => { msg.leading_comments = reader |> @lib.async_read_string() |> Some; true }
+      (4, _) => { msg.trailing_comments = reader |> @lib.async_read_string() |> Some; true }
+      (6, _) => { msg.leading_detached_comments.push(reader |> @lib.async_read_string()); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for SourceCodeInfo_Location with fn write(self: SourceCodeInfo_Location, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -6815,23 +6515,18 @@ pub fn SourceCodeInfo::new(location : Array[SourceCodeInfo_Location]) -> SourceC
 }
 pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.location.push((reader |> @lib.read_message() : SourceCodeInfo_Location))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.location.push((reader |> @lib.read_message() : SourceCodeInfo_Location)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for SourceCodeInfo with fn write(self: SourceCodeInfo, writer : &@lib.Writer) -> Unit raise {
   for item in self.location {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -6858,23 +6553,18 @@ pub impl @json.FromJson for SourceCodeInfo with fn from_json(json: Json, path: @
 }
 pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.location.push((reader |> @lib.async_read_message() : SourceCodeInfo_Location))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.location.push((reader |> @lib.async_read_message() : SourceCodeInfo_Location)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for SourceCodeInfo with fn write(self: SourceCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.location {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }
@@ -6968,22 +6658,17 @@ pub fn GeneratedCodeInfo_Annotation::new(path : Array[Int], source_file? : Strin
 }
 pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (1, 0) => msg.path.push(reader |> @lib.read_int32())
-      (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
-      (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
-      (4, _) => msg.end = reader |> @lib.read_int32() |> Some
-      (5, _) => msg.semantic = reader |> @lib.read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
+      (1, 0) => { msg.path.push(reader |> @lib.read_int32()); true }
+      (2, _) => { msg.source_file = reader |> @lib.read_string() |> Some; true }
+      (3, _) => { msg.begin = reader |> @lib.read_int32() |> Some; true }
+      (4, _) => { msg.end = reader |> @lib.read_int32() |> Some; true }
+      (5, _) => { msg.semantic = reader |> @lib.read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for GeneratedCodeInfo_Annotation with fn write(self: GeneratedCodeInfo_Annotation, writer : &@lib.Writer) -> Unit raise {
@@ -7060,22 +6745,17 @@ pub impl @json.FromJson for GeneratedCodeInfo_Annotation with fn from_json(json:
 }
 pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
-      (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
-      (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-      (5, _) => msg.semantic = reader |> @lib.async_read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
+      (1, 0) => { msg.path.push(reader |> @lib.async_read_int32()); true }
+      (2, _) => { msg.source_file = reader |> @lib.async_read_string() |> Some; true }
+      (3, _) => { msg.begin = reader |> @lib.async_read_int32() |> Some; true }
+      (4, _) => { msg.end = reader |> @lib.async_read_int32() |> Some; true }
+      (5, _) => { msg.semantic = reader |> @lib.async_read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some; true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for GeneratedCodeInfo_Annotation with fn write(self: GeneratedCodeInfo_Annotation, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -7131,23 +6811,18 @@ pub fn GeneratedCodeInfo::new(annotation : Array[GeneratedCodeInfo_Annotation]) 
 }
 pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
-  try {
-    for ;; {
-      match (reader |> @lib.read_tag()) {
-      (1, _) => msg.annotation.push((reader |> @lib.read_message() : GeneratedCodeInfo_Annotation))
-       (_, wire) => reader |> @lib.read_unknown(wire)
-      }
+  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
+    match (field_number, wire) {
+      (1, _) => { msg.annotation.push((reader |> @lib.read_message() : GeneratedCodeInfo_Annotation)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.Write for GeneratedCodeInfo with fn write(self: GeneratedCodeInfo, writer : &@lib.Writer) -> Unit raise {
   for item in self.annotation {
     writer |> @lib.write_varint(10UL)
-    writer |> @lib.write_uint32(@lib.size_of(item)); @lib.Write::write(item, writer)
+    writer |> @lib.write_message(item)
 
   }
 }
@@ -7174,23 +6849,18 @@ pub impl @json.FromJson for GeneratedCodeInfo with fn from_json(json: Json, path
 }
 pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
-  try {
-    for ;; {
-      match (reader |> @lib.async_read_tag()) {
-      (1, _) => msg.annotation.push((reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation))
-       (_, wire) => reader |> @lib.async_read_unknown(wire)
-      }
+  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
+    match (field_number, wire) {
+      (1, _) => { msg.annotation.push((reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation)); true }
+      _ => false
     }
-  } catch {
-    @lib.EndOfStream => ()
-    err => raise err
-  }
+  })
   msg
 }
 pub impl @lib.AsyncWrite for GeneratedCodeInfo with fn write(self: GeneratedCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.annotation {
     writer |> @lib.async_write_varint(10UL)
-    writer |> @lib.async_write_uint32(@lib.size_of(item)); @lib.AsyncWrite::write(item, writer)
+    writer |> @lib.async_write_message(item)
 
   }
 }

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -162,14 +162,10 @@ pub fn FileDescriptorSet::new(file : Array[FileDescriptorProto]) -> FileDescript
 }
 pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -204,14 +200,10 @@ pub impl @json.FromJson for FileDescriptorSet with fn from_json(json: Json, path
 }
 pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.file.push((reader |> @lib.async_read_message() : FileDescriptorProto))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.file.push((reader |> @lib.async_read_message() : FileDescriptorProto))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -323,29 +315,25 @@ pub fn FileDescriptorProto::new(name? : String, package_? : String, dependency :
 }
 pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
-          (3, _) => msg.dependency.push(reader |> @lib.read_string())
-          (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-          (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
-          (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-          (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
-          (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
-          (4, _) => msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
-          (5, _) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
-          (6, _) => msg.service.push((reader |> @lib.read_message() : ServiceDescriptorProto))
-          (7, _) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
-          (8, _) => msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
-          (9, _) => msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo) |> Some
-          (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
-          (14, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
+      (3, _) => msg.dependency.push(reader |> @lib.read_string())
+      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
+      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
+      (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
+      (4, _) => msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
+      (5, _) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
+      (6, _) => msg.service.push((reader |> @lib.read_message() : ServiceDescriptorProto))
+      (7, _) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
+      (8, _) => msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
+      (9, _) => msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo) |> Some
+      (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
+      (14, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -510,29 +498,25 @@ pub impl @json.FromJson for FileDescriptorProto with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
-          (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-          (10, 0) => msg.public_dependency.push(reader |> @lib.async_read_int32())
-          (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-          (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
-          (15, _) => msg.option_dependency.push(reader |> @lib.async_read_string())
-          (4, _) => msg.message_type.push((reader |> @lib.async_read_message() : DescriptorProto))
-          (5, _) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
-          (6, _) => msg.service.push((reader |> @lib.async_read_message() : ServiceDescriptorProto))
-          (7, _) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-          (8, _) => msg.options = (reader |> @lib.async_read_message() : FileOptions) |> Some
-          (9, _) => msg.source_code_info = (reader |> @lib.async_read_message() : SourceCodeInfo) |> Some
-          (12, _) => msg.syntax = reader |> @lib.async_read_string() |> Some
-          (14, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
+      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (10, 0) => msg.public_dependency.push(reader |> @lib.async_read_int32())
+      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
+      (15, _) => msg.option_dependency.push(reader |> @lib.async_read_string())
+      (4, _) => msg.message_type.push((reader |> @lib.async_read_message() : DescriptorProto))
+      (5, _) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
+      (6, _) => msg.service.push((reader |> @lib.async_read_message() : ServiceDescriptorProto))
+      (7, _) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+      (8, _) => msg.options = (reader |> @lib.async_read_message() : FileOptions) |> Some
+      (9, _) => msg.source_code_info = (reader |> @lib.async_read_message() : SourceCodeInfo) |> Some
+      (12, _) => msg.syntax = reader |> @lib.async_read_string() |> Some
+      (14, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -643,16 +627,12 @@ pub fn DescriptorProto_ExtensionRange::new(start? : Int, end? : Int, options? : 
 }
 pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-          (3, _) => msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+      (3, _) => msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -707,16 +687,12 @@ pub impl @json.FromJson for DescriptorProto_ExtensionRange with fn from_json(jso
 }
 pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-          (3, _) => msg.options = (reader |> @lib.async_read_message() : ExtensionRangeOptions) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+      (3, _) => msg.options = (reader |> @lib.async_read_message() : ExtensionRangeOptions) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -766,15 +742,11 @@ pub fn DescriptorProto_ReservedRange::new(start? : Int, end? : Int) -> Descripto
 }
 pub impl @lib.Read for DescriptorProto_ReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -819,15 +791,11 @@ pub impl @json.FromJson for DescriptorProto_ReservedRange with fn from_json(json
 }
 pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -926,24 +894,20 @@ pub fn DescriptorProto::new(name? : String, field : Array[FieldDescriptorProto],
 }
 pub impl @lib.Read for DescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
-          (6, _) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
-          (3, _) => msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto))
-          (4, _) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
-          (5, _) => msg.extension_range.push((reader |> @lib.read_message() : DescriptorProto_ExtensionRange))
-          (8, _) => msg.oneof_decl.push((reader |> @lib.read_message() : OneofDescriptorProto))
-          (7, _) => msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
-          (9, _) => msg.reserved_range.push((reader |> @lib.read_message() : DescriptorProto_ReservedRange))
-          (10, _) => msg.reserved_name.push(reader |> @lib.read_string())
-          (11, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
+      (6, _) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
+      (3, _) => msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto))
+      (4, _) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
+      (5, _) => msg.extension_range.push((reader |> @lib.read_message() : DescriptorProto_ExtensionRange))
+      (8, _) => msg.oneof_decl.push((reader |> @lib.read_message() : OneofDescriptorProto))
+      (7, _) => msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
+      (9, _) => msg.reserved_range.push((reader |> @lib.read_message() : DescriptorProto_ReservedRange))
+      (10, _) => msg.reserved_name.push(reader |> @lib.read_string())
+      (11, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1078,24 +1042,20 @@ pub impl @json.FromJson for DescriptorProto with fn from_json(json: Json, path: 
 }
 pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.field.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-          (6, _) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-          (3, _) => msg.nested_type.push((reader |> @lib.async_read_message() : DescriptorProto))
-          (4, _) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
-          (5, _) => msg.extension_range.push((reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange))
-          (8, _) => msg.oneof_decl.push((reader |> @lib.async_read_message() : OneofDescriptorProto))
-          (7, _) => msg.options = (reader |> @lib.async_read_message() : MessageOptions) |> Some
-          (9, _) => msg.reserved_range.push((reader |> @lib.async_read_message() : DescriptorProto_ReservedRange))
-          (10, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
-          (11, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.field.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+      (6, _) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+      (3, _) => msg.nested_type.push((reader |> @lib.async_read_message() : DescriptorProto))
+      (4, _) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
+      (5, _) => msg.extension_range.push((reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange))
+      (8, _) => msg.oneof_decl.push((reader |> @lib.async_read_message() : OneofDescriptorProto))
+      (7, _) => msg.options = (reader |> @lib.async_read_message() : MessageOptions) |> Some
+      (9, _) => msg.reserved_range.push((reader |> @lib.async_read_message() : DescriptorProto_ReservedRange))
+      (10, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
+      (11, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1241,18 +1201,14 @@ pub fn ExtensionRangeOptions_Declaration::new(number? : Int, full_name? : String
 }
 pub impl @lib.Read for ExtensionRangeOptions_Declaration with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.number = reader |> @lib.read_int32() |> Some
-          (2, _) => msg.full_name = reader |> @lib.read_string() |> Some
-          (3, _) => msg.type_ = reader |> @lib.read_string() |> Some
-          (5, _) => msg.reserved = reader |> @lib.read_bool() |> Some
-          (6, _) => msg.repeated = reader |> @lib.read_bool() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.number = reader |> @lib.read_int32() |> Some
+      (2, _) => msg.full_name = reader |> @lib.read_string() |> Some
+      (3, _) => msg.type_ = reader |> @lib.read_string() |> Some
+      (5, _) => msg.reserved = reader |> @lib.read_bool() |> Some
+      (6, _) => msg.repeated = reader |> @lib.read_bool() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1327,18 +1283,14 @@ pub impl @json.FromJson for ExtensionRangeOptions_Declaration with fn from_json(
 }
 pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-          (2, _) => msg.full_name = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
-          (5, _) => msg.reserved = reader |> @lib.async_read_bool() |> Some
-          (6, _) => msg.repeated = reader |> @lib.async_read_bool() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+      (2, _) => msg.full_name = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
+      (5, _) => msg.reserved = reader |> @lib.async_read_bool() |> Some
+      (6, _) => msg.repeated = reader |> @lib.async_read_bool() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1410,17 +1362,13 @@ pub fn ExtensionRangeOptions::new(uninterpreted_option : Array[UninterpretedOpti
 }
 pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-          (2, _) => msg.declaration.push((reader |> @lib.read_message() : ExtensionRangeOptions_Declaration))
-          (50, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (3, _) => msg.verification = reader |> @lib.read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      (2, _) => msg.declaration.push((reader |> @lib.read_message() : ExtensionRangeOptions_Declaration))
+      (50, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (3, _) => msg.verification = reader |> @lib.read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1485,17 +1433,13 @@ pub impl @json.FromJson for ExtensionRangeOptions with fn from_json(json: Json, 
 }
 pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-          (2, _) => msg.declaration.push((reader |> @lib.async_read_message() : ExtensionRangeOptions_Declaration))
-          (50, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-          (3, _) => msg.verification = reader |> @lib.async_read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      (2, _) => msg.declaration.push((reader |> @lib.async_read_message() : ExtensionRangeOptions_Declaration))
+      (50, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (3, _) => msg.verification = reader |> @lib.async_read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -1782,24 +1726,20 @@ pub fn FieldDescriptorProto::new(name? : String, number? : Int, label? : FieldDe
 }
 pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (3, _) => msg.number = reader |> @lib.read_int32() |> Some
-          (4, _) => msg.label = reader |> @lib.read_enum() |> FieldDescriptorProto_Label::from_enum |> Some
-          (5, _) => msg.type_ = reader |> @lib.read_enum() |> FieldDescriptorProto_Type::from_enum |> Some
-          (6, _) => msg.type_name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.extendee = reader |> @lib.read_string() |> Some
-          (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
-          (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
-          (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
-          (8, _) => msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
-          (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (3, _) => msg.number = reader |> @lib.read_int32() |> Some
+      (4, _) => msg.label = reader |> @lib.read_enum() |> FieldDescriptorProto_Label::from_enum |> Some
+      (5, _) => msg.type_ = reader |> @lib.read_enum() |> FieldDescriptorProto_Type::from_enum |> Some
+      (6, _) => msg.type_name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.extendee = reader |> @lib.read_string() |> Some
+      (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
+      (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
+      (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
+      (8, _) => msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
+      (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -1934,24 +1874,20 @@ pub impl @json.FromJson for FieldDescriptorProto with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-          (4, _) => msg.label = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Label::from_enum |> Some
-          (5, _) => msg.type_ = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Type::from_enum |> Some
-          (6, _) => msg.type_name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.extendee = reader |> @lib.async_read_string() |> Some
-          (7, _) => msg.default_value = reader |> @lib.async_read_string() |> Some
-          (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
-          (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
-          (8, _) => msg.options = (reader |> @lib.async_read_message() : FieldOptions) |> Some
-          (17, _) => msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+      (4, _) => msg.label = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Label::from_enum |> Some
+      (5, _) => msg.type_ = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Type::from_enum |> Some
+      (6, _) => msg.type_name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.extendee = reader |> @lib.async_read_string() |> Some
+      (7, _) => msg.default_value = reader |> @lib.async_read_string() |> Some
+      (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
+      (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
+      (8, _) => msg.options = (reader |> @lib.async_read_message() : FieldOptions) |> Some
+      (17, _) => msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2041,15 +1977,11 @@ pub fn OneofDescriptorProto::new(name? : String, options? : OneofOptions) -> One
 }
 pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2094,15 +2026,11 @@ pub impl @json.FromJson for OneofDescriptorProto with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.options = (reader |> @lib.async_read_message() : OneofOptions) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.options = (reader |> @lib.async_read_message() : OneofOptions) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2147,15 +2075,11 @@ pub fn EnumDescriptorProto_EnumReservedRange::new(start? : Int, end? : Int) -> E
 }
 pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2200,15 +2124,11 @@ pub impl @json.FromJson for EnumDescriptorProto_EnumReservedRange with fn from_j
 }
 pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
-          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+      (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2277,19 +2197,15 @@ pub fn EnumDescriptorProto::new(name? : String, value : Array[EnumValueDescripto
 }
 pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.value.push((reader |> @lib.read_message() : EnumValueDescriptorProto))
-          (3, _) => msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
-          (4, _) => msg.reserved_range.push((reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange))
-          (5, _) => msg.reserved_name.push(reader |> @lib.read_string())
-          (6, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.value.push((reader |> @lib.read_message() : EnumValueDescriptorProto))
+      (3, _) => msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
+      (4, _) => msg.reserved_range.push((reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange))
+      (5, _) => msg.reserved_name.push(reader |> @lib.read_string())
+      (6, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2374,19 +2290,15 @@ pub impl @json.FromJson for EnumDescriptorProto with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.value.push((reader |> @lib.async_read_message() : EnumValueDescriptorProto))
-          (3, _) => msg.options = (reader |> @lib.async_read_message() : EnumOptions) |> Some
-          (4, _) => msg.reserved_range.push((reader |> @lib.async_read_message() : EnumDescriptorProto_EnumReservedRange))
-          (5, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
-          (6, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.value.push((reader |> @lib.async_read_message() : EnumValueDescriptorProto))
+      (3, _) => msg.options = (reader |> @lib.async_read_message() : EnumOptions) |> Some
+      (4, _) => msg.reserved_range.push((reader |> @lib.async_read_message() : EnumDescriptorProto_EnumReservedRange))
+      (5, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
+      (6, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2457,16 +2369,12 @@ pub fn EnumValueDescriptorProto::new(name? : String, number? : Int, options? : E
 }
 pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.number = reader |> @lib.read_int32() |> Some
-          (3, _) => msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.number = reader |> @lib.read_int32() |> Some
+      (3, _) => msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2521,16 +2429,12 @@ pub impl @json.FromJson for EnumValueDescriptorProto with fn from_json(json: Jso
 }
 pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-          (3, _) => msg.options = (reader |> @lib.async_read_message() : EnumValueOptions) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+      (3, _) => msg.options = (reader |> @lib.async_read_message() : EnumValueOptions) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2586,16 +2490,12 @@ pub fn ServiceDescriptorProto::new(name? : String, method_ : Array[MethodDescrip
 }
 pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.method_.push((reader |> @lib.read_message() : MethodDescriptorProto))
-          (3, _) => msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.method_.push((reader |> @lib.read_message() : MethodDescriptorProto))
+      (3, _) => msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2650,16 +2550,12 @@ pub impl @json.FromJson for ServiceDescriptorProto with fn from_json(json: Json,
 }
 pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.method_.push((reader |> @lib.async_read_message() : MethodDescriptorProto))
-          (3, _) => msg.options = (reader |> @lib.async_read_message() : ServiceOptions) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.method_.push((reader |> @lib.async_read_message() : MethodDescriptorProto))
+      (3, _) => msg.options = (reader |> @lib.async_read_message() : ServiceOptions) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -2733,19 +2629,15 @@ pub fn MethodDescriptorProto::new(name? : String, input_type? : String, output_t
 }
 pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.read_string() |> Some
-          (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
-          (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
-          (4, _) => msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
-          (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
-          (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.read_string() |> Some
+      (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
+      (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
+      (4, _) => msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
+      (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
+      (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -2830,19 +2722,15 @@ pub impl @json.FromJson for MethodDescriptorProto with fn from_json(json: Json, 
 }
 pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-          (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
-          (4, _) => msg.options = (reader |> @lib.async_read_message() : MethodOptions) |> Some
-          (5, _) => msg.client_streaming = reader |> @lib.async_read_bool() |> Some
-          (6, _) => msg.server_streaming = reader |> @lib.async_read_bool() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+      (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
+      (4, _) => msg.options = (reader |> @lib.async_read_message() : MethodOptions) |> Some
+      (5, _) => msg.client_streaming = reader |> @lib.async_read_bool() |> Some
+      (6, _) => msg.server_streaming = reader |> @lib.async_read_bool() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -3065,34 +2953,30 @@ pub fn FileOptions::new(java_package? : String, java_outer_classname? : String, 
 }
 pub impl @lib.Read for FileOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileOptions raise {
   let msg = FileOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.java_package = reader |> @lib.read_string() |> Some
-          (8, _) => msg.java_outer_classname = reader |> @lib.read_string() |> Some
-          (10, _) => msg.java_multiple_files = reader |> @lib.read_bool() |> Some
-          (20, _) => msg.java_generate_equals_and_hash = reader |> @lib.read_bool() |> Some
-          (27, _) => msg.java_string_check_utf8 = reader |> @lib.read_bool() |> Some
-          (9, _) => msg.optimize_for = reader |> @lib.read_enum() |> FileOptions_OptimizeMode::from_enum |> Some
-          (11, _) => msg.go_package = reader |> @lib.read_string() |> Some
-          (16, _) => msg.cc_generic_services = reader |> @lib.read_bool() |> Some
-          (17, _) => msg.java_generic_services = reader |> @lib.read_bool() |> Some
-          (18, _) => msg.py_generic_services = reader |> @lib.read_bool() |> Some
-          (23, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (31, _) => msg.cc_enable_arenas = reader |> @lib.read_bool() |> Some
-          (36, _) => msg.objc_class_prefix = reader |> @lib.read_string() |> Some
-          (37, _) => msg.csharp_namespace = reader |> @lib.read_string() |> Some
-          (39, _) => msg.swift_prefix = reader |> @lib.read_string() |> Some
-          (40, _) => msg.php_class_prefix = reader |> @lib.read_string() |> Some
-          (41, _) => msg.php_namespace = reader |> @lib.read_string() |> Some
-          (44, _) => msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
-          (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
-          (50, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.java_package = reader |> @lib.read_string() |> Some
+      (8, _) => msg.java_outer_classname = reader |> @lib.read_string() |> Some
+      (10, _) => msg.java_multiple_files = reader |> @lib.read_bool() |> Some
+      (20, _) => msg.java_generate_equals_and_hash = reader |> @lib.read_bool() |> Some
+      (27, _) => msg.java_string_check_utf8 = reader |> @lib.read_bool() |> Some
+      (9, _) => msg.optimize_for = reader |> @lib.read_enum() |> FileOptions_OptimizeMode::from_enum |> Some
+      (11, _) => msg.go_package = reader |> @lib.read_string() |> Some
+      (16, _) => msg.cc_generic_services = reader |> @lib.read_bool() |> Some
+      (17, _) => msg.java_generic_services = reader |> @lib.read_bool() |> Some
+      (18, _) => msg.py_generic_services = reader |> @lib.read_bool() |> Some
+      (23, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (31, _) => msg.cc_enable_arenas = reader |> @lib.read_bool() |> Some
+      (36, _) => msg.objc_class_prefix = reader |> @lib.read_string() |> Some
+      (37, _) => msg.csharp_namespace = reader |> @lib.read_string() |> Some
+      (39, _) => msg.swift_prefix = reader |> @lib.read_string() |> Some
+      (40, _) => msg.php_class_prefix = reader |> @lib.read_string() |> Some
+      (41, _) => msg.php_namespace = reader |> @lib.read_string() |> Some
+      (44, _) => msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
+      (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
+      (50, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -3327,34 +3211,30 @@ pub impl @json.FromJson for FileOptions with fn from_json(json: Json, path: @jso
 }
 pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileOptions raise {
   let msg = FileOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.java_package = reader |> @lib.async_read_string() |> Some
-          (8, _) => msg.java_outer_classname = reader |> @lib.async_read_string() |> Some
-          (10, _) => msg.java_multiple_files = reader |> @lib.async_read_bool() |> Some
-          (20, _) => msg.java_generate_equals_and_hash = reader |> @lib.async_read_bool() |> Some
-          (27, _) => msg.java_string_check_utf8 = reader |> @lib.async_read_bool() |> Some
-          (9, _) => msg.optimize_for = reader |> @lib.async_read_enum() |> FileOptions_OptimizeMode::from_enum |> Some
-          (11, _) => msg.go_package = reader |> @lib.async_read_string() |> Some
-          (16, _) => msg.cc_generic_services = reader |> @lib.async_read_bool() |> Some
-          (17, _) => msg.java_generic_services = reader |> @lib.async_read_bool() |> Some
-          (18, _) => msg.py_generic_services = reader |> @lib.async_read_bool() |> Some
-          (23, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (31, _) => msg.cc_enable_arenas = reader |> @lib.async_read_bool() |> Some
-          (36, _) => msg.objc_class_prefix = reader |> @lib.async_read_string() |> Some
-          (37, _) => msg.csharp_namespace = reader |> @lib.async_read_string() |> Some
-          (39, _) => msg.swift_prefix = reader |> @lib.async_read_string() |> Some
-          (40, _) => msg.php_class_prefix = reader |> @lib.async_read_string() |> Some
-          (41, _) => msg.php_namespace = reader |> @lib.async_read_string() |> Some
-          (44, _) => msg.php_metadata_namespace = reader |> @lib.async_read_string() |> Some
-          (45, _) => msg.ruby_package = reader |> @lib.async_read_string() |> Some
-          (50, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.java_package = reader |> @lib.async_read_string() |> Some
+      (8, _) => msg.java_outer_classname = reader |> @lib.async_read_string() |> Some
+      (10, _) => msg.java_multiple_files = reader |> @lib.async_read_bool() |> Some
+      (20, _) => msg.java_generate_equals_and_hash = reader |> @lib.async_read_bool() |> Some
+      (27, _) => msg.java_string_check_utf8 = reader |> @lib.async_read_bool() |> Some
+      (9, _) => msg.optimize_for = reader |> @lib.async_read_enum() |> FileOptions_OptimizeMode::from_enum |> Some
+      (11, _) => msg.go_package = reader |> @lib.async_read_string() |> Some
+      (16, _) => msg.cc_generic_services = reader |> @lib.async_read_bool() |> Some
+      (17, _) => msg.java_generic_services = reader |> @lib.async_read_bool() |> Some
+      (18, _) => msg.py_generic_services = reader |> @lib.async_read_bool() |> Some
+      (23, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (31, _) => msg.cc_enable_arenas = reader |> @lib.async_read_bool() |> Some
+      (36, _) => msg.objc_class_prefix = reader |> @lib.async_read_string() |> Some
+      (37, _) => msg.csharp_namespace = reader |> @lib.async_read_string() |> Some
+      (39, _) => msg.swift_prefix = reader |> @lib.async_read_string() |> Some
+      (40, _) => msg.php_class_prefix = reader |> @lib.async_read_string() |> Some
+      (41, _) => msg.php_namespace = reader |> @lib.async_read_string() |> Some
+      (44, _) => msg.php_metadata_namespace = reader |> @lib.async_read_string() |> Some
+      (45, _) => msg.ruby_package = reader |> @lib.async_read_string() |> Some
+      (50, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -3524,20 +3404,16 @@ pub fn MessageOptions::new(message_set_wire_format? : Bool, no_standard_descript
 }
 pub impl @lib.Read for MessageOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MessageOptions raise {
   let msg = MessageOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.message_set_wire_format = reader |> @lib.read_bool() |> Some
-          (2, _) => msg.no_standard_descriptor_accessor = reader |> @lib.read_bool() |> Some
-          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (7, _) => msg.map_entry = reader |> @lib.read_bool() |> Some
-          (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
-          (12, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.message_set_wire_format = reader |> @lib.read_bool() |> Some
+      (2, _) => msg.no_standard_descriptor_accessor = reader |> @lib.read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (7, _) => msg.map_entry = reader |> @lib.read_bool() |> Some
+      (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
+      (12, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -3632,20 +3508,16 @@ pub impl @json.FromJson for MessageOptions with fn from_json(json: Json, path: @
 }
 pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MessageOptions raise {
   let msg = MessageOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.message_set_wire_format = reader |> @lib.async_read_bool() |> Some
-          (2, _) => msg.no_standard_descriptor_accessor = reader |> @lib.async_read_bool() |> Some
-          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (7, _) => msg.map_entry = reader |> @lib.async_read_bool() |> Some
-          (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
-          (12, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.message_set_wire_format = reader |> @lib.async_read_bool() |> Some
+      (2, _) => msg.no_standard_descriptor_accessor = reader |> @lib.async_read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (7, _) => msg.map_entry = reader |> @lib.async_read_bool() |> Some
+      (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
+      (12, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -3933,15 +3805,11 @@ pub fn FieldOptions_EditionDefault::new(edition? : Edition, value? : String) -> 
 }
 pub impl @lib.Read for FieldOptions_EditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (3, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-          (2, _) => msg.value = reader |> @lib.read_string() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (3, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+      (2, _) => msg.value = reader |> @lib.read_string() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -3986,15 +3854,11 @@ pub impl @json.FromJson for FieldOptions_EditionDefault with fn from_json(json: 
 }
 pub impl @lib.AsyncRead for FieldOptions_EditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (3, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-          (2, _) => msg.value = reader |> @lib.async_read_string() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (3, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+      (2, _) => msg.value = reader |> @lib.async_read_string() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -4051,17 +3915,13 @@ pub fn FieldOptions_FeatureSupport::new(edition_introduced? : Edition, edition_d
 }
 pub impl @lib.Read for FieldOptions_FeatureSupport with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.edition_introduced = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-          (2, _) => msg.edition_deprecated = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-          (3, _) => msg.deprecation_warning = reader |> @lib.read_string() |> Some
-          (4, _) => msg.edition_removed = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.edition_introduced = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+      (2, _) => msg.edition_deprecated = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+      (3, _) => msg.deprecation_warning = reader |> @lib.read_string() |> Some
+      (4, _) => msg.edition_removed = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -4126,17 +3986,13 @@ pub impl @json.FromJson for FieldOptions_FeatureSupport with fn from_json(json: 
 }
 pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.edition_introduced = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-          (2, _) => msg.edition_deprecated = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-          (3, _) => msg.deprecation_warning = reader |> @lib.async_read_string() |> Some
-          (4, _) => msg.edition_removed = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.edition_introduced = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+      (2, _) => msg.edition_deprecated = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+      (3, _) => msg.deprecation_warning = reader |> @lib.async_read_string() |> Some
+      (4, _) => msg.edition_removed = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -4263,28 +4119,24 @@ pub fn FieldOptions::new(ctype? : FieldOptions_CType, packed? : Bool, jstype? : 
 }
 pub impl @lib.Read for FieldOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions raise {
   let msg = FieldOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.ctype = reader |> @lib.read_enum() |> FieldOptions_CType::from_enum |> Some
-          (2, _) => msg.packed = reader |> @lib.read_bool() |> Some
-          (6, _) => msg.jstype = reader |> @lib.read_enum() |> FieldOptions_JSType::from_enum |> Some
-          (5, _) => msg.lazy_ = reader |> @lib.read_bool() |> Some
-          (15, _) => msg.unverified_lazy = reader |> @lib.read_bool() |> Some
-          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (10, _) => msg.weak = reader |> @lib.read_bool() |> Some
-          (16, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-          (17, _) => msg.retention = reader |> @lib.read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
-          (19, 2) => { let packed = reader |> @lib.read_packed(@lib.read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
-          (19, 0) => msg.targets.push(reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum)
-          (20, _) => msg.edition_defaults.push((reader |> @lib.read_message() : FieldOptions_EditionDefault))
-          (21, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (22, _) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.ctype = reader |> @lib.read_enum() |> FieldOptions_CType::from_enum |> Some
+      (2, _) => msg.packed = reader |> @lib.read_bool() |> Some
+      (6, _) => msg.jstype = reader |> @lib.read_enum() |> FieldOptions_JSType::from_enum |> Some
+      (5, _) => msg.lazy_ = reader |> @lib.read_bool() |> Some
+      (15, _) => msg.unverified_lazy = reader |> @lib.read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (10, _) => msg.weak = reader |> @lib.read_bool() |> Some
+      (16, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
+      (17, _) => msg.retention = reader |> @lib.read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
+      (19, 2) => { let packed = reader |> @lib.read_packed(@lib.read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
+      (19, 0) => msg.targets.push(reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum)
+      (20, _) => msg.edition_defaults.push((reader |> @lib.read_message() : FieldOptions_EditionDefault))
+      (21, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (22, _) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -4449,28 +4301,24 @@ pub impl @json.FromJson for FieldOptions with fn from_json(json: Json, path: @js
 }
 pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions raise {
   let msg = FieldOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.ctype = reader |> @lib.async_read_enum() |> FieldOptions_CType::from_enum |> Some
-          (2, _) => msg.packed = reader |> @lib.async_read_bool() |> Some
-          (6, _) => msg.jstype = reader |> @lib.async_read_enum() |> FieldOptions_JSType::from_enum |> Some
-          (5, _) => msg.lazy_ = reader |> @lib.async_read_bool() |> Some
-          (15, _) => msg.unverified_lazy = reader |> @lib.async_read_bool() |> Some
-          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (10, _) => msg.weak = reader |> @lib.async_read_bool() |> Some
-          (16, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-          (17, _) => msg.retention = reader |> @lib.async_read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
-          (19, 2) => { let packed = reader |> @lib.async_read_packed(@lib.async_read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
-          (19, 0) => msg.targets.push(reader |> @lib.async_read_enum() |> FieldOptions_OptionTargetType::from_enum)
-          (20, _) => msg.edition_defaults.push((reader |> @lib.async_read_message() : FieldOptions_EditionDefault))
-          (21, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-          (22, _) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.ctype = reader |> @lib.async_read_enum() |> FieldOptions_CType::from_enum |> Some
+      (2, _) => msg.packed = reader |> @lib.async_read_bool() |> Some
+      (6, _) => msg.jstype = reader |> @lib.async_read_enum() |> FieldOptions_JSType::from_enum |> Some
+      (5, _) => msg.lazy_ = reader |> @lib.async_read_bool() |> Some
+      (15, _) => msg.unverified_lazy = reader |> @lib.async_read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (10, _) => msg.weak = reader |> @lib.async_read_bool() |> Some
+      (16, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
+      (17, _) => msg.retention = reader |> @lib.async_read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
+      (19, 2) => { let packed = reader |> @lib.async_read_packed(@lib.async_read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
+      (19, 0) => msg.targets.push(reader |> @lib.async_read_enum() |> FieldOptions_OptionTargetType::from_enum)
+      (20, _) => msg.edition_defaults.push((reader |> @lib.async_read_message() : FieldOptions_EditionDefault))
+      (21, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (22, _) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -4575,15 +4423,11 @@ pub fn OneofOptions::new(features? : FeatureSet, uninterpreted_option : Array[Un
 }
 pub impl @lib.Read for OneofOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> OneofOptions raise {
   let msg = OneofOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -4628,15 +4472,11 @@ pub impl @json.FromJson for OneofOptions with fn from_json(json: Json, path: @js
 }
 pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> OneofOptions raise {
   let msg = OneofOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -4699,18 +4539,14 @@ pub fn EnumOptions::new(allow_alias? : Bool, deprecated? : Bool, deprecated_lega
 }
 pub impl @lib.Read for EnumOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumOptions raise {
   let msg = EnumOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (2, _) => msg.allow_alias = reader |> @lib.read_bool() |> Some
-          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
-          (7, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (2, _) => msg.allow_alias = reader |> @lib.read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
+      (7, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -4785,18 +4621,14 @@ pub impl @json.FromJson for EnumOptions with fn from_json(json: Json, path: @jso
 }
 pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumOptions raise {
   let msg = EnumOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (2, _) => msg.allow_alias = reader |> @lib.async_read_bool() |> Some
-          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
-          (7, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (2, _) => msg.allow_alias = reader |> @lib.async_read_bool() |> Some
+      (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
+      (7, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -4874,18 +4706,14 @@ pub fn EnumValueOptions::new(deprecated? : Bool, features? : FeatureSet, debug_r
 }
 pub impl @lib.Read for EnumValueOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (2, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-          (4, _) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (2, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
+      (4, _) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -4960,18 +4788,14 @@ pub impl @json.FromJson for EnumValueOptions with fn from_json(json: Json, path:
 }
 pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (2, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-          (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-          (4, _) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (2, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
+      (4, _) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -5037,16 +4861,12 @@ pub fn ServiceOptions::new(features? : FeatureSet, deprecated? : Bool, uninterpr
 }
 pub impl @lib.Read for ServiceOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (34, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (34, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -5101,16 +4921,12 @@ pub impl @json.FromJson for ServiceOptions with fn from_json(json: Json, path: @
 }
 pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (34, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-          (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (34, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -5216,17 +5032,13 @@ pub fn MethodOptions::new(deprecated? : Bool, idempotency_level? : MethodOptions
 }
 pub impl @lib.Read for MethodOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MethodOptions raise {
   let msg = MethodOptions::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-          (34, _) => msg.idempotency_level = reader |> @lib.read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
-          (35, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+      (34, _) => msg.idempotency_level = reader |> @lib.read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
+      (35, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -5291,17 +5103,13 @@ pub impl @json.FromJson for MethodOptions with fn from_json(json: Json, path: @j
 }
 pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MethodOptions raise {
   let msg = MethodOptions::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-          (34, _) => msg.idempotency_level = reader |> @lib.async_read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
-          (35, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+      (34, _) => msg.idempotency_level = reader |> @lib.async_read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
+      (35, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -5352,15 +5160,11 @@ pub fn UninterpretedOption_NamePart::new(name_part : String, is_extension : Bool
 }
 pub impl @lib.Read for UninterpretedOption_NamePart with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name_part = reader |> @lib.read_string()
-          (2, _) => msg.is_extension = reader |> @lib.read_bool()
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name_part = reader |> @lib.read_string()
+      (2, _) => msg.is_extension = reader |> @lib.read_bool()
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -5397,15 +5201,11 @@ pub impl @json.FromJson for UninterpretedOption_NamePart with fn from_json(json:
 }
 pub impl @lib.AsyncRead for UninterpretedOption_NamePart with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.name_part = reader |> @lib.async_read_string()
-          (2, _) => msg.is_extension = reader |> @lib.async_read_bool()
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.name_part = reader |> @lib.async_read_string()
+      (2, _) => msg.is_extension = reader |> @lib.async_read_bool()
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -5474,20 +5274,16 @@ pub fn UninterpretedOption::new(name : Array[UninterpretedOption_NamePart], iden
 }
 pub impl @lib.Read for UninterpretedOption with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (2, _) => msg.name.push((reader |> @lib.read_message() : UninterpretedOption_NamePart))
-          (3, _) => msg.identifier_value = reader |> @lib.read_string() |> Some
-          (4, _) => msg.positive_int_value = reader |> @lib.read_uint64() |> Some
-          (5, _) => msg.negative_int_value = reader |> @lib.read_int64() |> Some
-          (6, _) => msg.double_value = reader |> @lib.read_double() |> Some
-          (7, _) => msg.string_value = reader |> @lib.read_bytes() |> Some
-          (8, _) => msg.aggregate_value = reader |> @lib.read_string() |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (2, _) => msg.name.push((reader |> @lib.read_message() : UninterpretedOption_NamePart))
+      (3, _) => msg.identifier_value = reader |> @lib.read_string() |> Some
+      (4, _) => msg.positive_int_value = reader |> @lib.read_uint64() |> Some
+      (5, _) => msg.negative_int_value = reader |> @lib.read_int64() |> Some
+      (6, _) => msg.double_value = reader |> @lib.read_double() |> Some
+      (7, _) => msg.string_value = reader |> @lib.read_bytes() |> Some
+      (8, _) => msg.aggregate_value = reader |> @lib.read_string() |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -5582,20 +5378,16 @@ pub impl @json.FromJson for UninterpretedOption with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (2, _) => msg.name.push((reader |> @lib.async_read_message() : UninterpretedOption_NamePart))
-          (3, _) => msg.identifier_value = reader |> @lib.async_read_string() |> Some
-          (4, _) => msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some
-          (5, _) => msg.negative_int_value = reader |> @lib.async_read_int64() |> Some
-          (6, _) => msg.double_value = reader |> @lib.async_read_double() |> Some
-          (7, _) => msg.string_value = reader |> @lib.async_read_bytes() |> Some
-          (8, _) => msg.aggregate_value = reader |> @lib.async_read_string() |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (2, _) => msg.name.push((reader |> @lib.async_read_message() : UninterpretedOption_NamePart))
+      (3, _) => msg.identifier_value = reader |> @lib.async_read_string() |> Some
+      (4, _) => msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some
+      (5, _) => msg.negative_int_value = reader |> @lib.async_read_int64() |> Some
+      (6, _) => msg.double_value = reader |> @lib.async_read_double() |> Some
+      (7, _) => msg.string_value = reader |> @lib.async_read_bytes() |> Some
+      (8, _) => msg.aggregate_value = reader |> @lib.async_read_string() |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -6100,21 +5892,17 @@ pub fn FeatureSet::new(field_presence? : FeatureSet_FieldPresence, enum_type? : 
 }
 pub impl @lib.Read for FeatureSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSet raise {
   let msg = FeatureSet::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.field_presence = reader |> @lib.read_enum() |> FeatureSet_FieldPresence::from_enum |> Some
-          (2, _) => msg.enum_type = reader |> @lib.read_enum() |> FeatureSet_EnumType::from_enum |> Some
-          (3, _) => msg.repeated_field_encoding = reader |> @lib.read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some
-          (4, _) => msg.utf8_validation = reader |> @lib.read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some
-          (5, _) => msg.message_encoding = reader |> @lib.read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some
-          (6, _) => msg.json_format = reader |> @lib.read_enum() |> FeatureSet_JsonFormat::from_enum |> Some
-          (7, _) => msg.enforce_naming_style = reader |> @lib.read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some
-          (8, _) => msg.default_symbol_visibility = reader |> @lib.read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.field_presence = reader |> @lib.read_enum() |> FeatureSet_FieldPresence::from_enum |> Some
+      (2, _) => msg.enum_type = reader |> @lib.read_enum() |> FeatureSet_EnumType::from_enum |> Some
+      (3, _) => msg.repeated_field_encoding = reader |> @lib.read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some
+      (4, _) => msg.utf8_validation = reader |> @lib.read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some
+      (5, _) => msg.message_encoding = reader |> @lib.read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some
+      (6, _) => msg.json_format = reader |> @lib.read_enum() |> FeatureSet_JsonFormat::from_enum |> Some
+      (7, _) => msg.enforce_naming_style = reader |> @lib.read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some
+      (8, _) => msg.default_symbol_visibility = reader |> @lib.read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -6219,21 +6007,17 @@ pub impl @json.FromJson for FeatureSet with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for FeatureSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSet raise {
   let msg = FeatureSet::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.field_presence = reader |> @lib.async_read_enum() |> FeatureSet_FieldPresence::from_enum |> Some
-          (2, _) => msg.enum_type = reader |> @lib.async_read_enum() |> FeatureSet_EnumType::from_enum |> Some
-          (3, _) => msg.repeated_field_encoding = reader |> @lib.async_read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some
-          (4, _) => msg.utf8_validation = reader |> @lib.async_read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some
-          (5, _) => msg.message_encoding = reader |> @lib.async_read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some
-          (6, _) => msg.json_format = reader |> @lib.async_read_enum() |> FeatureSet_JsonFormat::from_enum |> Some
-          (7, _) => msg.enforce_naming_style = reader |> @lib.async_read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some
-          (8, _) => msg.default_symbol_visibility = reader |> @lib.async_read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.field_presence = reader |> @lib.async_read_enum() |> FeatureSet_FieldPresence::from_enum |> Some
+      (2, _) => msg.enum_type = reader |> @lib.async_read_enum() |> FeatureSet_EnumType::from_enum |> Some
+      (3, _) => msg.repeated_field_encoding = reader |> @lib.async_read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some
+      (4, _) => msg.utf8_validation = reader |> @lib.async_read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some
+      (5, _) => msg.message_encoding = reader |> @lib.async_read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some
+      (6, _) => msg.json_format = reader |> @lib.async_read_enum() |> FeatureSet_JsonFormat::from_enum |> Some
+      (7, _) => msg.enforce_naming_style = reader |> @lib.async_read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some
+      (8, _) => msg.default_symbol_visibility = reader |> @lib.async_read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -6314,16 +6098,12 @@ pub fn FeatureSetDefaults_FeatureSetEditionDefault::new(edition? : Edition, over
 }
 pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (3, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-          (4, _) => msg.overridable_features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          (5, _) => msg.fixed_features = (reader |> @lib.read_message() : FeatureSet) |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (3, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+      (4, _) => msg.overridable_features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (5, _) => msg.fixed_features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -6378,16 +6158,12 @@ pub impl @json.FromJson for FeatureSetDefaults_FeatureSetEditionDefault with fn 
 }
 pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (3, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-          (4, _) => msg.overridable_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-          (5, _) => msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (3, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+      (4, _) => msg.overridable_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (5, _) => msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -6443,16 +6219,12 @@ pub fn FeatureSetDefaults::new(defaults : Array[FeatureSetDefaults_FeatureSetEdi
 }
 pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.defaults.push((reader |> @lib.read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
-          (4, _) => msg.minimum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-          (5, _) => msg.maximum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.defaults.push((reader |> @lib.read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
+      (4, _) => msg.minimum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+      (5, _) => msg.maximum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -6507,16 +6279,12 @@ pub impl @json.FromJson for FeatureSetDefaults with fn from_json(json: Json, pat
 }
 pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.defaults.push((reader |> @lib.async_read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
-          (4, _) => msg.minimum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-          (5, _) => msg.maximum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.defaults.push((reader |> @lib.async_read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
+      (4, _) => msg.minimum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+      (5, _) => msg.maximum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -6584,20 +6352,16 @@ pub fn SourceCodeInfo_Location::new(path : Array[Int], span : Array[Int], leadin
 }
 pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-          (1, 0) => msg.path.push(reader |> @lib.read_int32())
-          (2, 2) => { msg.span.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-          (2, 0) => msg.span.push(reader |> @lib.read_int32())
-          (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
-          (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
-          (6, _) => msg.leading_detached_comments.push(reader |> @lib.read_string())
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (1, 0) => msg.path.push(reader |> @lib.read_int32())
+      (2, 2) => { msg.span.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (2, 0) => msg.span.push(reader |> @lib.read_int32())
+      (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
+      (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
+      (6, _) => msg.leading_detached_comments.push(reader |> @lib.read_string())
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -6680,20 +6444,16 @@ pub impl @json.FromJson for SourceCodeInfo_Location with fn from_json(json: Json
 }
 pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-          (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
-          (2, 2) => { msg.span.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-          (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
-          (3, _) => msg.leading_comments = reader |> @lib.async_read_string() |> Some
-          (4, _) => msg.trailing_comments = reader |> @lib.async_read_string() |> Some
-          (6, _) => msg.leading_detached_comments.push(reader |> @lib.async_read_string())
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+      (2, 2) => { msg.span.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
+      (3, _) => msg.leading_comments = reader |> @lib.async_read_string() |> Some
+      (4, _) => msg.trailing_comments = reader |> @lib.async_read_string() |> Some
+      (6, _) => msg.leading_detached_comments.push(reader |> @lib.async_read_string())
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -6755,14 +6515,10 @@ pub fn SourceCodeInfo::new(location : Array[SourceCodeInfo_Location]) -> SourceC
 }
 pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.location.push((reader |> @lib.read_message() : SourceCodeInfo_Location))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.location.push((reader |> @lib.read_message() : SourceCodeInfo_Location))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -6797,14 +6553,10 @@ pub impl @json.FromJson for SourceCodeInfo with fn from_json(json: Json, path: @
 }
 pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.location.push((reader |> @lib.async_read_message() : SourceCodeInfo_Location))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.location.push((reader |> @lib.async_read_message() : SourceCodeInfo_Location))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -6906,19 +6658,15 @@ pub fn GeneratedCodeInfo_Annotation::new(path : Array[Int], source_file? : Strin
 }
 pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-          (1, 0) => msg.path.push(reader |> @lib.read_int32())
-          (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
-          (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
-          (4, _) => msg.end = reader |> @lib.read_int32() |> Some
-          (5, _) => msg.semantic = reader |> @lib.read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (1, 0) => msg.path.push(reader |> @lib.read_int32())
+      (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
+      (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
+      (4, _) => msg.end = reader |> @lib.read_int32() |> Some
+      (5, _) => msg.semantic = reader |> @lib.read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -6997,19 +6745,15 @@ pub impl @json.FromJson for GeneratedCodeInfo_Annotation with fn from_json(json:
 }
 pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-          (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
-          (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
-          (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
-          (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-          (5, _) => msg.semantic = reader |> @lib.async_read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+      (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
+      (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
+      (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+      (5, _) => msg.semantic = reader |> @lib.async_read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg
@@ -7067,14 +6811,10 @@ pub fn GeneratedCodeInfo::new(annotation : Array[GeneratedCodeInfo_Annotation]) 
 }
 pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
-  for ;; {
-    match (reader |> @lib.read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.annotation.push((reader |> @lib.read_message() : GeneratedCodeInfo_Annotation))
-          _ => reader |> @lib.skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.annotation.push((reader |> @lib.read_message() : GeneratedCodeInfo_Annotation))
+      _ => reader |> @lib.skip_message_field(wire)
     }
   }
   msg
@@ -7109,14 +6849,10 @@ pub impl @json.FromJson for GeneratedCodeInfo with fn from_json(json: Json, path
 }
 pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
-  for ;; {
-    match (reader |> @lib.async_read_next_message_field()) {
-      Some((field_number, wire)) =>
-        match (field_number, wire) {
-          (1, _) => msg.annotation.push((reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation))
-          _ => reader |> @lib.async_skip_message_field(wire)
-        }
-      None => break
+  while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
+    match (field_number, wire) {
+      (1, _) => msg.annotation.push((reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation))
+      _ => reader |> @lib.async_skip_message_field(wire)
     }
   }
   msg

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -162,12 +162,16 @@ pub fn FileDescriptorSet::new(file : Array[FileDescriptorProto]) -> FileDescript
 }
 pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.file.push((reader |> @lib.read_message() : FileDescriptorProto)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FileDescriptorSet with fn write(self: FileDescriptorSet, writer : &@lib.Writer) -> Unit raise {
@@ -200,12 +204,16 @@ pub impl @json.FromJson for FileDescriptorSet with fn from_json(json: Json, path
 }
 pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileDescriptorSet raise {
   let msg = FileDescriptorSet::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.file.push((reader |> @lib.async_read_message() : FileDescriptorProto)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.file.push((reader |> @lib.async_read_message() : FileDescriptorProto))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FileDescriptorSet with fn write(self: FileDescriptorSet, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -315,27 +323,31 @@ pub fn FileDescriptorProto::new(name? : String, package_? : String, dependency :
 }
 pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
-      (2, _) => { msg.package_ = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.dependency.push(reader |> @lib.read_string()); true }
-      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
-      (10, 0) => { msg.public_dependency.push(reader |> @lib.read_int32()); true }
-      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
-      (11, 0) => { msg.weak_dependency.push(reader |> @lib.read_int32()); true }
-      (15, _) => { msg.option_dependency.push(reader |> @lib.read_string()); true }
-      (4, _) => { msg.message_type.push((reader |> @lib.read_message() : DescriptorProto)); true }
-      (5, _) => { msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto)); true }
-      (6, _) => { msg.service.push((reader |> @lib.read_message() : ServiceDescriptorProto)); true }
-      (7, _) => { msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto)); true }
-      (8, _) => { msg.options = (reader |> @lib.read_message() : FileOptions) |> Some; true }
-      (9, _) => { msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo) |> Some; true }
-      (12, _) => { msg.syntax = reader |> @lib.read_string() |> Some; true }
-      (14, _) => { msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
+          (3, _) => msg.dependency.push(reader |> @lib.read_string())
+          (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+          (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
+          (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+          (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
+          (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
+          (4, _) => msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
+          (5, _) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
+          (6, _) => msg.service.push((reader |> @lib.read_message() : ServiceDescriptorProto))
+          (7, _) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
+          (8, _) => msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
+          (9, _) => msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo) |> Some
+          (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
+          (14, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FileDescriptorProto with fn write(self: FileDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -498,27 +510,31 @@ pub impl @json.FromJson for FileDescriptorProto with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileDescriptorProto raise {
   let msg = FileDescriptorProto::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
-      (2, _) => { msg.package_ = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.dependency.push(reader |> @lib.async_read_string()); true }
-      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
-      (10, 0) => { msg.public_dependency.push(reader |> @lib.async_read_int32()); true }
-      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
-      (11, 0) => { msg.weak_dependency.push(reader |> @lib.async_read_int32()); true }
-      (15, _) => { msg.option_dependency.push(reader |> @lib.async_read_string()); true }
-      (4, _) => { msg.message_type.push((reader |> @lib.async_read_message() : DescriptorProto)); true }
-      (5, _) => { msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto)); true }
-      (6, _) => { msg.service.push((reader |> @lib.async_read_message() : ServiceDescriptorProto)); true }
-      (7, _) => { msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto)); true }
-      (8, _) => { msg.options = (reader |> @lib.async_read_message() : FileOptions) |> Some; true }
-      (9, _) => { msg.source_code_info = (reader |> @lib.async_read_message() : SourceCodeInfo) |> Some; true }
-      (12, _) => { msg.syntax = reader |> @lib.async_read_string() |> Some; true }
-      (14, _) => { msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
+          (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+          (10, 0) => msg.public_dependency.push(reader |> @lib.async_read_int32())
+          (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+          (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
+          (15, _) => msg.option_dependency.push(reader |> @lib.async_read_string())
+          (4, _) => msg.message_type.push((reader |> @lib.async_read_message() : DescriptorProto))
+          (5, _) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
+          (6, _) => msg.service.push((reader |> @lib.async_read_message() : ServiceDescriptorProto))
+          (7, _) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+          (8, _) => msg.options = (reader |> @lib.async_read_message() : FileOptions) |> Some
+          (9, _) => msg.source_code_info = (reader |> @lib.async_read_message() : SourceCodeInfo) |> Some
+          (12, _) => msg.syntax = reader |> @lib.async_read_string() |> Some
+          (14, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FileDescriptorProto with fn write(self: FileDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -627,14 +643,18 @@ pub fn DescriptorProto_ExtensionRange::new(start? : Int, end? : Int, options? : 
 }
 pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.start = reader |> @lib.read_int32() |> Some; true }
-      (2, _) => { msg.end = reader |> @lib.read_int32() |> Some; true }
-      (3, _) => { msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+          (3, _) => msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for DescriptorProto_ExtensionRange with fn write(self: DescriptorProto_ExtensionRange, writer : &@lib.Writer) -> Unit raise {
@@ -687,14 +707,18 @@ pub impl @json.FromJson for DescriptorProto_ExtensionRange with fn from_json(jso
 }
 pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto_ExtensionRange raise {
   let msg = DescriptorProto_ExtensionRange::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.start = reader |> @lib.async_read_int32() |> Some; true }
-      (2, _) => { msg.end = reader |> @lib.async_read_int32() |> Some; true }
-      (3, _) => { msg.options = (reader |> @lib.async_read_message() : ExtensionRangeOptions) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+          (3, _) => msg.options = (reader |> @lib.async_read_message() : ExtensionRangeOptions) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for DescriptorProto_ExtensionRange with fn write(self: DescriptorProto_ExtensionRange, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -742,13 +766,17 @@ pub fn DescriptorProto_ReservedRange::new(start? : Int, end? : Int) -> Descripto
 }
 pub impl @lib.Read for DescriptorProto_ReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.start = reader |> @lib.read_int32() |> Some; true }
-      (2, _) => { msg.end = reader |> @lib.read_int32() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for DescriptorProto_ReservedRange with fn write(self: DescriptorProto_ReservedRange, writer : &@lib.Writer) -> Unit raise {
@@ -791,13 +819,17 @@ pub impl @json.FromJson for DescriptorProto_ReservedRange with fn from_json(json
 }
 pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto_ReservedRange raise {
   let msg = DescriptorProto_ReservedRange::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.start = reader |> @lib.async_read_int32() |> Some; true }
-      (2, _) => { msg.end = reader |> @lib.async_read_int32() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for DescriptorProto_ReservedRange with fn write(self: DescriptorProto_ReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -894,22 +926,26 @@ pub fn DescriptorProto::new(name? : String, field : Array[FieldDescriptorProto],
 }
 pub impl @lib.Read for DescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
-      (2, _) => { msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto)); true }
-      (6, _) => { msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto)); true }
-      (3, _) => { msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto)); true }
-      (4, _) => { msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto)); true }
-      (5, _) => { msg.extension_range.push((reader |> @lib.read_message() : DescriptorProto_ExtensionRange)); true }
-      (8, _) => { msg.oneof_decl.push((reader |> @lib.read_message() : OneofDescriptorProto)); true }
-      (7, _) => { msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some; true }
-      (9, _) => { msg.reserved_range.push((reader |> @lib.read_message() : DescriptorProto_ReservedRange)); true }
-      (10, _) => { msg.reserved_name.push(reader |> @lib.read_string()); true }
-      (11, _) => { msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
+          (6, _) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
+          (3, _) => msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto))
+          (4, _) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
+          (5, _) => msg.extension_range.push((reader |> @lib.read_message() : DescriptorProto_ExtensionRange))
+          (8, _) => msg.oneof_decl.push((reader |> @lib.read_message() : OneofDescriptorProto))
+          (7, _) => msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
+          (9, _) => msg.reserved_range.push((reader |> @lib.read_message() : DescriptorProto_ReservedRange))
+          (10, _) => msg.reserved_name.push(reader |> @lib.read_string())
+          (11, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for DescriptorProto with fn write(self: DescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -1042,22 +1078,26 @@ pub impl @json.FromJson for DescriptorProto with fn from_json(json: Json, path: 
 }
 pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> DescriptorProto raise {
   let msg = DescriptorProto::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
-      (2, _) => { msg.field.push((reader |> @lib.async_read_message() : FieldDescriptorProto)); true }
-      (6, _) => { msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto)); true }
-      (3, _) => { msg.nested_type.push((reader |> @lib.async_read_message() : DescriptorProto)); true }
-      (4, _) => { msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto)); true }
-      (5, _) => { msg.extension_range.push((reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange)); true }
-      (8, _) => { msg.oneof_decl.push((reader |> @lib.async_read_message() : OneofDescriptorProto)); true }
-      (7, _) => { msg.options = (reader |> @lib.async_read_message() : MessageOptions) |> Some; true }
-      (9, _) => { msg.reserved_range.push((reader |> @lib.async_read_message() : DescriptorProto_ReservedRange)); true }
-      (10, _) => { msg.reserved_name.push(reader |> @lib.async_read_string()); true }
-      (11, _) => { msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.field.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+          (6, _) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+          (3, _) => msg.nested_type.push((reader |> @lib.async_read_message() : DescriptorProto))
+          (4, _) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
+          (5, _) => msg.extension_range.push((reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange))
+          (8, _) => msg.oneof_decl.push((reader |> @lib.async_read_message() : OneofDescriptorProto))
+          (7, _) => msg.options = (reader |> @lib.async_read_message() : MessageOptions) |> Some
+          (9, _) => msg.reserved_range.push((reader |> @lib.async_read_message() : DescriptorProto_ReservedRange))
+          (10, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
+          (11, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for DescriptorProto with fn write(self: DescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1201,16 +1241,20 @@ pub fn ExtensionRangeOptions_Declaration::new(number? : Int, full_name? : String
 }
 pub impl @lib.Read for ExtensionRangeOptions_Declaration with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.number = reader |> @lib.read_int32() |> Some; true }
-      (2, _) => { msg.full_name = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.type_ = reader |> @lib.read_string() |> Some; true }
-      (5, _) => { msg.reserved = reader |> @lib.read_bool() |> Some; true }
-      (6, _) => { msg.repeated = reader |> @lib.read_bool() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.number = reader |> @lib.read_int32() |> Some
+          (2, _) => msg.full_name = reader |> @lib.read_string() |> Some
+          (3, _) => msg.type_ = reader |> @lib.read_string() |> Some
+          (5, _) => msg.reserved = reader |> @lib.read_bool() |> Some
+          (6, _) => msg.repeated = reader |> @lib.read_bool() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for ExtensionRangeOptions_Declaration with fn write(self: ExtensionRangeOptions_Declaration, writer : &@lib.Writer) -> Unit raise {
@@ -1283,16 +1327,20 @@ pub impl @json.FromJson for ExtensionRangeOptions_Declaration with fn from_json(
 }
 pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ExtensionRangeOptions_Declaration raise {
   let msg = ExtensionRangeOptions_Declaration::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.number = reader |> @lib.async_read_int32() |> Some; true }
-      (2, _) => { msg.full_name = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.type_ = reader |> @lib.async_read_string() |> Some; true }
-      (5, _) => { msg.reserved = reader |> @lib.async_read_bool() |> Some; true }
-      (6, _) => { msg.repeated = reader |> @lib.async_read_bool() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+          (2, _) => msg.full_name = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
+          (5, _) => msg.reserved = reader |> @lib.async_read_bool() |> Some
+          (6, _) => msg.repeated = reader |> @lib.async_read_bool() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for ExtensionRangeOptions_Declaration with fn write(self: ExtensionRangeOptions_Declaration, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1362,15 +1410,19 @@ pub fn ExtensionRangeOptions::new(uninterpreted_option : Array[UninterpretedOpti
 }
 pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
-      (2, _) => { msg.declaration.push((reader |> @lib.read_message() : ExtensionRangeOptions_Declaration)); true }
-      (50, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
-      (3, _) => { msg.verification = reader |> @lib.read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+          (2, _) => msg.declaration.push((reader |> @lib.read_message() : ExtensionRangeOptions_Declaration))
+          (50, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (3, _) => msg.verification = reader |> @lib.read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for ExtensionRangeOptions with fn write(self: ExtensionRangeOptions, writer : &@lib.Writer) -> Unit raise {
@@ -1433,15 +1485,19 @@ pub impl @json.FromJson for ExtensionRangeOptions with fn from_json(json: Json, 
 }
 pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ExtensionRangeOptions raise {
   let msg = ExtensionRangeOptions::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
-      (2, _) => { msg.declaration.push((reader |> @lib.async_read_message() : ExtensionRangeOptions_Declaration)); true }
-      (50, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
-      (3, _) => { msg.verification = reader |> @lib.async_read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+          (2, _) => msg.declaration.push((reader |> @lib.async_read_message() : ExtensionRangeOptions_Declaration))
+          (50, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+          (3, _) => msg.verification = reader |> @lib.async_read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for ExtensionRangeOptions with fn write(self: ExtensionRangeOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1726,22 +1782,26 @@ pub fn FieldDescriptorProto::new(name? : String, number? : Int, label? : FieldDe
 }
 pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.number = reader |> @lib.read_int32() |> Some; true }
-      (4, _) => { msg.label = reader |> @lib.read_enum() |> FieldDescriptorProto_Label::from_enum |> Some; true }
-      (5, _) => { msg.type_ = reader |> @lib.read_enum() |> FieldDescriptorProto_Type::from_enum |> Some; true }
-      (6, _) => { msg.type_name = reader |> @lib.read_string() |> Some; true }
-      (2, _) => { msg.extendee = reader |> @lib.read_string() |> Some; true }
-      (7, _) => { msg.default_value = reader |> @lib.read_string() |> Some; true }
-      (9, _) => { msg.oneof_index = reader |> @lib.read_int32() |> Some; true }
-      (10, _) => { msg.json_name = reader |> @lib.read_string() |> Some; true }
-      (8, _) => { msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some; true }
-      (17, _) => { msg.proto3_optional = reader |> @lib.read_bool() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (3, _) => msg.number = reader |> @lib.read_int32() |> Some
+          (4, _) => msg.label = reader |> @lib.read_enum() |> FieldDescriptorProto_Label::from_enum |> Some
+          (5, _) => msg.type_ = reader |> @lib.read_enum() |> FieldDescriptorProto_Type::from_enum |> Some
+          (6, _) => msg.type_name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.extendee = reader |> @lib.read_string() |> Some
+          (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
+          (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
+          (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
+          (8, _) => msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
+          (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FieldDescriptorProto with fn write(self: FieldDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -1874,22 +1934,26 @@ pub impl @json.FromJson for FieldDescriptorProto with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldDescriptorProto raise {
   let msg = FieldDescriptorProto::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.number = reader |> @lib.async_read_int32() |> Some; true }
-      (4, _) => { msg.label = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Label::from_enum |> Some; true }
-      (5, _) => { msg.type_ = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Type::from_enum |> Some; true }
-      (6, _) => { msg.type_name = reader |> @lib.async_read_string() |> Some; true }
-      (2, _) => { msg.extendee = reader |> @lib.async_read_string() |> Some; true }
-      (7, _) => { msg.default_value = reader |> @lib.async_read_string() |> Some; true }
-      (9, _) => { msg.oneof_index = reader |> @lib.async_read_int32() |> Some; true }
-      (10, _) => { msg.json_name = reader |> @lib.async_read_string() |> Some; true }
-      (8, _) => { msg.options = (reader |> @lib.async_read_message() : FieldOptions) |> Some; true }
-      (17, _) => { msg.proto3_optional = reader |> @lib.async_read_bool() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+          (4, _) => msg.label = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Label::from_enum |> Some
+          (5, _) => msg.type_ = reader |> @lib.async_read_enum() |> FieldDescriptorProto_Type::from_enum |> Some
+          (6, _) => msg.type_name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.extendee = reader |> @lib.async_read_string() |> Some
+          (7, _) => msg.default_value = reader |> @lib.async_read_string() |> Some
+          (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
+          (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
+          (8, _) => msg.options = (reader |> @lib.async_read_message() : FieldOptions) |> Some
+          (17, _) => msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FieldDescriptorProto with fn write(self: FieldDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -1977,13 +2041,17 @@ pub fn OneofDescriptorProto::new(name? : String, options? : OneofOptions) -> One
 }
 pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
-      (2, _) => { msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for OneofDescriptorProto with fn write(self: OneofDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -2026,13 +2094,17 @@ pub impl @json.FromJson for OneofDescriptorProto with fn from_json(json: Json, p
 }
 pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> OneofDescriptorProto raise {
   let msg = OneofDescriptorProto::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
-      (2, _) => { msg.options = (reader |> @lib.async_read_message() : OneofOptions) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.options = (reader |> @lib.async_read_message() : OneofOptions) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for OneofDescriptorProto with fn write(self: OneofDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2075,13 +2147,17 @@ pub fn EnumDescriptorProto_EnumReservedRange::new(start? : Int, end? : Int) -> E
 }
 pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.start = reader |> @lib.read_int32() |> Some; true }
-      (2, _) => { msg.end = reader |> @lib.read_int32() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.read_int32() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for EnumDescriptorProto_EnumReservedRange with fn write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.Writer) -> Unit raise {
@@ -2124,13 +2200,17 @@ pub impl @json.FromJson for EnumDescriptorProto_EnumReservedRange with fn from_j
 }
 pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumDescriptorProto_EnumReservedRange raise {
   let msg = EnumDescriptorProto_EnumReservedRange::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.start = reader |> @lib.async_read_int32() |> Some; true }
-      (2, _) => { msg.end = reader |> @lib.async_read_int32() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
+          (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for EnumDescriptorProto_EnumReservedRange with fn write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2197,17 +2277,21 @@ pub fn EnumDescriptorProto::new(name? : String, value : Array[EnumValueDescripto
 }
 pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
-      (2, _) => { msg.value.push((reader |> @lib.read_message() : EnumValueDescriptorProto)); true }
-      (3, _) => { msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some; true }
-      (4, _) => { msg.reserved_range.push((reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange)); true }
-      (5, _) => { msg.reserved_name.push(reader |> @lib.read_string()); true }
-      (6, _) => { msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.value.push((reader |> @lib.read_message() : EnumValueDescriptorProto))
+          (3, _) => msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
+          (4, _) => msg.reserved_range.push((reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange))
+          (5, _) => msg.reserved_name.push(reader |> @lib.read_string())
+          (6, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for EnumDescriptorProto with fn write(self: EnumDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -2290,17 +2374,21 @@ pub impl @json.FromJson for EnumDescriptorProto with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumDescriptorProto raise {
   let msg = EnumDescriptorProto::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
-      (2, _) => { msg.value.push((reader |> @lib.async_read_message() : EnumValueDescriptorProto)); true }
-      (3, _) => { msg.options = (reader |> @lib.async_read_message() : EnumOptions) |> Some; true }
-      (4, _) => { msg.reserved_range.push((reader |> @lib.async_read_message() : EnumDescriptorProto_EnumReservedRange)); true }
-      (5, _) => { msg.reserved_name.push(reader |> @lib.async_read_string()); true }
-      (6, _) => { msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.value.push((reader |> @lib.async_read_message() : EnumValueDescriptorProto))
+          (3, _) => msg.options = (reader |> @lib.async_read_message() : EnumOptions) |> Some
+          (4, _) => msg.reserved_range.push((reader |> @lib.async_read_message() : EnumDescriptorProto_EnumReservedRange))
+          (5, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
+          (6, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for EnumDescriptorProto with fn write(self: EnumDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2369,14 +2457,18 @@ pub fn EnumValueDescriptorProto::new(name? : String, number? : Int, options? : E
 }
 pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
-      (2, _) => { msg.number = reader |> @lib.read_int32() |> Some; true }
-      (3, _) => { msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.number = reader |> @lib.read_int32() |> Some
+          (3, _) => msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for EnumValueDescriptorProto with fn write(self: EnumValueDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -2429,14 +2521,18 @@ pub impl @json.FromJson for EnumValueDescriptorProto with fn from_json(json: Jso
 }
 pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumValueDescriptorProto raise {
   let msg = EnumValueDescriptorProto::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
-      (2, _) => { msg.number = reader |> @lib.async_read_int32() |> Some; true }
-      (3, _) => { msg.options = (reader |> @lib.async_read_message() : EnumValueOptions) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
+          (3, _) => msg.options = (reader |> @lib.async_read_message() : EnumValueOptions) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for EnumValueDescriptorProto with fn write(self: EnumValueDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2490,14 +2586,18 @@ pub fn ServiceDescriptorProto::new(name? : String, method_ : Array[MethodDescrip
 }
 pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
-      (2, _) => { msg.method_.push((reader |> @lib.read_message() : MethodDescriptorProto)); true }
-      (3, _) => { msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.method_.push((reader |> @lib.read_message() : MethodDescriptorProto))
+          (3, _) => msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for ServiceDescriptorProto with fn write(self: ServiceDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -2550,14 +2650,18 @@ pub impl @json.FromJson for ServiceDescriptorProto with fn from_json(json: Json,
 }
 pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ServiceDescriptorProto raise {
   let msg = ServiceDescriptorProto::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
-      (2, _) => { msg.method_.push((reader |> @lib.async_read_message() : MethodDescriptorProto)); true }
-      (3, _) => { msg.options = (reader |> @lib.async_read_message() : ServiceOptions) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.method_.push((reader |> @lib.async_read_message() : MethodDescriptorProto))
+          (3, _) => msg.options = (reader |> @lib.async_read_message() : ServiceOptions) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for ServiceDescriptorProto with fn write(self: ServiceDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2629,17 +2733,21 @@ pub fn MethodDescriptorProto::new(name? : String, input_type? : String, output_t
 }
 pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.read_string() |> Some; true }
-      (2, _) => { msg.input_type = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.output_type = reader |> @lib.read_string() |> Some; true }
-      (4, _) => { msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some; true }
-      (5, _) => { msg.client_streaming = reader |> @lib.read_bool() |> Some; true }
-      (6, _) => { msg.server_streaming = reader |> @lib.read_bool() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.read_string() |> Some
+          (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
+          (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
+          (4, _) => msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
+          (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
+          (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for MethodDescriptorProto with fn write(self: MethodDescriptorProto, writer : &@lib.Writer) -> Unit raise {
@@ -2722,17 +2830,21 @@ pub impl @json.FromJson for MethodDescriptorProto with fn from_json(json: Json, 
 }
 pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MethodDescriptorProto raise {
   let msg = MethodDescriptorProto::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name = reader |> @lib.async_read_string() |> Some; true }
-      (2, _) => { msg.input_type = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.output_type = reader |> @lib.async_read_string() |> Some; true }
-      (4, _) => { msg.options = (reader |> @lib.async_read_message() : MethodOptions) |> Some; true }
-      (5, _) => { msg.client_streaming = reader |> @lib.async_read_bool() |> Some; true }
-      (6, _) => { msg.server_streaming = reader |> @lib.async_read_bool() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
+          (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
+          (4, _) => msg.options = (reader |> @lib.async_read_message() : MethodOptions) |> Some
+          (5, _) => msg.client_streaming = reader |> @lib.async_read_bool() |> Some
+          (6, _) => msg.server_streaming = reader |> @lib.async_read_bool() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for MethodDescriptorProto with fn write(self: MethodDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -2953,32 +3065,36 @@ pub fn FileOptions::new(java_package? : String, java_outer_classname? : String, 
 }
 pub impl @lib.Read for FileOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FileOptions raise {
   let msg = FileOptions::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.java_package = reader |> @lib.read_string() |> Some; true }
-      (8, _) => { msg.java_outer_classname = reader |> @lib.read_string() |> Some; true }
-      (10, _) => { msg.java_multiple_files = reader |> @lib.read_bool() |> Some; true }
-      (20, _) => { msg.java_generate_equals_and_hash = reader |> @lib.read_bool() |> Some; true }
-      (27, _) => { msg.java_string_check_utf8 = reader |> @lib.read_bool() |> Some; true }
-      (9, _) => { msg.optimize_for = reader |> @lib.read_enum() |> FileOptions_OptimizeMode::from_enum |> Some; true }
-      (11, _) => { msg.go_package = reader |> @lib.read_string() |> Some; true }
-      (16, _) => { msg.cc_generic_services = reader |> @lib.read_bool() |> Some; true }
-      (17, _) => { msg.java_generic_services = reader |> @lib.read_bool() |> Some; true }
-      (18, _) => { msg.py_generic_services = reader |> @lib.read_bool() |> Some; true }
-      (23, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
-      (31, _) => { msg.cc_enable_arenas = reader |> @lib.read_bool() |> Some; true }
-      (36, _) => { msg.objc_class_prefix = reader |> @lib.read_string() |> Some; true }
-      (37, _) => { msg.csharp_namespace = reader |> @lib.read_string() |> Some; true }
-      (39, _) => { msg.swift_prefix = reader |> @lib.read_string() |> Some; true }
-      (40, _) => { msg.php_class_prefix = reader |> @lib.read_string() |> Some; true }
-      (41, _) => { msg.php_namespace = reader |> @lib.read_string() |> Some; true }
-      (44, _) => { msg.php_metadata_namespace = reader |> @lib.read_string() |> Some; true }
-      (45, _) => { msg.ruby_package = reader |> @lib.read_string() |> Some; true }
-      (50, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.java_package = reader |> @lib.read_string() |> Some
+          (8, _) => msg.java_outer_classname = reader |> @lib.read_string() |> Some
+          (10, _) => msg.java_multiple_files = reader |> @lib.read_bool() |> Some
+          (20, _) => msg.java_generate_equals_and_hash = reader |> @lib.read_bool() |> Some
+          (27, _) => msg.java_string_check_utf8 = reader |> @lib.read_bool() |> Some
+          (9, _) => msg.optimize_for = reader |> @lib.read_enum() |> FileOptions_OptimizeMode::from_enum |> Some
+          (11, _) => msg.go_package = reader |> @lib.read_string() |> Some
+          (16, _) => msg.cc_generic_services = reader |> @lib.read_bool() |> Some
+          (17, _) => msg.java_generic_services = reader |> @lib.read_bool() |> Some
+          (18, _) => msg.py_generic_services = reader |> @lib.read_bool() |> Some
+          (23, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (31, _) => msg.cc_enable_arenas = reader |> @lib.read_bool() |> Some
+          (36, _) => msg.objc_class_prefix = reader |> @lib.read_string() |> Some
+          (37, _) => msg.csharp_namespace = reader |> @lib.read_string() |> Some
+          (39, _) => msg.swift_prefix = reader |> @lib.read_string() |> Some
+          (40, _) => msg.php_class_prefix = reader |> @lib.read_string() |> Some
+          (41, _) => msg.php_namespace = reader |> @lib.read_string() |> Some
+          (44, _) => msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
+          (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
+          (50, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FileOptions with fn write(self: FileOptions, writer : &@lib.Writer) -> Unit raise {
@@ -3211,32 +3327,36 @@ pub impl @json.FromJson for FileOptions with fn from_json(json: Json, path: @jso
 }
 pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FileOptions raise {
   let msg = FileOptions::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.java_package = reader |> @lib.async_read_string() |> Some; true }
-      (8, _) => { msg.java_outer_classname = reader |> @lib.async_read_string() |> Some; true }
-      (10, _) => { msg.java_multiple_files = reader |> @lib.async_read_bool() |> Some; true }
-      (20, _) => { msg.java_generate_equals_and_hash = reader |> @lib.async_read_bool() |> Some; true }
-      (27, _) => { msg.java_string_check_utf8 = reader |> @lib.async_read_bool() |> Some; true }
-      (9, _) => { msg.optimize_for = reader |> @lib.async_read_enum() |> FileOptions_OptimizeMode::from_enum |> Some; true }
-      (11, _) => { msg.go_package = reader |> @lib.async_read_string() |> Some; true }
-      (16, _) => { msg.cc_generic_services = reader |> @lib.async_read_bool() |> Some; true }
-      (17, _) => { msg.java_generic_services = reader |> @lib.async_read_bool() |> Some; true }
-      (18, _) => { msg.py_generic_services = reader |> @lib.async_read_bool() |> Some; true }
-      (23, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
-      (31, _) => { msg.cc_enable_arenas = reader |> @lib.async_read_bool() |> Some; true }
-      (36, _) => { msg.objc_class_prefix = reader |> @lib.async_read_string() |> Some; true }
-      (37, _) => { msg.csharp_namespace = reader |> @lib.async_read_string() |> Some; true }
-      (39, _) => { msg.swift_prefix = reader |> @lib.async_read_string() |> Some; true }
-      (40, _) => { msg.php_class_prefix = reader |> @lib.async_read_string() |> Some; true }
-      (41, _) => { msg.php_namespace = reader |> @lib.async_read_string() |> Some; true }
-      (44, _) => { msg.php_metadata_namespace = reader |> @lib.async_read_string() |> Some; true }
-      (45, _) => { msg.ruby_package = reader |> @lib.async_read_string() |> Some; true }
-      (50, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.java_package = reader |> @lib.async_read_string() |> Some
+          (8, _) => msg.java_outer_classname = reader |> @lib.async_read_string() |> Some
+          (10, _) => msg.java_multiple_files = reader |> @lib.async_read_bool() |> Some
+          (20, _) => msg.java_generate_equals_and_hash = reader |> @lib.async_read_bool() |> Some
+          (27, _) => msg.java_string_check_utf8 = reader |> @lib.async_read_bool() |> Some
+          (9, _) => msg.optimize_for = reader |> @lib.async_read_enum() |> FileOptions_OptimizeMode::from_enum |> Some
+          (11, _) => msg.go_package = reader |> @lib.async_read_string() |> Some
+          (16, _) => msg.cc_generic_services = reader |> @lib.async_read_bool() |> Some
+          (17, _) => msg.java_generic_services = reader |> @lib.async_read_bool() |> Some
+          (18, _) => msg.py_generic_services = reader |> @lib.async_read_bool() |> Some
+          (23, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (31, _) => msg.cc_enable_arenas = reader |> @lib.async_read_bool() |> Some
+          (36, _) => msg.objc_class_prefix = reader |> @lib.async_read_string() |> Some
+          (37, _) => msg.csharp_namespace = reader |> @lib.async_read_string() |> Some
+          (39, _) => msg.swift_prefix = reader |> @lib.async_read_string() |> Some
+          (40, _) => msg.php_class_prefix = reader |> @lib.async_read_string() |> Some
+          (41, _) => msg.php_namespace = reader |> @lib.async_read_string() |> Some
+          (44, _) => msg.php_metadata_namespace = reader |> @lib.async_read_string() |> Some
+          (45, _) => msg.ruby_package = reader |> @lib.async_read_string() |> Some
+          (50, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FileOptions with fn write(self: FileOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -3404,18 +3524,22 @@ pub fn MessageOptions::new(message_set_wire_format? : Bool, no_standard_descript
 }
 pub impl @lib.Read for MessageOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MessageOptions raise {
   let msg = MessageOptions::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.message_set_wire_format = reader |> @lib.read_bool() |> Some; true }
-      (2, _) => { msg.no_standard_descriptor_accessor = reader |> @lib.read_bool() |> Some; true }
-      (3, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
-      (7, _) => { msg.map_entry = reader |> @lib.read_bool() |> Some; true }
-      (11, _) => { msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some; true }
-      (12, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.message_set_wire_format = reader |> @lib.read_bool() |> Some
+          (2, _) => msg.no_standard_descriptor_accessor = reader |> @lib.read_bool() |> Some
+          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (7, _) => msg.map_entry = reader |> @lib.read_bool() |> Some
+          (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
+          (12, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for MessageOptions with fn write(self: MessageOptions, writer : &@lib.Writer) -> Unit raise {
@@ -3508,18 +3632,22 @@ pub impl @json.FromJson for MessageOptions with fn from_json(json: Json, path: @
 }
 pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MessageOptions raise {
   let msg = MessageOptions::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.message_set_wire_format = reader |> @lib.async_read_bool() |> Some; true }
-      (2, _) => { msg.no_standard_descriptor_accessor = reader |> @lib.async_read_bool() |> Some; true }
-      (3, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
-      (7, _) => { msg.map_entry = reader |> @lib.async_read_bool() |> Some; true }
-      (11, _) => { msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some; true }
-      (12, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.message_set_wire_format = reader |> @lib.async_read_bool() |> Some
+          (2, _) => msg.no_standard_descriptor_accessor = reader |> @lib.async_read_bool() |> Some
+          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (7, _) => msg.map_entry = reader |> @lib.async_read_bool() |> Some
+          (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
+          (12, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for MessageOptions with fn write(self: MessageOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -3805,13 +3933,17 @@ pub fn FieldOptions_EditionDefault::new(edition? : Edition, value? : String) -> 
 }
 pub impl @lib.Read for FieldOptions_EditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (3, _) => { msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
-      (2, _) => { msg.value = reader |> @lib.read_string() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (3, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+          (2, _) => msg.value = reader |> @lib.read_string() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FieldOptions_EditionDefault with fn write(self: FieldOptions_EditionDefault, writer : &@lib.Writer) -> Unit raise {
@@ -3854,13 +3986,17 @@ pub impl @json.FromJson for FieldOptions_EditionDefault with fn from_json(json: 
 }
 pub impl @lib.AsyncRead for FieldOptions_EditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions_EditionDefault raise {
   let msg = FieldOptions_EditionDefault::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (3, _) => { msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
-      (2, _) => { msg.value = reader |> @lib.async_read_string() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (3, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+          (2, _) => msg.value = reader |> @lib.async_read_string() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FieldOptions_EditionDefault with fn write(self: FieldOptions_EditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -3915,15 +4051,19 @@ pub fn FieldOptions_FeatureSupport::new(edition_introduced? : Edition, edition_d
 }
 pub impl @lib.Read for FieldOptions_FeatureSupport with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.edition_introduced = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
-      (2, _) => { msg.edition_deprecated = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
-      (3, _) => { msg.deprecation_warning = reader |> @lib.read_string() |> Some; true }
-      (4, _) => { msg.edition_removed = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.edition_introduced = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+          (2, _) => msg.edition_deprecated = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+          (3, _) => msg.deprecation_warning = reader |> @lib.read_string() |> Some
+          (4, _) => msg.edition_removed = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FieldOptions_FeatureSupport with fn write(self: FieldOptions_FeatureSupport, writer : &@lib.Writer) -> Unit raise {
@@ -3986,15 +4126,19 @@ pub impl @json.FromJson for FieldOptions_FeatureSupport with fn from_json(json: 
 }
 pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions_FeatureSupport raise {
   let msg = FieldOptions_FeatureSupport::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.edition_introduced = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
-      (2, _) => { msg.edition_deprecated = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
-      (3, _) => { msg.deprecation_warning = reader |> @lib.async_read_string() |> Some; true }
-      (4, _) => { msg.edition_removed = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.edition_introduced = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+          (2, _) => msg.edition_deprecated = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+          (3, _) => msg.deprecation_warning = reader |> @lib.async_read_string() |> Some
+          (4, _) => msg.edition_removed = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FieldOptions_FeatureSupport with fn write(self: FieldOptions_FeatureSupport, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -4119,26 +4263,30 @@ pub fn FieldOptions::new(ctype? : FieldOptions_CType, packed? : Bool, jstype? : 
 }
 pub impl @lib.Read for FieldOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FieldOptions raise {
   let msg = FieldOptions::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.ctype = reader |> @lib.read_enum() |> FieldOptions_CType::from_enum |> Some; true }
-      (2, _) => { msg.packed = reader |> @lib.read_bool() |> Some; true }
-      (6, _) => { msg.jstype = reader |> @lib.read_enum() |> FieldOptions_JSType::from_enum |> Some; true }
-      (5, _) => { msg.lazy_ = reader |> @lib.read_bool() |> Some; true }
-      (15, _) => { msg.unverified_lazy = reader |> @lib.read_bool() |> Some; true }
-      (3, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
-      (10, _) => { msg.weak = reader |> @lib.read_bool() |> Some; true }
-      (16, _) => { msg.debug_redact = reader |> @lib.read_bool() |> Some; true }
-      (17, _) => { msg.retention = reader |> @lib.read_enum() |> FieldOptions_OptionRetention::from_enum |> Some; true }
-      (19, 2) => { let packed = reader |> @lib.read_packed(@lib.read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) }; true }
-      (19, 0) => { msg.targets.push(reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum); true }
-      (20, _) => { msg.edition_defaults.push((reader |> @lib.read_message() : FieldOptions_EditionDefault)); true }
-      (21, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
-      (22, _) => { msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.ctype = reader |> @lib.read_enum() |> FieldOptions_CType::from_enum |> Some
+          (2, _) => msg.packed = reader |> @lib.read_bool() |> Some
+          (6, _) => msg.jstype = reader |> @lib.read_enum() |> FieldOptions_JSType::from_enum |> Some
+          (5, _) => msg.lazy_ = reader |> @lib.read_bool() |> Some
+          (15, _) => msg.unverified_lazy = reader |> @lib.read_bool() |> Some
+          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (10, _) => msg.weak = reader |> @lib.read_bool() |> Some
+          (16, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
+          (17, _) => msg.retention = reader |> @lib.read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
+          (19, 2) => { let packed = reader |> @lib.read_packed(@lib.read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
+          (19, 0) => msg.targets.push(reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum)
+          (20, _) => msg.edition_defaults.push((reader |> @lib.read_message() : FieldOptions_EditionDefault))
+          (21, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (22, _) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FieldOptions with fn write(self: FieldOptions, writer : &@lib.Writer) -> Unit raise {
@@ -4301,26 +4449,30 @@ pub impl @json.FromJson for FieldOptions with fn from_json(json: Json, path: @js
 }
 pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FieldOptions raise {
   let msg = FieldOptions::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.ctype = reader |> @lib.async_read_enum() |> FieldOptions_CType::from_enum |> Some; true }
-      (2, _) => { msg.packed = reader |> @lib.async_read_bool() |> Some; true }
-      (6, _) => { msg.jstype = reader |> @lib.async_read_enum() |> FieldOptions_JSType::from_enum |> Some; true }
-      (5, _) => { msg.lazy_ = reader |> @lib.async_read_bool() |> Some; true }
-      (15, _) => { msg.unverified_lazy = reader |> @lib.async_read_bool() |> Some; true }
-      (3, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
-      (10, _) => { msg.weak = reader |> @lib.async_read_bool() |> Some; true }
-      (16, _) => { msg.debug_redact = reader |> @lib.async_read_bool() |> Some; true }
-      (17, _) => { msg.retention = reader |> @lib.async_read_enum() |> FieldOptions_OptionRetention::from_enum |> Some; true }
-      (19, 2) => { let packed = reader |> @lib.async_read_packed(@lib.async_read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) }; true }
-      (19, 0) => { msg.targets.push(reader |> @lib.async_read_enum() |> FieldOptions_OptionTargetType::from_enum); true }
-      (20, _) => { msg.edition_defaults.push((reader |> @lib.async_read_message() : FieldOptions_EditionDefault)); true }
-      (21, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
-      (22, _) => { msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.ctype = reader |> @lib.async_read_enum() |> FieldOptions_CType::from_enum |> Some
+          (2, _) => msg.packed = reader |> @lib.async_read_bool() |> Some
+          (6, _) => msg.jstype = reader |> @lib.async_read_enum() |> FieldOptions_JSType::from_enum |> Some
+          (5, _) => msg.lazy_ = reader |> @lib.async_read_bool() |> Some
+          (15, _) => msg.unverified_lazy = reader |> @lib.async_read_bool() |> Some
+          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (10, _) => msg.weak = reader |> @lib.async_read_bool() |> Some
+          (16, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
+          (17, _) => msg.retention = reader |> @lib.async_read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
+          (19, 2) => { let packed = reader |> @lib.async_read_packed(@lib.async_read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
+          (19, 0) => msg.targets.push(reader |> @lib.async_read_enum() |> FieldOptions_OptionTargetType::from_enum)
+          (20, _) => msg.edition_defaults.push((reader |> @lib.async_read_message() : FieldOptions_EditionDefault))
+          (21, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+          (22, _) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FieldOptions with fn write(self: FieldOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -4423,13 +4575,17 @@ pub fn OneofOptions::new(features? : FeatureSet, uninterpreted_option : Array[Un
 }
 pub impl @lib.Read for OneofOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> OneofOptions raise {
   let msg = OneofOptions::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for OneofOptions with fn write(self: OneofOptions, writer : &@lib.Writer) -> Unit raise {
@@ -4472,13 +4628,17 @@ pub impl @json.FromJson for OneofOptions with fn from_json(json: Json, path: @js
 }
 pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> OneofOptions raise {
   let msg = OneofOptions::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for OneofOptions with fn write(self: OneofOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -4539,16 +4699,20 @@ pub fn EnumOptions::new(allow_alias? : Bool, deprecated? : Bool, deprecated_lega
 }
 pub impl @lib.Read for EnumOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumOptions raise {
   let msg = EnumOptions::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (2, _) => { msg.allow_alias = reader |> @lib.read_bool() |> Some; true }
-      (3, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
-      (6, _) => { msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some; true }
-      (7, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (2, _) => msg.allow_alias = reader |> @lib.read_bool() |> Some
+          (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
+          (7, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for EnumOptions with fn write(self: EnumOptions, writer : &@lib.Writer) -> Unit raise {
@@ -4621,16 +4785,20 @@ pub impl @json.FromJson for EnumOptions with fn from_json(json: Json, path: @jso
 }
 pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumOptions raise {
   let msg = EnumOptions::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (2, _) => { msg.allow_alias = reader |> @lib.async_read_bool() |> Some; true }
-      (3, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
-      (6, _) => { msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some; true }
-      (7, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (2, _) => msg.allow_alias = reader |> @lib.async_read_bool() |> Some
+          (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
+          (7, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for EnumOptions with fn write(self: EnumOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -4706,16 +4874,20 @@ pub fn EnumValueOptions::new(deprecated? : Bool, features? : FeatureSet, debug_r
 }
 pub impl @lib.Read for EnumValueOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
-      (2, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
-      (3, _) => { msg.debug_redact = reader |> @lib.read_bool() |> Some; true }
-      (4, _) => { msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (2, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
+          (4, _) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for EnumValueOptions with fn write(self: EnumValueOptions, writer : &@lib.Writer) -> Unit raise {
@@ -4788,16 +4960,20 @@ pub impl @json.FromJson for EnumValueOptions with fn from_json(json: Json, path:
 }
 pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> EnumValueOptions raise {
   let msg = EnumValueOptions::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
-      (2, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
-      (3, _) => { msg.debug_redact = reader |> @lib.async_read_bool() |> Some; true }
-      (4, _) => { msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (2, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+          (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
+          (4, _) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for EnumValueOptions with fn write(self: EnumValueOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -4861,14 +5037,18 @@ pub fn ServiceOptions::new(features? : FeatureSet, deprecated? : Bool, uninterpr
 }
 pub impl @lib.Read for ServiceOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (34, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
-      (33, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (34, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for ServiceOptions with fn write(self: ServiceOptions, writer : &@lib.Writer) -> Unit raise {
@@ -4921,14 +5101,18 @@ pub impl @json.FromJson for ServiceOptions with fn from_json(json: Json, path: @
 }
 pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> ServiceOptions raise {
   let msg = ServiceOptions::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (34, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
-      (33, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (34, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+          (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for ServiceOptions with fn write(self: ServiceOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -5032,15 +5216,19 @@ pub fn MethodOptions::new(deprecated? : Bool, idempotency_level? : MethodOptions
 }
 pub impl @lib.Read for MethodOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> MethodOptions raise {
   let msg = MethodOptions::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (33, _) => { msg.deprecated = reader |> @lib.read_bool() |> Some; true }
-      (34, _) => { msg.idempotency_level = reader |> @lib.read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some; true }
-      (35, _) => { msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
+          (34, _) => msg.idempotency_level = reader |> @lib.read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
+          (35, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for MethodOptions with fn write(self: MethodOptions, writer : &@lib.Writer) -> Unit raise {
@@ -5103,15 +5291,19 @@ pub impl @json.FromJson for MethodOptions with fn from_json(json: Json, path: @j
 }
 pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> MethodOptions raise {
   let msg = MethodOptions::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (33, _) => { msg.deprecated = reader |> @lib.async_read_bool() |> Some; true }
-      (34, _) => { msg.idempotency_level = reader |> @lib.async_read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some; true }
-      (35, _) => { msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
-      (999, _) => { msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
+          (34, _) => msg.idempotency_level = reader |> @lib.async_read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
+          (35, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+          (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for MethodOptions with fn write(self: MethodOptions, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -5160,13 +5352,17 @@ pub fn UninterpretedOption_NamePart::new(name_part : String, is_extension : Bool
 }
 pub impl @lib.Read for UninterpretedOption_NamePart with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.name_part = reader |> @lib.read_string(); true }
-      (2, _) => { msg.is_extension = reader |> @lib.read_bool(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name_part = reader |> @lib.read_string()
+          (2, _) => msg.is_extension = reader |> @lib.read_bool()
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for UninterpretedOption_NamePart with fn write(self: UninterpretedOption_NamePart, writer : &@lib.Writer) -> Unit raise {
@@ -5201,13 +5397,17 @@ pub impl @json.FromJson for UninterpretedOption_NamePart with fn from_json(json:
 }
 pub impl @lib.AsyncRead for UninterpretedOption_NamePart with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> UninterpretedOption_NamePart raise {
   let msg = UninterpretedOption_NamePart::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.name_part = reader |> @lib.async_read_string(); true }
-      (2, _) => { msg.is_extension = reader |> @lib.async_read_bool(); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.name_part = reader |> @lib.async_read_string()
+          (2, _) => msg.is_extension = reader |> @lib.async_read_bool()
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for UninterpretedOption_NamePart with fn write(self: UninterpretedOption_NamePart, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -5274,18 +5474,22 @@ pub fn UninterpretedOption::new(name : Array[UninterpretedOption_NamePart], iden
 }
 pub impl @lib.Read for UninterpretedOption with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (2, _) => { msg.name.push((reader |> @lib.read_message() : UninterpretedOption_NamePart)); true }
-      (3, _) => { msg.identifier_value = reader |> @lib.read_string() |> Some; true }
-      (4, _) => { msg.positive_int_value = reader |> @lib.read_uint64() |> Some; true }
-      (5, _) => { msg.negative_int_value = reader |> @lib.read_int64() |> Some; true }
-      (6, _) => { msg.double_value = reader |> @lib.read_double() |> Some; true }
-      (7, _) => { msg.string_value = reader |> @lib.read_bytes() |> Some; true }
-      (8, _) => { msg.aggregate_value = reader |> @lib.read_string() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (2, _) => msg.name.push((reader |> @lib.read_message() : UninterpretedOption_NamePart))
+          (3, _) => msg.identifier_value = reader |> @lib.read_string() |> Some
+          (4, _) => msg.positive_int_value = reader |> @lib.read_uint64() |> Some
+          (5, _) => msg.negative_int_value = reader |> @lib.read_int64() |> Some
+          (6, _) => msg.double_value = reader |> @lib.read_double() |> Some
+          (7, _) => msg.string_value = reader |> @lib.read_bytes() |> Some
+          (8, _) => msg.aggregate_value = reader |> @lib.read_string() |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for UninterpretedOption with fn write(self: UninterpretedOption, writer : &@lib.Writer) -> Unit raise {
@@ -5378,18 +5582,22 @@ pub impl @json.FromJson for UninterpretedOption with fn from_json(json: Json, pa
 }
 pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> UninterpretedOption raise {
   let msg = UninterpretedOption::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (2, _) => { msg.name.push((reader |> @lib.async_read_message() : UninterpretedOption_NamePart)); true }
-      (3, _) => { msg.identifier_value = reader |> @lib.async_read_string() |> Some; true }
-      (4, _) => { msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some; true }
-      (5, _) => { msg.negative_int_value = reader |> @lib.async_read_int64() |> Some; true }
-      (6, _) => { msg.double_value = reader |> @lib.async_read_double() |> Some; true }
-      (7, _) => { msg.string_value = reader |> @lib.async_read_bytes() |> Some; true }
-      (8, _) => { msg.aggregate_value = reader |> @lib.async_read_string() |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (2, _) => msg.name.push((reader |> @lib.async_read_message() : UninterpretedOption_NamePart))
+          (3, _) => msg.identifier_value = reader |> @lib.async_read_string() |> Some
+          (4, _) => msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some
+          (5, _) => msg.negative_int_value = reader |> @lib.async_read_int64() |> Some
+          (6, _) => msg.double_value = reader |> @lib.async_read_double() |> Some
+          (7, _) => msg.string_value = reader |> @lib.async_read_bytes() |> Some
+          (8, _) => msg.aggregate_value = reader |> @lib.async_read_string() |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for UninterpretedOption with fn write(self: UninterpretedOption, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -5892,19 +6100,23 @@ pub fn FeatureSet::new(field_presence? : FeatureSet_FieldPresence, enum_type? : 
 }
 pub impl @lib.Read for FeatureSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSet raise {
   let msg = FeatureSet::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.field_presence = reader |> @lib.read_enum() |> FeatureSet_FieldPresence::from_enum |> Some; true }
-      (2, _) => { msg.enum_type = reader |> @lib.read_enum() |> FeatureSet_EnumType::from_enum |> Some; true }
-      (3, _) => { msg.repeated_field_encoding = reader |> @lib.read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some; true }
-      (4, _) => { msg.utf8_validation = reader |> @lib.read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some; true }
-      (5, _) => { msg.message_encoding = reader |> @lib.read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some; true }
-      (6, _) => { msg.json_format = reader |> @lib.read_enum() |> FeatureSet_JsonFormat::from_enum |> Some; true }
-      (7, _) => { msg.enforce_naming_style = reader |> @lib.read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some; true }
-      (8, _) => { msg.default_symbol_visibility = reader |> @lib.read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.field_presence = reader |> @lib.read_enum() |> FeatureSet_FieldPresence::from_enum |> Some
+          (2, _) => msg.enum_type = reader |> @lib.read_enum() |> FeatureSet_EnumType::from_enum |> Some
+          (3, _) => msg.repeated_field_encoding = reader |> @lib.read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some
+          (4, _) => msg.utf8_validation = reader |> @lib.read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some
+          (5, _) => msg.message_encoding = reader |> @lib.read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some
+          (6, _) => msg.json_format = reader |> @lib.read_enum() |> FeatureSet_JsonFormat::from_enum |> Some
+          (7, _) => msg.enforce_naming_style = reader |> @lib.read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some
+          (8, _) => msg.default_symbol_visibility = reader |> @lib.read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FeatureSet with fn write(self: FeatureSet, writer : &@lib.Writer) -> Unit raise {
@@ -6007,19 +6219,23 @@ pub impl @json.FromJson for FeatureSet with fn from_json(json: Json, path: @json
 }
 pub impl @lib.AsyncRead for FeatureSet with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSet raise {
   let msg = FeatureSet::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.field_presence = reader |> @lib.async_read_enum() |> FeatureSet_FieldPresence::from_enum |> Some; true }
-      (2, _) => { msg.enum_type = reader |> @lib.async_read_enum() |> FeatureSet_EnumType::from_enum |> Some; true }
-      (3, _) => { msg.repeated_field_encoding = reader |> @lib.async_read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some; true }
-      (4, _) => { msg.utf8_validation = reader |> @lib.async_read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some; true }
-      (5, _) => { msg.message_encoding = reader |> @lib.async_read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some; true }
-      (6, _) => { msg.json_format = reader |> @lib.async_read_enum() |> FeatureSet_JsonFormat::from_enum |> Some; true }
-      (7, _) => { msg.enforce_naming_style = reader |> @lib.async_read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some; true }
-      (8, _) => { msg.default_symbol_visibility = reader |> @lib.async_read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.field_presence = reader |> @lib.async_read_enum() |> FeatureSet_FieldPresence::from_enum |> Some
+          (2, _) => msg.enum_type = reader |> @lib.async_read_enum() |> FeatureSet_EnumType::from_enum |> Some
+          (3, _) => msg.repeated_field_encoding = reader |> @lib.async_read_enum() |> FeatureSet_RepeatedFieldEncoding::from_enum |> Some
+          (4, _) => msg.utf8_validation = reader |> @lib.async_read_enum() |> FeatureSet_Utf8Validation::from_enum |> Some
+          (5, _) => msg.message_encoding = reader |> @lib.async_read_enum() |> FeatureSet_MessageEncoding::from_enum |> Some
+          (6, _) => msg.json_format = reader |> @lib.async_read_enum() |> FeatureSet_JsonFormat::from_enum |> Some
+          (7, _) => msg.enforce_naming_style = reader |> @lib.async_read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some
+          (8, _) => msg.default_symbol_visibility = reader |> @lib.async_read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FeatureSet with fn write(self: FeatureSet, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -6098,14 +6314,18 @@ pub fn FeatureSetDefaults_FeatureSetEditionDefault::new(edition? : Edition, over
 }
 pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (3, _) => { msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
-      (4, _) => { msg.overridable_features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
-      (5, _) => { msg.fixed_features = (reader |> @lib.read_message() : FeatureSet) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (3, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+          (4, _) => msg.overridable_features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          (5, _) => msg.fixed_features = (reader |> @lib.read_message() : FeatureSet) |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with fn write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.Writer) -> Unit raise {
@@ -6158,14 +6378,18 @@ pub impl @json.FromJson for FeatureSetDefaults_FeatureSetEditionDefault with fn 
 }
 pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSetDefaults_FeatureSetEditionDefault raise {
   let msg = FeatureSetDefaults_FeatureSetEditionDefault::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (3, _) => { msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
-      (4, _) => { msg.overridable_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
-      (5, _) => { msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (3, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+          (4, _) => msg.overridable_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+          (5, _) => msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FeatureSetDefaults_FeatureSetEditionDefault with fn write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -6219,14 +6443,18 @@ pub fn FeatureSetDefaults::new(defaults : Array[FeatureSetDefaults_FeatureSetEdi
 }
 pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.defaults.push((reader |> @lib.read_message() : FeatureSetDefaults_FeatureSetEditionDefault)); true }
-      (4, _) => { msg.minimum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
-      (5, _) => { msg.maximum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.defaults.push((reader |> @lib.read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
+          (4, _) => msg.minimum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+          (5, _) => msg.maximum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for FeatureSetDefaults with fn write(self: FeatureSetDefaults, writer : &@lib.Writer) -> Unit raise {
@@ -6279,14 +6507,18 @@ pub impl @json.FromJson for FeatureSetDefaults with fn from_json(json: Json, pat
 }
 pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> FeatureSetDefaults raise {
   let msg = FeatureSetDefaults::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.defaults.push((reader |> @lib.async_read_message() : FeatureSetDefaults_FeatureSetEditionDefault)); true }
-      (4, _) => { msg.minimum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
-      (5, _) => { msg.maximum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.defaults.push((reader |> @lib.async_read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
+          (4, _) => msg.minimum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+          (5, _) => msg.maximum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for FeatureSetDefaults with fn write(self: FeatureSetDefaults, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -6352,18 +6584,22 @@ pub fn SourceCodeInfo_Location::new(path : Array[Int], span : Array[Int], leadin
 }
 pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
-      (1, 0) => { msg.path.push(reader |> @lib.read_int32()); true }
-      (2, 2) => { msg.span.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
-      (2, 0) => { msg.span.push(reader |> @lib.read_int32()); true }
-      (3, _) => { msg.leading_comments = reader |> @lib.read_string() |> Some; true }
-      (4, _) => { msg.trailing_comments = reader |> @lib.read_string() |> Some; true }
-      (6, _) => { msg.leading_detached_comments.push(reader |> @lib.read_string()); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+          (1, 0) => msg.path.push(reader |> @lib.read_int32())
+          (2, 2) => { msg.span.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+          (2, 0) => msg.span.push(reader |> @lib.read_int32())
+          (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
+          (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
+          (6, _) => msg.leading_detached_comments.push(reader |> @lib.read_string())
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for SourceCodeInfo_Location with fn write(self: SourceCodeInfo_Location, writer : &@lib.Writer) -> Unit raise {
@@ -6444,18 +6680,22 @@ pub impl @json.FromJson for SourceCodeInfo_Location with fn from_json(json: Json
 }
 pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> SourceCodeInfo_Location raise {
   let msg = SourceCodeInfo_Location::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
-      (1, 0) => { msg.path.push(reader |> @lib.async_read_int32()); true }
-      (2, 2) => { msg.span.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
-      (2, 0) => { msg.span.push(reader |> @lib.async_read_int32()); true }
-      (3, _) => { msg.leading_comments = reader |> @lib.async_read_string() |> Some; true }
-      (4, _) => { msg.trailing_comments = reader |> @lib.async_read_string() |> Some; true }
-      (6, _) => { msg.leading_detached_comments.push(reader |> @lib.async_read_string()); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+          (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+          (2, 2) => { msg.span.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+          (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
+          (3, _) => msg.leading_comments = reader |> @lib.async_read_string() |> Some
+          (4, _) => msg.trailing_comments = reader |> @lib.async_read_string() |> Some
+          (6, _) => msg.leading_detached_comments.push(reader |> @lib.async_read_string())
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for SourceCodeInfo_Location with fn write(self: SourceCodeInfo_Location, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -6515,12 +6755,16 @@ pub fn SourceCodeInfo::new(location : Array[SourceCodeInfo_Location]) -> SourceC
 }
 pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.location.push((reader |> @lib.read_message() : SourceCodeInfo_Location)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.location.push((reader |> @lib.read_message() : SourceCodeInfo_Location))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for SourceCodeInfo with fn write(self: SourceCodeInfo, writer : &@lib.Writer) -> Unit raise {
@@ -6553,12 +6797,16 @@ pub impl @json.FromJson for SourceCodeInfo with fn from_json(json: Json, path: @
 }
 pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> SourceCodeInfo raise {
   let msg = SourceCodeInfo::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.location.push((reader |> @lib.async_read_message() : SourceCodeInfo_Location)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.location.push((reader |> @lib.async_read_message() : SourceCodeInfo_Location))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for SourceCodeInfo with fn write(self: SourceCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -6658,17 +6906,21 @@ pub fn GeneratedCodeInfo_Annotation::new(path : Array[Int], source_file? : Strin
 }
 pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()); true }
-      (1, 0) => { msg.path.push(reader |> @lib.read_int32()); true }
-      (2, _) => { msg.source_file = reader |> @lib.read_string() |> Some; true }
-      (3, _) => { msg.begin = reader |> @lib.read_int32() |> Some; true }
-      (4, _) => { msg.end = reader |> @lib.read_int32() |> Some; true }
-      (5, _) => { msg.semantic = reader |> @lib.read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+          (1, 0) => msg.path.push(reader |> @lib.read_int32())
+          (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
+          (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
+          (4, _) => msg.end = reader |> @lib.read_int32() |> Some
+          (5, _) => msg.semantic = reader |> @lib.read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for GeneratedCodeInfo_Annotation with fn write(self: GeneratedCodeInfo_Annotation, writer : &@lib.Writer) -> Unit raise {
@@ -6745,17 +6997,21 @@ pub impl @json.FromJson for GeneratedCodeInfo_Annotation with fn from_json(json:
 }
 pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GeneratedCodeInfo_Annotation raise {
   let msg = GeneratedCodeInfo_Annotation::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()); true }
-      (1, 0) => { msg.path.push(reader |> @lib.async_read_int32()); true }
-      (2, _) => { msg.source_file = reader |> @lib.async_read_string() |> Some; true }
-      (3, _) => { msg.begin = reader |> @lib.async_read_int32() |> Some; true }
-      (4, _) => { msg.end = reader |> @lib.async_read_int32() |> Some; true }
-      (5, _) => { msg.semantic = reader |> @lib.async_read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some; true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+          (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+          (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
+          (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
+          (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
+          (5, _) => msg.semantic = reader |> @lib.async_read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for GeneratedCodeInfo_Annotation with fn write(self: GeneratedCodeInfo_Annotation, writer : &@lib.AsyncWriter) -> Unit raise {
@@ -6811,12 +7067,16 @@ pub fn GeneratedCodeInfo::new(annotation : Array[GeneratedCodeInfo_Annotation]) 
 }
 pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.Reader]) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
-  reader |> @lib.read_message_fields(fn(field_number, wire) raise {
-    match (field_number, wire) {
-      (1, _) => { msg.annotation.push((reader |> @lib.read_message() : GeneratedCodeInfo_Annotation)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.annotation.push((reader |> @lib.read_message() : GeneratedCodeInfo_Annotation))
+          _ => reader |> @lib.skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.Write for GeneratedCodeInfo with fn write(self: GeneratedCodeInfo, writer : &@lib.Writer) -> Unit raise {
@@ -6849,12 +7109,16 @@ pub impl @json.FromJson for GeneratedCodeInfo with fn from_json(json: Json, path
 }
 pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(reader : @lib.LimitedReader[&@lib.AsyncReader]) -> GeneratedCodeInfo raise {
   let msg = GeneratedCodeInfo::default()
-  reader |> @lib.async_read_message_fields(async fn(field_number, wire) {
-    match (field_number, wire) {
-      (1, _) => { msg.annotation.push((reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation)); true }
-      _ => false
+  for ;; {
+    match (reader |> @lib.async_read_next_message_field()) {
+      Some((field_number, wire)) =>
+        match (field_number, wire) {
+          (1, _) => msg.annotation.push((reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation))
+          _ => reader |> @lib.async_skip_message_field(wire)
+        }
+      None => break
     }
-  })
+  }
   msg
 }
 pub impl @lib.AsyncWrite for GeneratedCodeInfo with fn write(self: GeneratedCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {


### PR DESCRIPTION
## Why
Generated readers still owned message frame mechanics: normal `EndOfStream` completion and unknown-field skipping were spelled out in every generated message. Generated writers also spelled out length-delimited message field writes. That duplicated Runtime wire behavior across generated code and made framing bugs lower-locality than they need to be.

The read path is hot, so this PR keeps generated readers as direct pattern-`while` loops instead of routing every field through a closure callback.

## What
- Add Runtime `read_next_message_field` and `async_read_next_message_field` helpers that convert normal message-frame completion into `None`.
- Add Runtime `skip_message_field` and `async_skip_message_field` helpers for unknown-field skipping in message readers.
- Add Runtime `write_message` and `async_write_message` helpers for length-delimited message writes.
- Keep generated readers as direct `while ... is Some((field_number, wire))` loops: generated code owns field assignment, while Runtime owns frame completion and skip semantics.
- Regenerate standard protobuf sources, reader fixtures, and snapshots to use the new helpers.

## Why This Is Correct
`read_next_message_field` preserves the previous generated behavior by reading the next tag and translating normal `EndOfStream` at the limited message frame into `None`, which generated readers handle by ending the pattern-`while` loop. Other errors still propagate. `skip_message_field` delegates to the existing unknown-field skip implementation, so unknown wire handling stays unchanged. Message write helpers perform the same size prefix followed by the message body write that generated code emitted before.

## Scope
This PR moves message framing semantics and length-delimited message writes into Runtime without changing protobuf wire semantics, Field/Oneof/Message shape interfaces, map/packed length chunk generation, or generated field assignment.