### PR TITLE
Centralize field envelope sizing in runtime

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,5 +13,6 @@
 - **Oneof shape**: Generator-side decisions that turn protobuf oneof descriptors into generated enum names, message storage fields, enum variants, field numbers, value types, and oneof read/write/size/JSON cases.
 - **Message shape**: Generator-side decisions that collect a message's generated MoonBit name, normal Field shape slices, Oneof shapes, and Runtime-owned JSON implementation status for template emission.
 - **Message framing**: Runtime-owned handling of protobuf message frame mechanics, including length-delimited message writes, message-field tag reads, normal `EndOfStream` completion, and unknown-field skipping.
+- **Field envelope**: Runtime-owned size and write framing around a field payload, including the encoded tag size, optional length prefix size, and payload size.
 - **Generated-code harness**: a test workflow that builds the Generator, generates MoonBit code from focused proto fixtures, and verifies the generated code through its public Runtime interfaces.
 - **Harness case**: a self-contained Generated-code harness input with proto fixtures, a runner test, and `case.toml` metadata.

--- a/cli/field_codec_shape.mbt
+++ b/cli/field_codec_shape.mbt
@@ -187,29 +187,33 @@ fn FieldCodecValue::packed_element_size(self : FieldCodecValue) -> String raise 
 fn FieldCodecValue::unpacked_size_expr(
   self : FieldCodecValue,
   value_expr : String,
-  tag_size : Int,
+  field_number : Int,
 ) -> (String, Bool) {
   match self.type_ {
     FieldDescriptorProto_Type::TYPE_STRING
     | FieldDescriptorProto_Type::TYPE_BYTES
     | FieldDescriptorProto_Type::TYPE_MESSAGE =>
       (
-        "@lib.size_of_length_delimited_field(\{tag_size}U, @lib.size_of(\{value_expr}))",
+        "@lib.size_of_length_delimited_field(\{field_number}U, @lib.size_of(\{value_expr}))",
         true,
       )
     FieldDescriptorProto_Type::TYPE_FIXED32
     | FieldDescriptorProto_Type::TYPE_SFIXED32
     | FieldDescriptorProto_Type::TYPE_FLOAT => {
       let fixed_size = sizeFixed32()
-      ("@lib.size_of_field(\{tag_size}U, \{fixed_size}U)", false)
+      ("@lib.size_of_field(\{field_number}U, \{fixed_size}U)", false)
     }
     FieldDescriptorProto_Type::TYPE_FIXED64
     | FieldDescriptorProto_Type::TYPE_SFIXED64
     | FieldDescriptorProto_Type::TYPE_DOUBLE => {
       let fixed_size = sizeFixed64()
-      ("@lib.size_of_field(\{tag_size}U, \{fixed_size}U)", false)
+      ("@lib.size_of_field(\{field_number}U, \{fixed_size}U)", false)
     }
-    _ => ("@lib.size_of_field(\{tag_size}U, @lib.size_of(\{value_expr}))", true)
+    _ =>
+      (
+        "@lib.size_of_field(\{field_number}U, @lib.size_of(\{value_expr}))",
+        true,
+      )
   }
 }
 
@@ -247,9 +251,8 @@ fn FieldCodecShape::packed_data_size_expr(
 fn FieldCodecShape::packed_delta_size_expr(
   self : FieldCodecShape,
 ) -> String raise {
-  let tag_size = size_tag(self.field_number)
   let data_size = self.packed_data_size_expr()
-  "@lib.size_of_length_delimited_field(\{tag_size}U, \{data_size})"
+  "@lib.size_of_length_delimited_field(\{self.field_number}U, \{data_size})"
 }
 
 ///|
@@ -337,10 +340,11 @@ fn CodeGenerator::gen_field_codec_write(
       let key_field = shape.key.unwrap()
       let value_field = shape.map_value.unwrap()
       let tag_val = tag(shape.value.type_, shape.field_number, false)
-      let key_tag_size = size_tag(key_field.number)
-      let value_tag_size = size_tag(value_field.number)
-      let (key_size, _) = key_field.unpacked_size_expr("k", key_tag_size)
-      let (value_size, _) = value_field.unpacked_size_expr("v", value_tag_size)
+      let (key_size, _) = key_field.unpacked_size_expr("k", key_field.number)
+      let (value_size, _) = value_field.unpacked_size_expr(
+        "v",
+        value_field.number,
+      )
       let key_tag_val = tag(key_field.type_, key_field.number, false)
       let value_tag_val = tag(value_field.type_, value_field.number, false)
       let field_write_type_k = key_field.write_expr("k", is_async~)
@@ -433,29 +437,27 @@ fn CodeGenerator::gen_field_codec_size(
     MapField => {
       let key_field = shape.key.unwrap()
       let value_field = shape.map_value.unwrap()
-      let tag_size = size_tag(shape.field_number)
-      let (key_size, _) = key_field.unpacked_size_expr(
-        "k",
-        size_tag(key_field.number),
-      )
+      let (key_size, _) = key_field.unpacked_size_expr("k", key_field.number)
       let (value_size, _) = value_field.unpacked_size_expr(
         "v",
-        size_tag(value_field.number),
+        value_field.number,
       )
       content.write_string(
         (
           $|  for k, v in self.\{shape.field_name} {
           $|    let key_size = \{key_size}
           $|    let value_size = \{value_size}
-          $|    size += @lib.size_of_length_delimited_field(\{tag_size}U, key_size + value_size)
+          $|    size += @lib.size_of_length_delimited_field(\{shape.field_number}U, key_size + value_size)
           $|  }
           $|
         ),
       )
     }
     RepeatedField => {
-      let tag_size = size_tag(shape.field_number)
-      let (delta_size, _) = shape.value.unpacked_size_expr("s", tag_size)
+      let (delta_size, _) = shape.value.unpacked_size_expr(
+        "s",
+        shape.field_number,
+      )
       content.write_string(
         (
           $|  for s in self.\{shape.field_name} {
@@ -468,7 +470,7 @@ fn CodeGenerator::gen_field_codec_size(
     OptionalField => {
       let (delta_size, need_v) = shape.value.unpacked_size_expr(
         "v",
-        size_tag(shape.field_number),
+        shape.field_number,
       )
       if need_v {
         content.write_string(
@@ -493,7 +495,7 @@ fn CodeGenerator::gen_field_codec_size(
     SingularField => {
       let (delta_size, _) = shape.value.unpacked_size_expr(
         "self.\{shape.field_name}",
-        size_tag(shape.field_number),
+        shape.field_number,
       )
       if shape.has_implicit_presence {
         content.write_string(

--- a/cli/field_codec_shape.mbt
+++ b/cli/field_codec_shape.mbt
@@ -194,22 +194,22 @@ fn FieldCodecValue::unpacked_size_expr(
     | FieldDescriptorProto_Type::TYPE_BYTES
     | FieldDescriptorProto_Type::TYPE_MESSAGE =>
       (
-        "\{tag_size}U + { let size = @lib.size_of(\{value_expr}); @lib.size_of(size) + size }",
+        "@lib.size_of_length_delimited_field(\{tag_size}U, @lib.size_of(\{value_expr}))",
         true,
       )
     FieldDescriptorProto_Type::TYPE_FIXED32
     | FieldDescriptorProto_Type::TYPE_SFIXED32
     | FieldDescriptorProto_Type::TYPE_FLOAT => {
       let fixed_size = sizeFixed32()
-      ("\{tag_size}U + \{fixed_size}U", false)
+      ("@lib.size_of_field(\{tag_size}U, \{fixed_size}U)", false)
     }
     FieldDescriptorProto_Type::TYPE_FIXED64
     | FieldDescriptorProto_Type::TYPE_SFIXED64
     | FieldDescriptorProto_Type::TYPE_DOUBLE => {
       let fixed_size = sizeFixed64()
-      ("\{tag_size}U + \{fixed_size}U", false)
+      ("@lib.size_of_field(\{tag_size}U, \{fixed_size}U)", false)
     }
-    _ => ("\{tag_size}U + @lib.size_of(\{value_expr})", true)
+    _ => ("@lib.size_of_field(\{tag_size}U, @lib.size_of(\{value_expr}))", true)
   }
 }
 
@@ -249,16 +249,7 @@ fn FieldCodecShape::packed_delta_size_expr(
 ) -> String raise {
   let tag_size = size_tag(self.field_number)
   let data_size = self.packed_data_size_expr()
-  match self.value.type_ {
-    FieldDescriptorProto_Type::TYPE_FIXED32
-    | FieldDescriptorProto_Type::TYPE_SFIXED32
-    | FieldDescriptorProto_Type::TYPE_FLOAT
-    | FieldDescriptorProto_Type::TYPE_FIXED64
-    | FieldDescriptorProto_Type::TYPE_SFIXED64
-    | FieldDescriptorProto_Type::TYPE_DOUBLE =>
-      "\{tag_size}U + { let size = \{data_size}; @lib.size_of(size) + size}"
-    _ => "\{tag_size}U + { let size = \{data_size}; @lib.size_of(size) + size }"
-  }
+  "@lib.size_of_length_delimited_field(\{tag_size}U, \{data_size})"
 }
 
 ///|
@@ -456,7 +447,7 @@ fn CodeGenerator::gen_field_codec_size(
           $|  for k, v in self.\{shape.field_name} {
           $|    let key_size = \{key_size}
           $|    let value_size = \{value_size}
-          $|    size += \{tag_size}U + @lib.size_of(key_size + value_size) + key_size + value_size
+          $|    size += @lib.size_of_length_delimited_field(\{tag_size}U, key_size + value_size)
           $|  }
           $|
         ),

--- a/cli/oneof_shape.mbt
+++ b/cli/oneof_shape.mbt
@@ -83,7 +83,7 @@ fn CodeGenerator::gen_oneof_codec_size(
   for field in shape.fields {
     let (delta_size, need_v) = field.value.unpacked_size_expr(
       "v",
-      size_tag(field.field_number),
+      field.field_number,
     )
     let value_binding = if need_v { "v" } else { "_" }
     content.write_string(

--- a/cli/utils.mbt
+++ b/cli/utils.mbt
@@ -183,17 +183,6 @@ fn sizeFixed64() -> UInt {
 }
 
 ///|
-fn size_tag(num : Int) -> Int {
-  size_varint(encode_tag(num, 0))
-}
-
-///|
-fn size_varint(v : UInt64) -> Int {
-  let len64 = if v == 0UL { 1 } else { 64 - v.clz() }
-  (9 * len64 + 64) / 64
-}
-
-///|
 fn encode_tag(num : Int, typ : Int) -> UInt64 {
   (num.to_uint64() << 3) | (typ & 7).to_uint64()
 }

--- a/lib/google/protobuf/any.mbt
+++ b/lib/google/protobuf/any.mbt
@@ -8,18 +8,10 @@ pub(all) struct Any {
 pub impl @lib.Sized for Any with fn size_of(self) {
   let mut size = 0U
   if self.type_url != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.type_url)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.type_url))
   }
   if self.value != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.value)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.value))
   }
   size
 }

--- a/lib/google/protobuf/any.mbt
+++ b/lib/google/protobuf/any.mbt
@@ -11,7 +11,7 @@ pub impl @lib.Sized for Any with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.type_url))
   }
   if self.value != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.value))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.value))
   }
   size
 }

--- a/lib/google/protobuf/api.mbt
+++ b/lib/google/protobuf/api.mbt
@@ -17,25 +17,25 @@ pub impl @lib.Sized for Api with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   for s in self.methods {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   for s in self.options {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   if self.version != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.version))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(self.version))
   }
   if self.source_context is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
   }
   for s in self.mixins {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   if self.syntax != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.syntax))
+    size += @lib.size_of_field(7U, @lib.size_of(self.syntax))
   }
   if self.edition != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.edition))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(self.edition))
   }
   size
 }
@@ -281,30 +281,30 @@ pub impl @lib.Sized for Method with fn size_of(self) {
   }
   if self.request_type_url != Default::default() {
     size += @lib.size_of_length_delimited_field(
-      1U,
+      2U,
       @lib.size_of(self.request_type_url),
     )
   }
   if self.request_streaming != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.request_streaming))
+    size += @lib.size_of_field(3U, @lib.size_of(self.request_streaming))
   }
   if self.response_type_url != Default::default() {
     size += @lib.size_of_length_delimited_field(
-      1U,
+      4U,
       @lib.size_of(self.response_type_url),
     )
   }
   if self.response_streaming != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.response_streaming))
+    size += @lib.size_of_field(5U, @lib.size_of(self.response_streaming))
   }
   for s in self.options {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   if self.syntax != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.syntax))
+    size += @lib.size_of_field(7U, @lib.size_of(self.syntax))
   }
   if self.edition != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.edition))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(self.edition))
   }
   size
 }
@@ -541,7 +541,7 @@ pub impl @lib.Sized for Mixin with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.root != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.root))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.root))
   }
   size
 }

--- a/lib/google/protobuf/api.mbt
+++ b/lib/google/protobuf/api.mbt
@@ -14,56 +14,28 @@ pub(all) struct Api {
 pub impl @lib.Sized for Api with fn size_of(self) {
   let mut size = 0U
   if self.name != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.name)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   for s in self.methods {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.options {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.version != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.version)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.version))
   }
   if self.source_context is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.mixins {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.syntax != Default::default() {
-    size += 1U + @lib.size_of(self.syntax)
+    size += @lib.size_of_field(1U, @lib.size_of(self.syntax))
   }
   if self.edition != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.edition)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.edition))
   }
   size
 }
@@ -305,48 +277,34 @@ pub(all) struct Method {
 pub impl @lib.Sized for Method with fn size_of(self) {
   let mut size = 0U
   if self.name != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.name)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.request_type_url != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.request_type_url)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      1U,
+      @lib.size_of(self.request_type_url),
+    )
   }
   if self.request_streaming != Default::default() {
-    size += 1U + @lib.size_of(self.request_streaming)
+    size += @lib.size_of_field(1U, @lib.size_of(self.request_streaming))
   }
   if self.response_type_url != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.response_type_url)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      1U,
+      @lib.size_of(self.response_type_url),
+    )
   }
   if self.response_streaming != Default::default() {
-    size += 1U + @lib.size_of(self.response_streaming)
+    size += @lib.size_of_field(1U, @lib.size_of(self.response_streaming))
   }
   for s in self.options {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.syntax != Default::default() {
-    size += 1U + @lib.size_of(self.syntax)
+    size += @lib.size_of_field(1U, @lib.size_of(self.syntax))
   }
   if self.edition != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.edition)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.edition))
   }
   size
 }
@@ -580,18 +538,10 @@ pub(all) struct Mixin {
 pub impl @lib.Sized for Mixin with fn size_of(self) {
   let mut size = 0U
   if self.name != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.name)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.root != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.root)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.root))
   }
   size
 }

--- a/lib/google/protobuf/compiler/top.mbt
+++ b/lib/google/protobuf/compiler/top.mbt
@@ -10,20 +10,16 @@ pub(all) struct Version {
 pub impl @lib.Sized for Version with fn size_of(self) {
   let mut size = 0U
   if self.major is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.minor is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.patch is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.suffix is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -180,39 +176,19 @@ pub(all) struct CodeGeneratorRequest {
 pub impl @lib.Sized for CodeGeneratorRequest with fn size_of(self) {
   let mut size = 0U
   for s in self.file_to_generate {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.parameter is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.proto_file {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.source_file_descriptors {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.compiler_version is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -493,32 +469,16 @@ pub(all) struct CodeGeneratorResponse_File {
 pub impl @lib.Sized for CodeGeneratorResponse_File with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.insertion_point is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.content is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.generated_code_info is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -696,27 +656,19 @@ pub(all) struct CodeGeneratorResponse {
 pub impl @lib.Sized for CodeGeneratorResponse with fn size_of(self) {
   let mut size = 0U
   if self.error is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.supported_features is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.minimum_edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.maximum_edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   for s in self.file {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }

--- a/lib/google/protobuf/compiler/top.mbt
+++ b/lib/google/protobuf/compiler/top.mbt
@@ -13,13 +13,13 @@ pub impl @lib.Sized for Version with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.minor is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.patch is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.suffix is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   size
 }
@@ -179,16 +179,16 @@ pub impl @lib.Sized for CodeGeneratorRequest with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.parameter is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.proto_file {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(15U, @lib.size_of(s))
   }
   for s in self.source_file_descriptors {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(17U, @lib.size_of(s))
   }
   if self.compiler_version is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -472,13 +472,13 @@ pub impl @lib.Sized for CodeGeneratorResponse_File with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.insertion_point is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.content is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(15U, @lib.size_of(v))
   }
   if self.generated_code_info is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(16U, @lib.size_of(v))
   }
   size
 }
@@ -659,16 +659,16 @@ pub impl @lib.Sized for CodeGeneratorResponse with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.supported_features is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.minimum_edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.maximum_edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   for s in self.file {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(15U, @lib.size_of(s))
   }
   size
 }

--- a/lib/google/protobuf/descriptor.mbt
+++ b/lib/google/protobuf/descriptor.mbt
@@ -318,43 +318,43 @@ pub impl @lib.Sized for FileDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.package_ is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.dependency {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   for s in self.public_dependency {
-    size += @lib.size_of_field(1U, @lib.size_of(s))
+    size += @lib.size_of_field(10U, @lib.size_of(s))
   }
   for s in self.weak_dependency {
-    size += @lib.size_of_field(1U, @lib.size_of(s))
+    size += @lib.size_of_field(11U, @lib.size_of(s))
   }
   for s in self.option_dependency {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(15U, @lib.size_of(s))
   }
   for s in self.message_type {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   for s in self.enum_type {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   for s in self.service {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   for s in self.extension {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(v))
   }
   if self.source_code_info is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(9U, @lib.size_of(v))
   }
   if self.syntax is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(12U, @lib.size_of(v))
   }
   if self.edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(14U, @lib.size_of(v))
   }
   size
 }
@@ -759,10 +759,10 @@ pub impl @lib.Sized for DescriptorProto_ExtensionRange with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -911,7 +911,7 @@ pub impl @lib.Sized for DescriptorProto_ReservedRange with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -1047,34 +1047,34 @@ pub impl @lib.Sized for DescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.field {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   for s in self.extension {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   for s in self.nested_type {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   for s in self.enum_type {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   for s in self.extension_range {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   for s in self.oneof_decl {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(v))
   }
   for s in self.reserved_range {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(9U, @lib.size_of(s))
   }
   for s in self.reserved_name {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(10U, @lib.size_of(s))
   }
   if self.visibility is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(11U, @lib.size_of(v))
   }
   size
 }
@@ -1490,16 +1490,16 @@ pub impl @lib.Sized for ExtensionRangeOptions_Declaration with fn size_of(self) 
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.full_name is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.type_ is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.reserved is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.repeated is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   size
 }
@@ -1688,16 +1688,16 @@ pub(all) struct ExtensionRangeOptions {
 pub impl @lib.Sized for ExtensionRangeOptions with fn size_of(self) {
   let mut size = 0U
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   for s in self.declaration {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(50U, @lib.size_of(v))
   }
   if self.verification is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -2137,34 +2137,34 @@ pub impl @lib.Sized for FieldDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.number is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.label is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   if self.type_ is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.type_name is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(v))
   }
   if self.extendee is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.default_value is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(v))
   }
   if self.oneof_index is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(9U, @lib.size_of(v))
   }
   if self.json_name is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(10U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(v))
   }
   if self.proto3_optional is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(17U, @lib.size_of(v))
   }
   size
 }
@@ -2485,7 +2485,7 @@ pub impl @lib.Sized for OneofDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -2618,7 +2618,7 @@ pub impl @lib.Sized for EnumDescriptorProto_EnumReservedRange with fn size_of(
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -2749,19 +2749,19 @@ pub impl @lib.Sized for EnumDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.value {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   for s in self.reserved_range {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   for s in self.reserved_name {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   if self.visibility is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   size
 }
@@ -2994,10 +2994,10 @@ pub impl @lib.Sized for EnumValueDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.number is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -3145,10 +3145,10 @@ pub impl @lib.Sized for ServiceDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.method_ {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -3305,19 +3305,19 @@ pub impl @lib.Sized for MethodDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.input_type is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.output_type is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   if self.client_streaming is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.server_streaming is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   size
 }
@@ -3621,64 +3621,64 @@ pub impl @lib.Sized for FileOptions with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.java_outer_classname is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(v))
   }
   if self.java_multiple_files is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(10U, @lib.size_of(v))
   }
   if self.java_generate_equals_and_hash is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(20U, @lib.size_of(v))
   }
   if self.java_string_check_utf8 is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(27U, @lib.size_of(v))
   }
   if self.optimize_for is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(9U, @lib.size_of(v))
   }
   if self.go_package is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(11U, @lib.size_of(v))
   }
   if self.cc_generic_services is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(16U, @lib.size_of(v))
   }
   if self.java_generic_services is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(17U, @lib.size_of(v))
   }
   if self.py_generic_services is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(18U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(23U, @lib.size_of(v))
   }
   if self.cc_enable_arenas is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(31U, @lib.size_of(v))
   }
   if self.objc_class_prefix is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(36U, @lib.size_of(v))
   }
   if self.csharp_namespace is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(37U, @lib.size_of(v))
   }
   if self.swift_prefix is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(39U, @lib.size_of(v))
   }
   if self.php_class_prefix is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(40U, @lib.size_of(v))
   }
   if self.php_namespace is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(41U, @lib.size_of(v))
   }
   if self.php_metadata_namespace is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(44U, @lib.size_of(v))
   }
   if self.ruby_package is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(45U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(50U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -4211,22 +4211,22 @@ pub impl @lib.Sized for MessageOptions with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.no_standard_descriptor_accessor is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.map_entry is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(7U, @lib.size_of(v))
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(11U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(12U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -4810,10 +4810,10 @@ pub(all) struct FieldOptions_EditionDefault {
 pub impl @lib.Sized for FieldOptions_EditionDefault with fn size_of(self) {
   let mut size = 0U
   if self.edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.value is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -4948,13 +4948,13 @@ pub impl @lib.Sized for FieldOptions_FeatureSupport with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.edition_deprecated is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.deprecation_warning is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.edition_removed is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   size
 }
@@ -5164,43 +5164,43 @@ pub impl @lib.Sized for FieldOptions with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.packed is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.jstype is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   if self.lazy_ is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.unverified_lazy is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(15U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.weak is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(10U, @lib.size_of(v))
   }
   if self.debug_redact is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(16U, @lib.size_of(v))
   }
   if self.retention is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(17U, @lib.size_of(v))
   }
   for s in self.targets {
-    size += @lib.size_of_field(2U, @lib.size_of(s))
+    size += @lib.size_of_field(19U, @lib.size_of(s))
   }
   for s in self.edition_defaults {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(20U, @lib.size_of(s))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(21U, @lib.size_of(v))
   }
   if self.feature_support is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(22U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -5620,7 +5620,7 @@ pub impl @lib.Sized for OneofOptions with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -5755,19 +5755,19 @@ pub(all) struct EnumOptions {
 pub impl @lib.Sized for EnumOptions with fn size_of(self) {
   let mut size = 0U
   if self.allow_alias is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -5976,16 +5976,16 @@ pub impl @lib.Sized for EnumValueOptions with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.debug_redact is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.feature_support is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -6189,13 +6189,13 @@ pub(all) struct ServiceOptions {
 pub impl @lib.Sized for ServiceOptions with fn size_of(self) {
   let mut size = 0U
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(34U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(33U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -6423,16 +6423,16 @@ pub(all) struct MethodOptions {
 pub impl @lib.Sized for MethodOptions with fn size_of(self) {
   let mut size = 0U
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(33U, @lib.size_of(v))
   }
   if self.idempotency_level is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(34U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(35U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -6617,7 +6617,7 @@ pub(all) struct UninterpretedOption_NamePart {
 pub impl @lib.Sized for UninterpretedOption_NamePart with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name_part))
-  size += @lib.size_of_field(1U, @lib.size_of(self.is_extension))
+  size += @lib.size_of_field(2U, @lib.size_of(self.is_extension))
   size
 }
 
@@ -6739,25 +6739,25 @@ pub(all) struct UninterpretedOption {
 pub impl @lib.Sized for UninterpretedOption with fn size_of(self) {
   let mut size = 0U
   for s in self.name {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.identifier_value is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.positive_int_value is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   if self.negative_int_value is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.double_value is Some(_) {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(6U, 8U)
   }
   if self.string_value is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(v))
   }
   if self.aggregate_value is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(v))
   }
   size
 }
@@ -7669,25 +7669,25 @@ pub impl @lib.Sized for FeatureSet with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.enum_type is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.repeated_field_encoding is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.utf8_validation is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   if self.message_encoding is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.json_format is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   if self.enforce_naming_style is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(7U, @lib.size_of(v))
   }
   if self.default_symbol_visibility is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(8U, @lib.size_of(v))
   }
   size
 }
@@ -7998,13 +7998,13 @@ pub impl @lib.Sized for FeatureSetDefaults_FeatureSetEditionDefault with fn size
 ) {
   let mut size = 0U
   if self.edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.overridable_features is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   if self.fixed_features is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
   }
   size
 }
@@ -8177,10 +8177,10 @@ pub impl @lib.Sized for FeatureSetDefaults with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.minimum_edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   if self.maximum_edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   size
 }
@@ -8362,18 +8362,18 @@ pub impl @lib.Sized for SourceCodeInfo_Location with fn size_of(self) {
   }
   if !self.span.is_empty() {
     size += @lib.size_of_length_delimited_field(
-      1U,
+      2U,
       self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add),
     )
   }
   if self.leading_comments is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.trailing_comments is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   for s in self.leading_detached_comments {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   size
 }
@@ -8788,16 +8788,16 @@ pub impl @lib.Sized for GeneratedCodeInfo_Annotation with fn size_of(self) {
     )
   }
   if self.source_file is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.begin is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   if self.semantic is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   size
 }

--- a/lib/google/protobuf/descriptor.mbt
+++ b/lib/google/protobuf/descriptor.mbt
@@ -191,11 +191,7 @@ pub(all) struct FileDescriptorSet {
 pub impl @lib.Sized for FileDescriptorSet with fn size_of(self) {
   let mut size = 0U
   for s in self.file {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -319,90 +315,46 @@ pub(all) struct FileDescriptorProto {
 pub impl @lib.Sized for FileDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.package_ is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.dependency {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.public_dependency {
-    size += 1U + @lib.size_of(s)
+    size += @lib.size_of_field(1U, @lib.size_of(s))
   }
   for s in self.weak_dependency {
-    size += 1U + @lib.size_of(s)
+    size += @lib.size_of_field(1U, @lib.size_of(s))
   }
   for s in self.option_dependency {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.message_type {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.enum_type {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.service {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.extension {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.source_code_info is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.syntax is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -804,17 +756,13 @@ pub(all) struct DescriptorProto_ExtensionRange {
 pub impl @lib.Sized for DescriptorProto_ExtensionRange with fn size_of(self) {
   let mut size = 0U
   if self.start is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -960,10 +908,10 @@ pub(all) struct DescriptorProto_ReservedRange {
 pub impl @lib.Sized for DescriptorProto_ReservedRange with fn size_of(self) {
   let mut size = 0U
   if self.start is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -1096,77 +1044,37 @@ pub(all) struct DescriptorProto {
 pub impl @lib.Sized for DescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.field {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.extension {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.nested_type {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.enum_type {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.extension_range {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.oneof_decl {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.reserved_range {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.reserved_name {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.visibility is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -1579,27 +1487,19 @@ pub(all) struct ExtensionRangeOptions_Declaration {
 pub impl @lib.Sized for ExtensionRangeOptions_Declaration with fn size_of(self) {
   let mut size = 0U
   if self.number is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.full_name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.type_ is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.reserved is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.repeated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -1788,28 +1688,16 @@ pub(all) struct ExtensionRangeOptions {
 pub impl @lib.Sized for ExtensionRangeOptions with fn size_of(self) {
   let mut size = 0U
   for s in self.uninterpreted_option {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   for s in self.declaration {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.features is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.verification is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -2246,61 +2134,37 @@ pub(all) struct FieldDescriptorProto {
 pub impl @lib.Sized for FieldDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.number is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.label is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.type_ is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.type_name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.extendee is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.default_value is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.oneof_index is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.json_name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.proto3_optional is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -2618,18 +2482,10 @@ pub(all) struct OneofDescriptorProto {
 pub impl @lib.Sized for OneofDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -2759,10 +2615,10 @@ pub impl @lib.Sized for EnumDescriptorProto_EnumReservedRange with fn size_of(
 ) {
   let mut size = 0U
   if self.start is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -2890,42 +2746,22 @@ pub(all) struct EnumDescriptorProto {
 pub impl @lib.Sized for EnumDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.value {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.reserved_range {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.reserved_name {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.visibility is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -3155,21 +2991,13 @@ pub(all) struct EnumValueDescriptorProto {
 pub impl @lib.Sized for EnumValueDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.number is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -3314,25 +3142,13 @@ pub(all) struct ServiceDescriptorProto {
 pub impl @lib.Sized for ServiceDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.method_ {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -3486,38 +3302,22 @@ pub(all) struct MethodDescriptorProto {
 pub impl @lib.Sized for MethodDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.input_type is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.output_type is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.client_streaming is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.server_streaming is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -3818,115 +3618,67 @@ pub(all) struct FileOptions {
 pub impl @lib.Sized for FileOptions with fn size_of(self) {
   let mut size = 0U
   if self.java_package is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.java_outer_classname is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.java_multiple_files is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.java_generate_equals_and_hash is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.java_string_check_utf8 is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.optimize_for is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.go_package is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.cc_generic_services is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.java_generic_services is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.py_generic_services is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.cc_enable_arenas is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.objc_class_prefix is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.csharp_namespace is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.swift_prefix is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.php_class_prefix is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.php_namespace is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.php_metadata_namespace is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.ruby_package is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -4456,33 +4208,25 @@ pub(all) struct MessageOptions {
 pub impl @lib.Sized for MessageOptions with fn size_of(self) {
   let mut size = 0U
   if self.message_set_wire_format is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.no_standard_descriptor_accessor is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.map_entry is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -5066,14 +4810,10 @@ pub(all) struct FieldOptions_EditionDefault {
 pub impl @lib.Sized for FieldOptions_EditionDefault with fn size_of(self) {
   let mut size = 0U
   if self.edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.value is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -5205,20 +4945,16 @@ pub(all) struct FieldOptions_FeatureSupport {
 pub impl @lib.Sized for FieldOptions_FeatureSupport with fn size_of(self) {
   let mut size = 0U
   if self.edition_introduced is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.edition_deprecated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecation_warning is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.edition_removed is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -5425,62 +5161,46 @@ pub(all) struct FieldOptions {
 pub impl @lib.Sized for FieldOptions with fn size_of(self) {
   let mut size = 0U
   if self.ctype is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.packed is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.jstype is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.lazy_ is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.unverified_lazy is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.weak is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.debug_redact is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.retention is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   for s in self.targets {
-    size += 2U + @lib.size_of(s)
+    size += @lib.size_of_field(2U, @lib.size_of(s))
   }
   for s in self.edition_defaults {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.features is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.feature_support is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -5897,18 +5617,10 @@ pub(all) struct OneofOptions {
 pub impl @lib.Sized for OneofOptions with fn size_of(self) {
   let mut size = 0U
   if self.features is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -6043,27 +5755,19 @@ pub(all) struct EnumOptions {
 pub impl @lib.Sized for EnumOptions with fn size_of(self) {
   let mut size = 0U
   if self.allow_alias is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -6269,31 +5973,19 @@ pub(all) struct EnumValueOptions {
 pub impl @lib.Sized for EnumValueOptions with fn size_of(self) {
   let mut size = 0U
   if self.deprecated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.debug_redact is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.feature_support is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -6497,21 +6189,13 @@ pub(all) struct ServiceOptions {
 pub impl @lib.Sized for ServiceOptions with fn size_of(self) {
   let mut size = 0U
   if self.features is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -6739,24 +6423,16 @@ pub(all) struct MethodOptions {
 pub impl @lib.Sized for MethodOptions with fn size_of(self) {
   let mut size = 0U
   if self.deprecated is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.idempotency_level is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -6940,12 +6616,8 @@ pub(all) struct UninterpretedOption_NamePart {
 ///|
 pub impl @lib.Sized for UninterpretedOption_NamePart with fn size_of(self) {
   let mut size = 0U
-  size += 1U +
-    ({
-      let size = @lib.size_of(self.name_part)
-      @lib.size_of(size) + size
-    })
-  size += 1U + @lib.size_of(self.is_extension)
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name_part))
+  size += @lib.size_of_field(1U, @lib.size_of(self.is_extension))
   size
 }
 
@@ -7067,41 +6739,25 @@ pub(all) struct UninterpretedOption {
 pub impl @lib.Sized for UninterpretedOption with fn size_of(self) {
   let mut size = 0U
   for s in self.name {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.identifier_value is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.positive_int_value is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.negative_int_value is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.double_value is Some(_) {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.string_value is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.aggregate_value is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -8010,28 +7666,28 @@ pub(all) struct FeatureSet {
 pub impl @lib.Sized for FeatureSet with fn size_of(self) {
   let mut size = 0U
   if self.field_presence is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.enum_type is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.repeated_field_encoding is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.utf8_validation is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.message_encoding is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.json_format is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.enforce_naming_style is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.default_symbol_visibility is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -8342,21 +7998,13 @@ pub impl @lib.Sized for FeatureSetDefaults_FeatureSetEditionDefault with fn size
 ) {
   let mut size = 0U
   if self.edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.overridable_features is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.fixed_features is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -8526,17 +8174,13 @@ pub(all) struct FeatureSetDefaults {
 pub impl @lib.Sized for FeatureSetDefaults with fn size_of(self) {
   let mut size = 0U
   for s in self.defaults {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.minimum_edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.maximum_edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -8711,39 +8355,25 @@ pub(all) struct SourceCodeInfo_Location {
 pub impl @lib.Sized for SourceCodeInfo_Location with fn size_of(self) {
   let mut size = 0U
   if !self.path.is_empty() {
-    size += 1U +
-      ({
-        let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      1U,
+      self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add),
+    )
   }
   if !self.span.is_empty() {
-    size += 1U +
-      ({
-        let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      1U,
+      self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add),
+    )
   }
   if self.leading_comments is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.trailing_comments is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.leading_detached_comments {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -8965,11 +8595,7 @@ pub(all) struct SourceCodeInfo {
 pub impl @lib.Sized for SourceCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.location {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -9156,27 +8782,22 @@ pub(all) struct GeneratedCodeInfo_Annotation {
 pub impl @lib.Sized for GeneratedCodeInfo_Annotation with fn size_of(self) {
   let mut size = 0U
   if !self.path.is_empty() {
-    size += 1U +
-      ({
-        let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      1U,
+      self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add),
+    )
   }
   if self.source_file is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.begin is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.semantic is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -9379,11 +9000,7 @@ pub(all) struct GeneratedCodeInfo {
 pub impl @lib.Sized for GeneratedCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.annotation {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }

--- a/lib/google/protobuf/duration.mbt
+++ b/lib/google/protobuf/duration.mbt
@@ -11,7 +11,7 @@ pub impl @lib.Sized for Duration with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(self.seconds))
   }
   if self.nanos != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.nanos))
+    size += @lib.size_of_field(2U, @lib.size_of(self.nanos))
   }
   size
 }

--- a/lib/google/protobuf/duration.mbt
+++ b/lib/google/protobuf/duration.mbt
@@ -8,10 +8,10 @@ pub(all) struct Duration {
 pub impl @lib.Sized for Duration with fn size_of(self) {
   let mut size = 0U
   if self.seconds != Default::default() {
-    size += 1U + @lib.size_of(self.seconds)
+    size += @lib.size_of_field(1U, @lib.size_of(self.seconds))
   }
   if self.nanos != Default::default() {
-    size += 1U + @lib.size_of(self.nanos)
+    size += @lib.size_of_field(1U, @lib.size_of(self.nanos))
   }
   size
 }

--- a/lib/google/protobuf/field_mask.mbt
+++ b/lib/google/protobuf/field_mask.mbt
@@ -7,11 +7,7 @@ pub(all) struct FieldMask {
 pub impl @lib.Sized for FieldMask with fn size_of(self) {
   let mut size = 0U
   for s in self.paths {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }

--- a/lib/google/protobuf/source_context.mbt
+++ b/lib/google/protobuf/source_context.mbt
@@ -7,11 +7,10 @@ pub(all) struct SourceContext {
 pub impl @lib.Sized for SourceContext with fn size_of(self) {
   let mut size = 0U
   if self.file_name != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.file_name)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      1U,
+      @lib.size_of(self.file_name),
+    )
   }
   size
 }

--- a/lib/google/protobuf/struct.mbt
+++ b/lib/google/protobuf/struct.mbt
@@ -71,17 +71,9 @@ pub(all) struct Struct_FieldsEntry {
 pub impl @lib.Sized for Struct_FieldsEntry with fn size_of(self) {
   let mut size = 0U
   if self.key != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.key)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
   }
-  size += 1U +
-    ({
-      let size = @lib.size_of(self.value)
-      @lib.size_of(size) + size
-    })
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.value))
   size
 }
 
@@ -197,17 +189,9 @@ pub(all) struct Struct {
 pub impl @lib.Sized for Struct with fn size_of(self) {
   let mut size = 0U
   for k, v in self.fields {
-    let key_size = 1U +
-      ({
-        let size = @lib.size_of(k)
-        @lib.size_of(size) + size
-      })
-    let value_size = 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
-    size += 1U + @lib.size_of(key_size + value_size) + key_size + value_size
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(1U, key_size + value_size)
   }
   size
 }
@@ -249,16 +233,8 @@ pub impl @lib.Write for Struct with fn write(
     let k = keys[i]
     let v = self.fields.get(k).unwrap()
     writer |> @lib.write_varint(10UL)
-    let key_size = 1U +
-      ({
-        let size = @lib.size_of(k)
-        @lib.size_of(size) + size
-      })
-    let value_size = 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
@@ -324,16 +300,8 @@ pub impl @lib.AsyncWrite for Struct with fn write(
     let k = keys[i]
     let v = self.fields.get(k).unwrap()
     writer |> @lib.async_write_varint(10UL)
-    let key_size = 1U +
-      ({
-        let size = @lib.size_of(k)
-        @lib.size_of(size) + size
-      })
-    let value_size = 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)
@@ -419,27 +387,15 @@ pub impl ToJson for Value_Kind with fn to_json(self : Value_Kind) -> Json {
 pub impl @lib.Sized for Value with fn size_of(self) {
   let mut size = 0U
   match self.kind {
-    NullValue(v) => size += 1U + @lib.size_of(v)
-    NumberValue(_) => size += 1U + 8U
+    NullValue(v) => size += @lib.size_of_field(1U, @lib.size_of(v))
+    NumberValue(_) => size += @lib.size_of_field(1U, 8U)
     StringValue(v) =>
-      size += 1U +
-        ({
-          let size = @lib.size_of(v)
-          @lib.size_of(size) + size
-        })
-    BoolValue(v) => size += 1U + @lib.size_of(v)
+      size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    BoolValue(v) => size += @lib.size_of_field(1U, @lib.size_of(v))
     StructValue(v) =>
-      size += 1U +
-        ({
-          let size = @lib.size_of(v)
-          @lib.size_of(size) + size
-        })
+      size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
     ListValue(v) =>
-      size += 1U +
-        ({
-          let size = @lib.size_of(v)
-          @lib.size_of(size) + size
-        })
+      size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
     NotSet => ()
   }
   size
@@ -627,11 +583,7 @@ pub(all) struct ListValue {
 pub impl @lib.Sized for ListValue with fn size_of(self) {
   let mut size = 0U
   for s in self.values {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }

--- a/lib/google/protobuf/struct.mbt
+++ b/lib/google/protobuf/struct.mbt
@@ -73,7 +73,7 @@ pub impl @lib.Sized for Struct_FieldsEntry with fn size_of(self) {
   if self.key != Default::default() {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
   }
-  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.value))
+  size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.value))
   size
 }
 
@@ -190,7 +190,7 @@ pub impl @lib.Sized for Struct with fn size_of(self) {
   let mut size = 0U
   for k, v in self.fields {
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    let value_size = @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
     size += @lib.size_of_length_delimited_field(1U, key_size + value_size)
   }
   size
@@ -234,7 +234,7 @@ pub impl @lib.Write for Struct with fn write(
     let v = self.fields.get(k).unwrap()
     writer |> @lib.write_varint(10UL)
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    let value_size = @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
@@ -301,7 +301,7 @@ pub impl @lib.AsyncWrite for Struct with fn write(
     let v = self.fields.get(k).unwrap()
     writer |> @lib.async_write_varint(10UL)
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    let value_size = @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)
@@ -388,14 +388,14 @@ pub impl @lib.Sized for Value with fn size_of(self) {
   let mut size = 0U
   match self.kind {
     NullValue(v) => size += @lib.size_of_field(1U, @lib.size_of(v))
-    NumberValue(_) => size += @lib.size_of_field(1U, 8U)
+    NumberValue(_) => size += @lib.size_of_field(2U, 8U)
     StringValue(v) =>
-      size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
-    BoolValue(v) => size += @lib.size_of_field(1U, @lib.size_of(v))
+      size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
+    BoolValue(v) => size += @lib.size_of_field(4U, @lib.size_of(v))
     StructValue(v) =>
-      size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+      size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
     ListValue(v) =>
-      size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+      size += @lib.size_of_length_delimited_field(6U, @lib.size_of(v))
     NotSet => ()
   }
   size

--- a/lib/google/protobuf/timestamp.mbt
+++ b/lib/google/protobuf/timestamp.mbt
@@ -8,10 +8,10 @@ pub(all) struct Timestamp {
 pub impl @lib.Sized for Timestamp with fn size_of(self) {
   let mut size = 0U
   if self.seconds != Default::default() {
-    size += 1U + @lib.size_of(self.seconds)
+    size += @lib.size_of_field(1U, @lib.size_of(self.seconds))
   }
   if self.nanos != Default::default() {
-    size += 1U + @lib.size_of(self.nanos)
+    size += @lib.size_of_field(1U, @lib.size_of(self.nanos))
   }
   size
 }

--- a/lib/google/protobuf/timestamp.mbt
+++ b/lib/google/protobuf/timestamp.mbt
@@ -11,7 +11,7 @@ pub impl @lib.Sized for Timestamp with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(self.seconds))
   }
   if self.nanos != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.nanos))
+    size += @lib.size_of_field(2U, @lib.size_of(self.nanos))
   }
   size
 }

--- a/lib/google/protobuf/type.mbt
+++ b/lib/google/protobuf/type.mbt
@@ -91,22 +91,22 @@ pub impl @lib.Sized for Type with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   for s in self.fields {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   for s in self.oneofs {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   for s in self.options {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   if self.source_context is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
   }
   if self.syntax != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.syntax))
+    size += @lib.size_of_field(6U, @lib.size_of(self.syntax))
   }
   if self.edition != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.edition))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(self.edition))
   }
   size
 }
@@ -582,35 +582,35 @@ pub impl @lib.Sized for Field with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(self.kind))
   }
   if self.cardinality != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.cardinality))
+    size += @lib.size_of_field(2U, @lib.size_of(self.cardinality))
   }
   if self.number != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.number))
+    size += @lib.size_of_field(3U, @lib.size_of(self.number))
   }
   if self.name != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(self.name))
   }
   if self.type_url != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.type_url))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(self.type_url))
   }
   if self.oneof_index != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.oneof_index))
+    size += @lib.size_of_field(7U, @lib.size_of(self.oneof_index))
   }
   if self.packed != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.packed))
+    size += @lib.size_of_field(8U, @lib.size_of(self.packed))
   }
   for s in self.options {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(9U, @lib.size_of(s))
   }
   if self.json_name != Default::default() {
     size += @lib.size_of_length_delimited_field(
-      1U,
+      10U,
       @lib.size_of(self.json_name),
     )
   }
   if self.default_value != Default::default() {
     size += @lib.size_of_length_delimited_field(
-      1U,
+      11U,
       @lib.size_of(self.default_value),
     )
   }
@@ -889,19 +889,19 @@ pub impl @lib.Sized for Enum with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   for s in self.enumvalue {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   for s in self.options {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   if self.source_context is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   if self.syntax != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.syntax))
+    size += @lib.size_of_field(5U, @lib.size_of(self.syntax))
   }
   if self.edition != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.edition))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(self.edition))
   }
   size
 }
@@ -1100,10 +1100,10 @@ pub impl @lib.Sized for EnumValue with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.number != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.number))
+    size += @lib.size_of_field(2U, @lib.size_of(self.number))
   }
   for s in self.options {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   size
 }
@@ -1242,7 +1242,7 @@ pub impl @lib.Sized for Option with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.value is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   size
 }

--- a/lib/google/protobuf/type.mbt
+++ b/lib/google/protobuf/type.mbt
@@ -88,49 +88,25 @@ pub(all) struct Type {
 pub impl @lib.Sized for Type with fn size_of(self) {
   let mut size = 0U
   if self.name != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.name)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   for s in self.fields {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.oneofs {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.options {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.source_context is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.syntax != Default::default() {
-    size += 1U + @lib.size_of(self.syntax)
+    size += @lib.size_of_field(1U, @lib.size_of(self.syntax))
   }
   if self.edition != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.edition)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.edition))
   }
   size
 }
@@ -603,54 +579,40 @@ pub(all) struct Field {
 pub impl @lib.Sized for Field with fn size_of(self) {
   let mut size = 0U
   if self.kind != Default::default() {
-    size += 1U + @lib.size_of(self.kind)
+    size += @lib.size_of_field(1U, @lib.size_of(self.kind))
   }
   if self.cardinality != Default::default() {
-    size += 1U + @lib.size_of(self.cardinality)
+    size += @lib.size_of_field(1U, @lib.size_of(self.cardinality))
   }
   if self.number != Default::default() {
-    size += 1U + @lib.size_of(self.number)
+    size += @lib.size_of_field(1U, @lib.size_of(self.number))
   }
   if self.name != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.name)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.type_url != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.type_url)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.type_url))
   }
   if self.oneof_index != Default::default() {
-    size += 1U + @lib.size_of(self.oneof_index)
+    size += @lib.size_of_field(1U, @lib.size_of(self.oneof_index))
   }
   if self.packed != Default::default() {
-    size += 1U + @lib.size_of(self.packed)
+    size += @lib.size_of_field(1U, @lib.size_of(self.packed))
   }
   for s in self.options {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.json_name != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.json_name)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      1U,
+      @lib.size_of(self.json_name),
+    )
   }
   if self.default_value != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.default_value)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      1U,
+      @lib.size_of(self.default_value),
+    )
   }
   size
 }
@@ -924,42 +886,22 @@ pub(all) struct Enum {
 pub impl @lib.Sized for Enum with fn size_of(self) {
   let mut size = 0U
   if self.name != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.name)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   for s in self.enumvalue {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.options {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.source_context is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.syntax != Default::default() {
-    size += 1U + @lib.size_of(self.syntax)
+    size += @lib.size_of_field(1U, @lib.size_of(self.syntax))
   }
   if self.edition != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.edition)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.edition))
   }
   size
 }
@@ -1155,21 +1097,13 @@ pub(all) struct EnumValue {
 pub impl @lib.Sized for EnumValue with fn size_of(self) {
   let mut size = 0U
   if self.name != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.name)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.number != Default::default() {
-    size += 1U + @lib.size_of(self.number)
+    size += @lib.size_of_field(1U, @lib.size_of(self.number))
   }
   for s in self.options {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -1305,18 +1239,10 @@ pub(all) struct Option {
 pub impl @lib.Sized for Option with fn size_of(self) {
   let mut size = 0U
   if self.name != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.name)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.value is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }

--- a/lib/google/protobuf/wrappers.mbt
+++ b/lib/google/protobuf/wrappers.mbt
@@ -7,7 +7,7 @@ pub(all) struct DoubleValue {
 pub impl @lib.Sized for DoubleValue with fn size_of(self) {
   let mut size = 0U
   if self.value != Default::default() {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   size
 }
@@ -109,7 +109,7 @@ pub(all) struct FloatValue {
 pub impl @lib.Sized for FloatValue with fn size_of(self) {
   let mut size = 0U
   if self.value != Default::default() {
-    size += 1U + 4U
+    size += @lib.size_of_field(1U, 4U)
   }
   size
 }
@@ -211,7 +211,7 @@ pub(all) struct Int64Value {
 pub impl @lib.Sized for Int64Value with fn size_of(self) {
   let mut size = 0U
   if self.value != Default::default() {
-    size += 1U + @lib.size_of(self.value)
+    size += @lib.size_of_field(1U, @lib.size_of(self.value))
   }
   size
 }
@@ -313,7 +313,7 @@ pub(all) struct UInt64Value {
 pub impl @lib.Sized for UInt64Value with fn size_of(self) {
   let mut size = 0U
   if self.value != Default::default() {
-    size += 1U + @lib.size_of(self.value)
+    size += @lib.size_of_field(1U, @lib.size_of(self.value))
   }
   size
 }
@@ -415,7 +415,7 @@ pub(all) struct Int32Value {
 pub impl @lib.Sized for Int32Value with fn size_of(self) {
   let mut size = 0U
   if self.value != Default::default() {
-    size += 1U + @lib.size_of(self.value)
+    size += @lib.size_of_field(1U, @lib.size_of(self.value))
   }
   size
 }
@@ -517,7 +517,7 @@ pub(all) struct UInt32Value {
 pub impl @lib.Sized for UInt32Value with fn size_of(self) {
   let mut size = 0U
   if self.value != Default::default() {
-    size += 1U + @lib.size_of(self.value)
+    size += @lib.size_of_field(1U, @lib.size_of(self.value))
   }
   size
 }
@@ -619,7 +619,7 @@ pub(all) struct BoolValue {
 pub impl @lib.Sized for BoolValue with fn size_of(self) {
   let mut size = 0U
   if self.value != Default::default() {
-    size += 1U + @lib.size_of(self.value)
+    size += @lib.size_of_field(1U, @lib.size_of(self.value))
   }
   size
 }
@@ -721,11 +721,7 @@ pub(all) struct StringValue {
 pub impl @lib.Sized for StringValue with fn size_of(self) {
   let mut size = 0U
   if self.value != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.value)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.value))
   }
   size
 }
@@ -827,11 +823,7 @@ pub(all) struct BytesValue {
 pub impl @lib.Sized for BytesValue with fn size_of(self) {
   let mut size = 0U
   if self.value != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.value)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.value))
   }
   size
 }

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -144,8 +144,6 @@ pub fn[T : Sized] size_of(T) -> UInt
 
 pub fn size_of_field(UInt, UInt) -> UInt
 
-pub fn size_of_length_delimited(UInt) -> UInt
-
 pub fn size_of_length_delimited_field(UInt, UInt) -> UInt
 
 pub fn[T : Reader] skip_message_field(T, UInt) -> Unit raise

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -142,6 +142,12 @@ pub fn[T : Reader] read_varint32(T) -> UInt raise
 
 pub fn[T : Sized] size_of(T) -> UInt
 
+pub fn size_of_field(UInt, UInt) -> UInt
+
+pub fn size_of_length_delimited(UInt) -> UInt
+
+pub fn size_of_length_delimited_field(UInt, UInt) -> UInt
+
 pub fn[T : Reader] skip_message_field(T, UInt) -> Unit raise
 
 pub fn[T : Writer] write_bool(T, Bool) -> Unit raise

--- a/lib/sizeof.mbt
+++ b/lib/sizeof.mbt
@@ -23,6 +23,24 @@ pub fn[T : Sized] size_of(t : T) -> UInt {
 }
 
 ///|
+pub fn size_of_field(tag_size : UInt, payload_size : UInt) -> UInt {
+  tag_size + payload_size
+}
+
+///|
+pub fn size_of_length_delimited(payload_size : UInt) -> UInt {
+  size_of(payload_size) + payload_size
+}
+
+///|
+pub fn size_of_length_delimited_field(
+  tag_size : UInt,
+  payload_size : UInt,
+) -> UInt {
+  tag_size + size_of_length_delimited(payload_size)
+}
+
+///|
 fn size_of_varint(v : UInt64) -> UInt {
   if v < 0x80UL {
     1

--- a/lib/sizeof.mbt
+++ b/lib/sizeof.mbt
@@ -23,21 +23,27 @@ pub fn[T : Sized] size_of(t : T) -> UInt {
 }
 
 ///|
-pub fn size_of_field(tag_size : UInt, payload_size : UInt) -> UInt {
-  tag_size + payload_size
+fn size_of_tag(field_number : UInt) -> UInt {
+  size_of_varint((field_number << 3).to_uint64())
 }
 
 ///|
-pub fn size_of_length_delimited(payload_size : UInt) -> UInt {
-  size_of(payload_size) + payload_size
+/// Size of a non-length-delimited field envelope around an already-sized payload.
+/// `field_number` is the protobuf field number, not an encoded tag size.
+pub fn size_of_field(field_number : UInt, payload_size : UInt) -> UInt {
+  size_of_tag(field_number) + payload_size
 }
 
 ///|
+/// Size of a length-delimited field envelope around an already-sized payload.
+/// `field_number` is the protobuf field number, not an encoded tag size.
 pub fn size_of_length_delimited_field(
-  tag_size : UInt,
+  field_number : UInt,
   payload_size : UInt,
 ) -> UInt {
-  tag_size + size_of_length_delimited(payload_size)
+  size_of_tag(field_number) +
+  size_of_varint(payload_size.to_uint64()) +
+  payload_size
 }
 
 ///|

--- a/lib/writer_test.mbt
+++ b/lib/writer_test.mbt
@@ -32,6 +32,14 @@ test "varint size boundaries" {
 }
 
 ///|
+test "field envelope size" {
+  @debug.assert_eq(@protobuf.size_of_field(2U, 8U), 10U)
+  @debug.assert_eq(@protobuf.size_of_length_delimited(127U), 128U)
+  @debug.assert_eq(@protobuf.size_of_length_delimited(128U), 130U)
+  @debug.assert_eq(@protobuf.size_of_length_delimited_field(2U, 128U), 132U)
+}
+
+///|
 test "integer" {
   let writer = Buffer()
   writer |> @protobuf.write_int64(-2)

--- a/lib/writer_test.mbt
+++ b/lib/writer_test.mbt
@@ -33,10 +33,10 @@ test "varint size boundaries" {
 
 ///|
 test "field envelope size" {
-  @debug.assert_eq(@protobuf.size_of_field(2U, 8U), 10U)
-  @debug.assert_eq(@protobuf.size_of_length_delimited(127U), 128U)
-  @debug.assert_eq(@protobuf.size_of_length_delimited(128U), 130U)
-  @debug.assert_eq(@protobuf.size_of_length_delimited_field(2U, 128U), 132U)
+  @debug.assert_eq(@protobuf.size_of_field(1U, 8U), 9U)
+  @debug.assert_eq(@protobuf.size_of_field(16U, 8U), 10U)
+  @debug.assert_eq(@protobuf.size_of_length_delimited_field(1U, 127U), 129U)
+  @debug.assert_eq(@protobuf.size_of_length_delimited_field(16U, 128U), 132U)
 }
 
 ///|

--- a/test/reader/gen_proto2/src/top.mbt
+++ b/test/reader/gen_proto2/src/top.mbt
@@ -196,58 +196,58 @@ pub(all) struct FooMessageP2 {
 pub impl @lib.Sized for FooMessageP2 with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_field(1U, @lib.size_of(self.f_int32))
-  size += @lib.size_of_field(1U, @lib.size_of(self.f_int64))
+  size += @lib.size_of_field(2U, @lib.size_of(self.f_int64))
   if self.f_uint32 is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.f_uint64 is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   if self.f_sint32 is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.f_sint64 is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   if self.f_bool is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(7U, @lib.size_of(v))
   }
   if self.f_foo_enum is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(8U, @lib.size_of(v))
   }
   if self.f_fixed64 is Some(_) {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(9U, 8U)
   }
   if self.f_sfixed64 is Some(_) {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(10U, 8U)
   }
   if self.f_fixed32 is Some(_) {
-    size += @lib.size_of_field(1U, 4U)
+    size += @lib.size_of_field(11U, 4U)
   }
   if self.f_sfixed32 is Some(_) {
-    size += @lib.size_of_field(1U, 4U)
+    size += @lib.size_of_field(12U, 4U)
   }
   if self.f_double is Some(_) {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(13U, 8U)
   }
   if self.f_float is Some(_) {
-    size += @lib.size_of_field(1U, 4U)
+    size += @lib.size_of_field(14U, 4U)
   }
   if self.f_bytes is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(15U, @lib.size_of(v))
   }
   if self.f_string is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(16U, @lib.size_of(v))
   }
   if self.f_bar_message is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(18U, @lib.size_of(v))
   }
   for s in self.f_repeated_int32 {
-    size += @lib.size_of_field(2U, @lib.size_of(s))
+    size += @lib.size_of_field(19U, @lib.size_of(s))
   }
   if !self.f_repeated_packed_int32.is_empty() {
     size += @lib.size_of_length_delimited_field(
-      2U,
+      20U,
       self.f_repeated_packed_int32
       .iter()
       .map(@lib.size_of)
@@ -256,58 +256,58 @@ pub impl @lib.Sized for FooMessageP2 with fn size_of(self) {
   }
   if !self.f_repeated_packed_float.is_empty() {
     size += @lib.size_of_length_delimited_field(
-      2U,
+      21U,
       self.f_repeated_packed_float.length().reinterpret_as_uint() * 4,
     )
   }
   if self.f_baz is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(23U, @lib.size_of(v))
   }
   if self.f_nested is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(24U, @lib.size_of(v))
   }
   if self.f_nested_enum is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(25U, @lib.size_of(v))
   }
   for s in self.f_map {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(27U, @lib.size_of(s))
   }
   if self.f1 is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(28U, @lib.size_of(v))
   }
   if self.f2 is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(29U, @lib.size_of(v))
   }
   if self.f3 is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(30U, @lib.size_of(v))
   }
   for s in self.f_repeated_string {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(31U, @lib.size_of(s))
   }
   for s in self.f_repeated_baz_message {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(32U, @lib.size_of(s))
   }
   if self.f_optional_string is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(33U, @lib.size_of(v))
   }
   if self.f_default_int32 is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(34U, @lib.size_of(v))
   }
   if self.f_default_string is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(35U, @lib.size_of(v))
   }
   if self.f_default_bool is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(36U, @lib.size_of(v))
   }
   if self.f_default_double is Some(_) {
-    size += @lib.size_of_field(2U, 8U)
+    size += @lib.size_of_field(37U, 8U)
   }
   if self.f_default_enum is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(38U, @lib.size_of(v))
   }
   if !self.f_repeated_packed_enum.is_empty() {
     size += @lib.size_of_length_delimited_field(
-      2U,
+      39U,
       self.f_repeated_packed_enum
       .iter()
       .map(@lib.size_of)
@@ -1204,7 +1204,7 @@ pub(all) struct MapEntryP2 {
 pub impl @lib.Sized for MapEntryP2 with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
-  size += @lib.size_of_field(1U, @lib.size_of(self.value))
+  size += @lib.size_of_field(2U, @lib.size_of(self.value))
   size
 }
 
@@ -1603,10 +1603,10 @@ pub impl @lib.Sized for BazMessageP2 with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.b_int64 is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.b_string is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }

--- a/test/reader/gen_proto2/src/top.mbt
+++ b/test/reader/gen_proto2/src/top.mbt
@@ -64,7 +64,7 @@ pub(all) struct BarMessageP2 {
 ///|
 pub impl @lib.Sized for BarMessageP2 with fn size_of(self) {
   let mut size = 0U
-  size += 1U + @lib.size_of(self.b_int32)
+  size += @lib.size_of_field(1U, @lib.size_of(self.b_int32))
   size
 }
 
@@ -195,172 +195,124 @@ pub(all) struct FooMessageP2 {
 ///|
 pub impl @lib.Sized for FooMessageP2 with fn size_of(self) {
   let mut size = 0U
-  size += 1U + @lib.size_of(self.f_int32)
-  size += 1U + @lib.size_of(self.f_int64)
+  size += @lib.size_of_field(1U, @lib.size_of(self.f_int32))
+  size += @lib.size_of_field(1U, @lib.size_of(self.f_int64))
   if self.f_uint32 is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.f_uint64 is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.f_sint32 is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.f_sint64 is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.f_bool is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.f_foo_enum is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.f_fixed64 is Some(_) {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.f_sfixed64 is Some(_) {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.f_fixed32 is Some(_) {
-    size += 1U + 4U
+    size += @lib.size_of_field(1U, 4U)
   }
   if self.f_sfixed32 is Some(_) {
-    size += 1U + 4U
+    size += @lib.size_of_field(1U, 4U)
   }
   if self.f_double is Some(_) {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.f_float is Some(_) {
-    size += 1U + 4U
+    size += @lib.size_of_field(1U, 4U)
   }
   if self.f_bytes is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.f_string is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.f_bar_message is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.f_repeated_int32 {
-    size += 2U + @lib.size_of(s)
+    size += @lib.size_of_field(2U, @lib.size_of(s))
   }
   if !self.f_repeated_packed_int32.is_empty() {
-    size += 2U +
-      ({
-        let size = self.f_repeated_packed_int32
-          .iter()
-          .map(@lib.size_of)
-          .fold(init=0U, UInt::add)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      2U,
+      self.f_repeated_packed_int32
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add),
+    )
   }
   if !self.f_repeated_packed_float.is_empty() {
-    size += 2U +
-      ({
-        let size = self.f_repeated_packed_float.length().reinterpret_as_uint() *
-          4
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      2U,
+      self.f_repeated_packed_float.length().reinterpret_as_uint() * 4,
+    )
   }
   if self.f_baz is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.f_nested is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.f_nested_enum is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   for s in self.f_map {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.f1 is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.f2 is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.f3 is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.f_repeated_string {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   for s in self.f_repeated_baz_message {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.f_optional_string is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.f_default_int32 is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.f_default_string is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.f_default_bool is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.f_default_double is Some(_) {
-    size += 2U + 8U
+    size += @lib.size_of_field(2U, 8U)
   }
   if self.f_default_enum is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if !self.f_repeated_packed_enum.is_empty() {
-    size += 2U +
-      ({
-        let size = self.f_repeated_packed_enum
-          .iter()
-          .map(@lib.size_of)
-          .fold(init=0U, UInt::add)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      2U,
+      self.f_repeated_packed_enum
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add),
+    )
   }
   size
 }
@@ -1251,12 +1203,8 @@ pub(all) struct MapEntryP2 {
 ///|
 pub impl @lib.Sized for MapEntryP2 with fn size_of(self) {
   let mut size = 0U
-  size += 1U +
-    ({
-      let size = @lib.size_of(self.key)
-      @lib.size_of(size) + size
-    })
-  size += 1U + @lib.size_of(self.value)
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
+  size += @lib.size_of_field(1U, @lib.size_of(self.value))
   size
 }
 
@@ -1434,7 +1382,7 @@ pub(all) struct BazMessageP2_Nested_NestedMessage {
 ///|
 pub impl @lib.Sized for BazMessageP2_Nested_NestedMessage with fn size_of(self) {
   let mut size = 0U
-  size += 1U + @lib.size_of(self.f_nested)
+  size += @lib.size_of_field(1U, @lib.size_of(self.f_nested))
   size
 }
 
@@ -1535,11 +1483,7 @@ pub(all) struct BazMessageP2_Nested {
 pub impl @lib.Sized for BazMessageP2_Nested with fn size_of(self) {
   let mut size = 0U
   if self.f_nested is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -1656,21 +1600,13 @@ pub(all) struct BazMessageP2 {
 pub impl @lib.Sized for BazMessageP2 with fn size_of(self) {
   let mut size = 0U
   if self.nested is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.b_int64 is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.b_string is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -1812,11 +1748,7 @@ pub(all) struct RepeatedMessageP2 {
 pub impl @lib.Sized for RepeatedMessageP2 with fn size_of(self) {
   let mut size = 0U
   for s in self.bar_message {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -76,7 +76,7 @@ pub(all) struct BarMessage {
 pub impl @lib.Sized for BarMessage with fn size_of(self) {
   let mut size = 0U
   if self.b_int32 != Default::default() {
-    size += 1U + @lib.size_of(self.b_int32)
+    size += @lib.size_of_field(1U, @lib.size_of(self.b_int32))
   }
   size
 }
@@ -179,14 +179,10 @@ pub(all) struct FooMessage_FMapEntry {
 pub impl @lib.Sized for FooMessage_FMapEntry with fn size_of(self) {
   let mut size = 0U
   if self.key != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.key)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
   }
   if self.value != Default::default() {
-    size += 1U + @lib.size_of(self.value)
+    size += @lib.size_of_field(1U, @lib.size_of(self.value))
   }
   size
 }
@@ -387,186 +383,128 @@ pub impl ToJson for FooMessage_TestOneof with fn to_json(
 pub impl @lib.Sized for FooMessage with fn size_of(self) {
   let mut size = 0U
   if self.f_int32 != Default::default() {
-    size += 1U + @lib.size_of(self.f_int32)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_int32))
   }
   if self.f_int64 != Default::default() {
-    size += 1U + @lib.size_of(self.f_int64)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_int64))
   }
   if self.f_uint32 != Default::default() {
-    size += 1U + @lib.size_of(self.f_uint32)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_uint32))
   }
   if self.f_uint64 != Default::default() {
-    size += 1U + @lib.size_of(self.f_uint64)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_uint64))
   }
   if self.f_sint32 != Default::default() {
-    size += 1U + @lib.size_of(self.f_sint32)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_sint32))
   }
   if self.f_sint64 != Default::default() {
-    size += 1U + @lib.size_of(self.f_sint64)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_sint64))
   }
   if self.f_bool != Default::default() {
-    size += 1U + @lib.size_of(self.f_bool)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_bool))
   }
   if self.f_foo_enum != Default::default() {
-    size += 1U + @lib.size_of(self.f_foo_enum)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_foo_enum))
   }
   if self.f_fixed64 != Default::default() {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.f_sfixed64 != Default::default() {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.f_fixed32 != Default::default() {
-    size += 1U + 4U
+    size += @lib.size_of_field(1U, 4U)
   }
   if self.f_sfixed32 != Default::default() {
-    size += 1U + 4U
+    size += @lib.size_of_field(1U, 4U)
   }
   if self.f_double != Default::default() {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.f_float != Default::default() {
-    size += 1U + 4U
+    size += @lib.size_of_field(1U, 4U)
   }
   if self.f_bytes != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.f_bytes)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.f_bytes))
   }
   if self.f_string != Default::default() {
-    size += 2U +
-      ({
-        let size = @lib.size_of(self.f_string)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.f_string))
   }
   if self.f_bar_message is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if !self.f_repeated_int32.is_empty() {
-    size += 2U +
-      ({
-        let size = self.f_repeated_int32
-          .iter()
-          .map(@lib.size_of)
-          .fold(init=0U, UInt::add)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      2U,
+      self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add),
+    )
   }
   if !self.f_repeated_packed_int32.is_empty() {
-    size += 2U +
-      ({
-        let size = self.f_repeated_packed_int32
-          .iter()
-          .map(@lib.size_of)
-          .fold(init=0U, UInt::add)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      2U,
+      self.f_repeated_packed_int32
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add),
+    )
   }
   if !self.f_repeated_packed_float.is_empty() {
-    size += 2U +
-      ({
-        let size = self.f_repeated_packed_float.length().reinterpret_as_uint() *
-          4
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      2U,
+      self.f_repeated_packed_float.length().reinterpret_as_uint() * 4,
+    )
   }
   if self.f_baz is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.f_nested is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.f_nested_enum != Default::default() {
-    size += 2U + @lib.size_of(self.f_nested_enum)
+    size += @lib.size_of_field(2U, @lib.size_of(self.f_nested_enum))
   }
   for k, v in self.f_map {
-    let key_size = 1U +
-      ({
-        let size = @lib.size_of(k)
-        @lib.size_of(size) + size
-      })
-    let value_size = 1U + @lib.size_of(v)
-    size += 2U + @lib.size_of(key_size + value_size) + key_size + value_size
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, key_size + value_size)
   }
   for s in self.f_repeated_string {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   for s in self.f_repeated_baz_message {
-    size += 2U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.f_optional_string is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.with_json_name != Default::default() {
-    size += 2U +
-      ({
-        let size = @lib.size_of(self.with_json_name)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      2U,
+      @lib.size_of(self.with_json_name),
+    )
   }
   if !self.f_repeated_packed_enum.is_empty() {
-    size += 2U +
-      ({
-        let size = self.f_repeated_packed_enum
-          .iter()
-          .map(@lib.size_of)
-          .fold(init=0U, UInt::add)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(
+      2U,
+      self.f_repeated_packed_enum
+      .iter()
+      .map(@lib.size_of)
+      .fold(init=0U, UInt::add),
+    )
   }
   for s in self.f_repeated_unpacked_enum {
-    size += 2U + @lib.size_of(s)
+    size += @lib.size_of_field(2U, @lib.size_of(s))
   }
   if self.f_timestamp is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.f_duration is Some(v) {
-    size += 2U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   match self.test_oneof {
-    F1(v) => size += 2U + @lib.size_of(v)
-    F2(v) => size += 2U + @lib.size_of(v)
-    F3(v) =>
-      size += 2U +
-        ({
-          let size = @lib.size_of(v)
-          @lib.size_of(size) + size
-        })
+    F1(v) => size += @lib.size_of_field(2U, @lib.size_of(v))
+    F2(v) => size += @lib.size_of_field(2U, @lib.size_of(v))
+    F3(v) => size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
     NotSet => ()
   }
   size
@@ -906,12 +844,8 @@ pub impl @lib.Write for FooMessage with fn write(
     let k = keys[i]
     let v = self.f_map.get(k).unwrap()
     writer |> @lib.write_varint(210UL)
-    let key_size = 1U +
-      ({
-        let size = @lib.size_of(k)
-        @lib.size_of(size) + size
-      })
-    let value_size = 1U + @lib.size_of(v)
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
@@ -1403,12 +1337,8 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(
     let k = keys[i]
     let v = self.f_map.get(k).unwrap()
     writer |> @lib.async_write_varint(210UL)
-    let key_size = 1U +
-      ({
-        let size = @lib.size_of(k)
-        @lib.size_of(size) + size
-      })
-    let value_size = 1U + @lib.size_of(v)
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)
@@ -1564,7 +1494,7 @@ pub(all) struct BazMessage_Nested_NestedMessage {
 pub impl @lib.Sized for BazMessage_Nested_NestedMessage with fn size_of(self) {
   let mut size = 0U
   if self.f_nested != Default::default() {
-    size += 1U + @lib.size_of(self.f_nested)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_nested))
   }
   size
 }
@@ -1670,11 +1600,7 @@ pub(all) struct BazMessage_Nested {
 pub impl @lib.Sized for BazMessage_Nested with fn size_of(self) {
   let mut size = 0U
   if self.f_nested is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -1791,21 +1717,13 @@ pub(all) struct BazMessage {
 pub impl @lib.Sized for BazMessage with fn size_of(self) {
   let mut size = 0U
   if self.nested is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.b_int64 != Default::default() {
-    size += 1U + @lib.size_of(self.b_int64)
+    size += @lib.size_of_field(1U, @lib.size_of(self.b_int64))
   }
   if self.b_string != Default::default() {
-    size += 1U +
-      ({
-        let size = @lib.size_of(self.b_string)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.b_string))
   }
   size
 }
@@ -1947,11 +1865,7 @@ pub(all) struct RepeatedMessage {
 pub impl @lib.Sized for RepeatedMessage with fn size_of(self) {
   let mut size = 0U
   for s in self.bar_message {
-    size += 1U +
-      ({
-        let size = @lib.size_of(s)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -2058,7 +1972,7 @@ pub(all) struct EmptyMessage {
 pub impl @lib.Sized for EmptyMessage with fn size_of(self) {
   let mut size = 0U
   if self.field != Default::default() {
-    size += 1U + @lib.size_of(self.field)
+    size += @lib.size_of_field(1U, @lib.size_of(self.field))
   }
   size
 }
@@ -2160,11 +2074,7 @@ pub(all) struct EmptyMessageWithField {
 pub impl @lib.Sized for EmptyMessageWithField with fn size_of(self) {
   let mut size = 0U
   if self.empty_message is Some(v) {
-    size += 1U +
-      ({
-        let size = @lib.size_of(v)
-        @lib.size_of(size) + size
-      })
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -2324,14 +2234,9 @@ pub impl ToJson for OnlyOneOfField_TestOneof with fn to_json(
 pub impl @lib.Sized for OnlyOneOfField with fn size_of(self) {
   let mut size = 0U
   match self.test_oneof {
-    F1(v) => size += 1U + @lib.size_of(v)
-    F2(v) => size += 1U + @lib.size_of(v)
-    F3(v) =>
-      size += 1U +
-        ({
-          let size = @lib.size_of(v)
-          @lib.size_of(size) + size
-        })
+    F1(v) => size += @lib.size_of_field(1U, @lib.size_of(v))
+    F2(v) => size += @lib.size_of_field(1U, @lib.size_of(v))
+    F3(v) => size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
     NotSet => ()
   }
   size

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -182,7 +182,7 @@ pub impl @lib.Sized for FooMessage_FMapEntry with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
   }
   if self.value != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.value))
+    size += @lib.size_of_field(2U, @lib.size_of(self.value))
   }
   size
 }
@@ -386,62 +386,65 @@ pub impl @lib.Sized for FooMessage with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(self.f_int32))
   }
   if self.f_int64 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_int64))
+    size += @lib.size_of_field(2U, @lib.size_of(self.f_int64))
   }
   if self.f_uint32 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_uint32))
+    size += @lib.size_of_field(3U, @lib.size_of(self.f_uint32))
   }
   if self.f_uint64 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_uint64))
+    size += @lib.size_of_field(4U, @lib.size_of(self.f_uint64))
   }
   if self.f_sint32 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_sint32))
+    size += @lib.size_of_field(5U, @lib.size_of(self.f_sint32))
   }
   if self.f_sint64 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_sint64))
+    size += @lib.size_of_field(6U, @lib.size_of(self.f_sint64))
   }
   if self.f_bool != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_bool))
+    size += @lib.size_of_field(7U, @lib.size_of(self.f_bool))
   }
   if self.f_foo_enum != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_foo_enum))
+    size += @lib.size_of_field(8U, @lib.size_of(self.f_foo_enum))
   }
   if self.f_fixed64 != Default::default() {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(9U, 8U)
   }
   if self.f_sfixed64 != Default::default() {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(10U, 8U)
   }
   if self.f_fixed32 != Default::default() {
-    size += @lib.size_of_field(1U, 4U)
+    size += @lib.size_of_field(11U, 4U)
   }
   if self.f_sfixed32 != Default::default() {
-    size += @lib.size_of_field(1U, 4U)
+    size += @lib.size_of_field(12U, 4U)
   }
   if self.f_double != Default::default() {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(13U, 8U)
   }
   if self.f_float != Default::default() {
-    size += @lib.size_of_field(1U, 4U)
+    size += @lib.size_of_field(14U, 4U)
   }
   if self.f_bytes != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.f_bytes))
+    size += @lib.size_of_length_delimited_field(15U, @lib.size_of(self.f_bytes))
   }
   if self.f_string != Default::default() {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.f_string))
+    size += @lib.size_of_length_delimited_field(
+      16U,
+      @lib.size_of(self.f_string),
+    )
   }
   if self.f_bar_message is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(18U, @lib.size_of(v))
   }
   if !self.f_repeated_int32.is_empty() {
     size += @lib.size_of_length_delimited_field(
-      2U,
+      19U,
       self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add),
     )
   }
   if !self.f_repeated_packed_int32.is_empty() {
     size += @lib.size_of_length_delimited_field(
-      2U,
+      20U,
       self.f_repeated_packed_int32
       .iter()
       .map(@lib.size_of)
@@ -450,42 +453,42 @@ pub impl @lib.Sized for FooMessage with fn size_of(self) {
   }
   if !self.f_repeated_packed_float.is_empty() {
     size += @lib.size_of_length_delimited_field(
-      2U,
+      21U,
       self.f_repeated_packed_float.length().reinterpret_as_uint() * 4,
     )
   }
   if self.f_baz is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(23U, @lib.size_of(v))
   }
   if self.f_nested is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(24U, @lib.size_of(v))
   }
   if self.f_nested_enum != Default::default() {
-    size += @lib.size_of_field(2U, @lib.size_of(self.f_nested_enum))
+    size += @lib.size_of_field(25U, @lib.size_of(self.f_nested_enum))
   }
   for k, v in self.f_map {
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
-    size += @lib.size_of_length_delimited_field(2U, key_size + value_size)
+    let value_size = @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(26U, key_size + value_size)
   }
   for s in self.f_repeated_string {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(30U, @lib.size_of(s))
   }
   for s in self.f_repeated_baz_message {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(31U, @lib.size_of(s))
   }
   if self.f_optional_string is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(32U, @lib.size_of(v))
   }
   if self.with_json_name != Default::default() {
     size += @lib.size_of_length_delimited_field(
-      2U,
+      33U,
       @lib.size_of(self.with_json_name),
     )
   }
   if !self.f_repeated_packed_enum.is_empty() {
     size += @lib.size_of_length_delimited_field(
-      2U,
+      34U,
       self.f_repeated_packed_enum
       .iter()
       .map(@lib.size_of)
@@ -493,18 +496,18 @@ pub impl @lib.Sized for FooMessage with fn size_of(self) {
     )
   }
   for s in self.f_repeated_unpacked_enum {
-    size += @lib.size_of_field(2U, @lib.size_of(s))
+    size += @lib.size_of_field(35U, @lib.size_of(s))
   }
   if self.f_timestamp is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(36U, @lib.size_of(v))
   }
   if self.f_duration is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(37U, @lib.size_of(v))
   }
   match self.test_oneof {
-    F1(v) => size += @lib.size_of_field(2U, @lib.size_of(v))
-    F2(v) => size += @lib.size_of_field(2U, @lib.size_of(v))
-    F3(v) => size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    F1(v) => size += @lib.size_of_field(27U, @lib.size_of(v))
+    F2(v) => size += @lib.size_of_field(28U, @lib.size_of(v))
+    F3(v) => size += @lib.size_of_length_delimited_field(29U, @lib.size_of(v))
     NotSet => ()
   }
   size
@@ -845,7 +848,7 @@ pub impl @lib.Write for FooMessage with fn write(
     let v = self.f_map.get(k).unwrap()
     writer |> @lib.write_varint(210UL)
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
+    let value_size = @lib.size_of_field(2U, @lib.size_of(v))
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
@@ -1338,7 +1341,7 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(
     let v = self.f_map.get(k).unwrap()
     writer |> @lib.async_write_varint(210UL)
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
+    let value_size = @lib.size_of_field(2U, @lib.size_of(v))
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)
@@ -1720,10 +1723,10 @@ pub impl @lib.Sized for BazMessage with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.b_int64 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.b_int64))
+    size += @lib.size_of_field(2U, @lib.size_of(self.b_int64))
   }
   if self.b_string != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.b_string))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(self.b_string))
   }
   size
 }
@@ -2235,8 +2238,8 @@ pub impl @lib.Sized for OnlyOneOfField with fn size_of(self) {
   let mut size = 0U
   match self.test_oneof {
     F1(v) => size += @lib.size_of_field(1U, @lib.size_of(v))
-    F2(v) => size += @lib.size_of_field(1U, @lib.size_of(v))
-    F3(v) => size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    F2(v) => size += @lib.size_of_field(2U, @lib.size_of(v))
+    F3(v) => size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
     NotSet => ()
   }
   size

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -127,7 +127,7 @@ pub impl @lib.Sized for FooMessage_FMapEntry with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
   }
   if self.value != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.value))
+    size += @lib.size_of_field(2U, @lib.size_of(self.value))
   }
   size
 }
@@ -280,89 +280,89 @@ pub impl @lib.Sized for FooMessage with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(self.f_int32))
   }
   if self.f_int64 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_int64))
+    size += @lib.size_of_field(2U, @lib.size_of(self.f_int64))
   }
   if self.f_uint32 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_uint32))
+    size += @lib.size_of_field(3U, @lib.size_of(self.f_uint32))
   }
   if self.f_uint64 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_uint64))
+    size += @lib.size_of_field(4U, @lib.size_of(self.f_uint64))
   }
   if self.f_sint32 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_sint32))
+    size += @lib.size_of_field(5U, @lib.size_of(self.f_sint32))
   }
   if self.f_sint64 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_sint64))
+    size += @lib.size_of_field(6U, @lib.size_of(self.f_sint64))
   }
   if self.f_bool != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_bool))
+    size += @lib.size_of_field(7U, @lib.size_of(self.f_bool))
   }
   if self.f_foo_enum != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.f_foo_enum))
+    size += @lib.size_of_field(8U, @lib.size_of(self.f_foo_enum))
   }
   if self.f_fixed64 != Default::default() {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(9U, 8U)
   }
   if self.f_sfixed64 != Default::default() {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(10U, 8U)
   }
   if self.f_fixed32 != Default::default() {
-    size += @lib.size_of_field(1U, 4U)
+    size += @lib.size_of_field(11U, 4U)
   }
   if self.f_sfixed32 != Default::default() {
-    size += @lib.size_of_field(1U, 4U)
+    size += @lib.size_of_field(12U, 4U)
   }
   if self.f_double != Default::default() {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(13U, 8U)
   }
   if self.f_float != Default::default() {
-    size += @lib.size_of_field(1U, 4U)
+    size += @lib.size_of_field(14U, 4U)
   }
   if self.f_bytes != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.f_bytes))
+    size += @lib.size_of_length_delimited_field(15U, @lib.size_of(self.f_bytes))
   }
   if self.f_string != Default::default() {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.f_string))
+    size += @lib.size_of_length_delimited_field(16U, @lib.size_of(self.f_string))
   }
   if self.f_bar_message is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(18U, @lib.size_of(v))
   }
   if !self.f_repeated_int32.is_empty() {
-    size += @lib.size_of_length_delimited_field(2U, self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add))
+    size += @lib.size_of_length_delimited_field(19U, self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add))
   }
   if !self.f_repeated_packed_int32.is_empty() {
-    size += @lib.size_of_length_delimited_field(2U, self.f_repeated_packed_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add))
+    size += @lib.size_of_length_delimited_field(20U, self.f_repeated_packed_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add))
   }
   if !self.f_repeated_packed_float.is_empty() {
-    size += @lib.size_of_length_delimited_field(2U, self.f_repeated_packed_float.length().reinterpret_as_uint() * 4)
+    size += @lib.size_of_length_delimited_field(21U, self.f_repeated_packed_float.length().reinterpret_as_uint() * 4)
   }
   if self.f_baz is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(23U, @lib.size_of(v))
   }
   if self.f_nested is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(24U, @lib.size_of(v))
   }
   if self.f_nested_enum != Default::default() {
-    size += @lib.size_of_field(2U, @lib.size_of(self.f_nested_enum))
+    size += @lib.size_of_field(25U, @lib.size_of(self.f_nested_enum))
   }
   for k, v in self.f_map {
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
-    size += @lib.size_of_length_delimited_field(2U, key_size + value_size)
+    let value_size = @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(26U, key_size + value_size)
   }
   for s in self.f_repeated_string {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(30U, @lib.size_of(s))
   }
   for s in self.f_repeated_baz_message {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(31U, @lib.size_of(s))
   }
   if self.f_optional_string is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(32U, @lib.size_of(v))
   }
   match self.test_oneof {
-    F1(v) => { size += @lib.size_of_field(2U, @lib.size_of(v)) }
-    F2(v) => { size += @lib.size_of_field(2U, @lib.size_of(v)) }
-    F3(v) => { size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v)) }
+    F1(v) => { size += @lib.size_of_field(27U, @lib.size_of(v)) }
+    F2(v) => { size += @lib.size_of_field(28U, @lib.size_of(v)) }
+    F3(v) => { size += @lib.size_of_length_delimited_field(29U, @lib.size_of(v)) }
     NotSet => ()
   }
   size
@@ -590,7 +590,7 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
     let v = self.f_map.get(k).unwrap()
     writer |> @lib.write_varint(210UL)
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
+    let value_size = @lib.size_of_field(2U, @lib.size_of(v))
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
@@ -934,7 +934,7 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
     let v = self.f_map.get(k).unwrap()
     writer |> @lib.async_write_varint(210UL)
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
+    let value_size = @lib.size_of_field(2U, @lib.size_of(v))
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)
@@ -1188,10 +1188,10 @@ pub impl @lib.Sized for BazMessage with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.b_int64 != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.b_int64))
+    size += @lib.size_of_field(2U, @lib.size_of(self.b_int64))
   }
   if self.b_string != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.b_string))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(self.b_string))
   }
   size
 }

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -51,7 +51,7 @@ pub(all) struct BarMessage {
 pub impl @lib.Sized for BarMessage with fn size_of(self) {
   let mut size = 0U
   if self.b_int32 != Default::default() {
-    size += 1U + @lib.size_of(self.b_int32)
+    size += @lib.size_of_field(1U, @lib.size_of(self.b_int32))
   }
   size
 }
@@ -124,10 +124,10 @@ pub(all) struct FooMessage_FMapEntry {
 pub impl @lib.Sized for FooMessage_FMapEntry with fn size_of(self) {
   let mut size = 0U
   if self.key != Default::default() {
-    size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
   }
   if self.value != Default::default() {
-    size += 1U + @lib.size_of(self.value)
+    size += @lib.size_of_field(1U, @lib.size_of(self.value))
   }
   size
 }
@@ -277,92 +277,92 @@ pub impl ToJson for FooMessage_TestOneof with fn to_json(self : FooMessage_TestO
 pub impl @lib.Sized for FooMessage with fn size_of(self) {
   let mut size = 0U
   if self.f_int32 != Default::default() {
-    size += 1U + @lib.size_of(self.f_int32)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_int32))
   }
   if self.f_int64 != Default::default() {
-    size += 1U + @lib.size_of(self.f_int64)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_int64))
   }
   if self.f_uint32 != Default::default() {
-    size += 1U + @lib.size_of(self.f_uint32)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_uint32))
   }
   if self.f_uint64 != Default::default() {
-    size += 1U + @lib.size_of(self.f_uint64)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_uint64))
   }
   if self.f_sint32 != Default::default() {
-    size += 1U + @lib.size_of(self.f_sint32)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_sint32))
   }
   if self.f_sint64 != Default::default() {
-    size += 1U + @lib.size_of(self.f_sint64)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_sint64))
   }
   if self.f_bool != Default::default() {
-    size += 1U + @lib.size_of(self.f_bool)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_bool))
   }
   if self.f_foo_enum != Default::default() {
-    size += 1U + @lib.size_of(self.f_foo_enum)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_foo_enum))
   }
   if self.f_fixed64 != Default::default() {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.f_sfixed64 != Default::default() {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.f_fixed32 != Default::default() {
-    size += 1U + 4U
+    size += @lib.size_of_field(1U, 4U)
   }
   if self.f_sfixed32 != Default::default() {
-    size += 1U + 4U
+    size += @lib.size_of_field(1U, 4U)
   }
   if self.f_double != Default::default() {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.f_float != Default::default() {
-    size += 1U + 4U
+    size += @lib.size_of_field(1U, 4U)
   }
   if self.f_bytes != Default::default() {
-    size += 1U + { let size = @lib.size_of(self.f_bytes); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.f_bytes))
   }
   if self.f_string != Default::default() {
-    size += 2U + { let size = @lib.size_of(self.f_string); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.f_string))
   }
   if self.f_bar_message is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if !self.f_repeated_int32.is_empty() {
-    size += 2U + { let size = self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, self.f_repeated_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add))
   }
   if !self.f_repeated_packed_int32.is_empty() {
-    size += 2U + { let size = self.f_repeated_packed_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, self.f_repeated_packed_int32.iter().map(@lib.size_of).fold(init=0U, UInt::add))
   }
   if !self.f_repeated_packed_float.is_empty() {
-    size += 2U + { let size = self.f_repeated_packed_float.length().reinterpret_as_uint() * 4; @lib.size_of(size) + size}
+    size += @lib.size_of_length_delimited_field(2U, self.f_repeated_packed_float.length().reinterpret_as_uint() * 4)
   }
   if self.f_baz is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.f_nested is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.f_nested_enum != Default::default() {
-    size += 2U + @lib.size_of(self.f_nested_enum)
+    size += @lib.size_of_field(2U, @lib.size_of(self.f_nested_enum))
   }
   for k, v in self.f_map {
-    let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }
-    let value_size = 1U + @lib.size_of(v)
-    size += 2U + @lib.size_of(key_size + value_size) + key_size + value_size
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, key_size + value_size)
   }
   for s in self.f_repeated_string {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   for s in self.f_repeated_baz_message {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.f_optional_string is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   match self.test_oneof {
-    F1(v) => { size += 2U + @lib.size_of(v) }
-    F2(v) => { size += 2U + @lib.size_of(v) }
-    F3(v) => { size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size } }
+    F1(v) => { size += @lib.size_of_field(2U, @lib.size_of(v)) }
+    F2(v) => { size += @lib.size_of_field(2U, @lib.size_of(v)) }
+    F3(v) => { size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v)) }
     NotSet => ()
   }
   size
@@ -589,8 +589,8 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
     let k = keys[i]
     let v = self.f_map.get(k).unwrap()
     writer |> @lib.write_varint(210UL)
-    let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }
-    let value_size = 1U + @lib.size_of(v)
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
@@ -933,8 +933,8 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
     let k = keys[i]
     let v = self.f_map.get(k).unwrap()
     writer |> @lib.async_write_varint(210UL)
-    let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }
-    let value_size = 1U + @lib.size_of(v)
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_field(1U, @lib.size_of(v))
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)
@@ -1036,7 +1036,7 @@ pub(all) struct BazMessage_Nested_NestedMessage {
 pub impl @lib.Sized for BazMessage_Nested_NestedMessage with fn size_of(self) {
   let mut size = 0U
   if self.f_nested != Default::default() {
-    size += 1U + @lib.size_of(self.f_nested)
+    size += @lib.size_of_field(1U, @lib.size_of(self.f_nested))
   }
   size
 }
@@ -1108,7 +1108,7 @@ pub(all) struct BazMessage_Nested {
 pub impl @lib.Sized for BazMessage_Nested with fn size_of(self) {
   let mut size = 0U
   if self.f_nested is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -1185,13 +1185,13 @@ pub(all) struct BazMessage {
 pub impl @lib.Sized for BazMessage with fn size_of(self) {
   let mut size = 0U
   if self.nested is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.b_int64 != Default::default() {
-    size += 1U + @lib.size_of(self.b_int64)
+    size += @lib.size_of_field(1U, @lib.size_of(self.b_int64))
   }
   if self.b_string != Default::default() {
-    size += 1U + { let size = @lib.size_of(self.b_string); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.b_string))
   }
   size
 }
@@ -1298,7 +1298,7 @@ pub(all) struct RepeatedMessage {
 pub impl @lib.Sized for RepeatedMessage with fn size_of(self) {
   let mut size = 0U
   for s in self.bar_message {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -5,10 +5,10 @@ pub(all) struct Hello_MetadataEntry {
 pub impl @lib.Sized for Hello_MetadataEntry with fn size_of(self) {
   let mut size = 0U
   if self.key != Default::default() {
-    size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
   }
   if self.value != Default::default() {
-    size += 1U + { let size = @lib.size_of(self.value); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.value))
   }
   size
 }
@@ -100,21 +100,21 @@ pub(all) struct Hello {
 pub impl @lib.Sized for Hello with fn size_of(self) {
   let mut size = 0U
   if self.name != Default::default() {
-    size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.age != Default::default() {
-    size += 1U + @lib.size_of(self.age)
+    size += @lib.size_of_field(1U, @lib.size_of(self.age))
   }
   for s in self.hobbies {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for k, v in self.metadata {
-    let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }
-    let value_size = 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
-    size += 1U + @lib.size_of(key_size + value_size) + key_size + value_size
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(1U, key_size + value_size)
   }
   if self.friend is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -169,8 +169,8 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
     let k = keys[i]
     let v = self.metadata.get(k).unwrap()
     writer |> @lib.write_varint(34UL)
-    let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }
-    let value_size = 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
@@ -256,8 +256,8 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
     let k = keys[i]
     let v = self.metadata.get(k).unwrap()
     writer |> @lib.async_write_varint(34UL)
-    let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }
-    let value_size = 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -8,7 +8,7 @@ pub impl @lib.Sized for Hello_MetadataEntry with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
   }
   if self.value != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.value))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.value))
   }
   size
 }
@@ -103,18 +103,18 @@ pub impl @lib.Sized for Hello with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.age != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.age))
+    size += @lib.size_of_field(2U, @lib.size_of(self.age))
   }
   for s in self.hobbies {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   for k, v in self.metadata {
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
-    size += @lib.size_of_length_delimited_field(1U, key_size + value_size)
+    let value_size = @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, key_size + value_size)
   }
   if self.friend is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
   }
   size
 }
@@ -170,7 +170,7 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
     let v = self.metadata.get(k).unwrap()
     writer |> @lib.write_varint(34UL)
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    let value_size = @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
@@ -257,7 +257,7 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
     let v = self.metadata.get(k).unwrap()
     writer |> @lib.async_write_varint(34UL)
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    let value_size = @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
@@ -4,7 +4,7 @@ pub(all) struct Test {
 pub impl @lib.Sized for Test with fn size_of(self) {
   let mut size = 0U
   if self.test_hello is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }

--- a/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
@@ -4,7 +4,7 @@ pub(all) struct Test {
 pub impl @lib.Sized for Test with fn size_of(self) {
   let mut size = 0U
   if self.created_at is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -5,10 +5,10 @@ pub(all) struct Hello_MetadataEntry {
 pub impl @lib.Sized for Hello_MetadataEntry with fn size_of(self) {
   let mut size = 0U
   if self.key != Default::default() {
-    size += 1U + { let size = @lib.size_of(self.key); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
   }
   if self.value != Default::default() {
-    size += 1U + { let size = @lib.size_of(self.value); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.value))
   }
   size
 }
@@ -100,21 +100,21 @@ pub(all) struct Hello {
 pub impl @lib.Sized for Hello with fn size_of(self) {
   let mut size = 0U
   if self.name != Default::default() {
-    size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.age != Default::default() {
-    size += 1U + @lib.size_of(self.age)
+    size += @lib.size_of_field(1U, @lib.size_of(self.age))
   }
   for s in self.hobbies {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for k, v in self.metadata {
-    let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }
-    let value_size = 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
-    size += 1U + @lib.size_of(key_size + value_size) + key_size + value_size
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(1U, key_size + value_size)
   }
   if self.friend is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -169,8 +169,8 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
     let k = keys[i]
     let v = self.metadata.get(k).unwrap()
     writer |> @lib.write_varint(34UL)
-    let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }
-    let value_size = 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
@@ -256,8 +256,8 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
     let k = keys[i]
     let v = self.metadata.get(k).unwrap()
     writer |> @lib.async_write_varint(34UL)
-    let key_size = 1U + { let size = @lib.size_of(k); @lib.size_of(size) + size }
-    let value_size = 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
+    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -8,7 +8,7 @@ pub impl @lib.Sized for Hello_MetadataEntry with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.key))
   }
   if self.value != Default::default() {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.value))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.value))
   }
   size
 }
@@ -103,18 +103,18 @@ pub impl @lib.Sized for Hello with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   }
   if self.age != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.age))
+    size += @lib.size_of_field(2U, @lib.size_of(self.age))
   }
   for s in self.hobbies {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   for k, v in self.metadata {
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
-    size += @lib.size_of_length_delimited_field(1U, key_size + value_size)
+    let value_size = @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, key_size + value_size)
   }
   if self.friend is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
   }
   size
 }
@@ -170,7 +170,7 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
     let v = self.metadata.get(k).unwrap()
     writer |> @lib.write_varint(34UL)
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    let value_size = @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
@@ -257,7 +257,7 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
     let v = self.metadata.get(k).unwrap()
     writer |> @lib.async_write_varint(34UL)
     let key_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(k))
-    let value_size = @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    let value_size = @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)

--- a/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
@@ -4,7 +4,7 @@ pub(all) struct Test {
 pub impl @lib.Sized for Test with fn size_of(self) {
   let mut size = 0U
   if self.created_at is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }

--- a/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
+++ b/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
@@ -10,13 +10,13 @@ pub impl @lib.Sized for Version with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.minor is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.patch is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.suffix is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   size
 }
@@ -155,16 +155,16 @@ pub impl @lib.Sized for CodeGeneratorRequest with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.parameter is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.proto_file {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(15U, @lib.size_of(s))
   }
   for s in self.source_file_descriptors {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(17U, @lib.size_of(s))
   }
   if self.compiler_version is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -365,13 +365,13 @@ pub impl @lib.Sized for CodeGeneratorResponse_File with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.insertion_point is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.content is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(15U, @lib.size_of(v))
   }
   if self.generated_code_info is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(16U, @lib.size_of(v))
   }
   size
 }
@@ -510,16 +510,16 @@ pub impl @lib.Sized for CodeGeneratorResponse with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.supported_features is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.minimum_edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.maximum_edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   for s in self.file {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(15U, @lib.size_of(s))
   }
   size
 }

--- a/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
+++ b/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
@@ -7,16 +7,16 @@ pub(all) struct Version {
 pub impl @lib.Sized for Version with fn size_of(self) {
   let mut size = 0U
   if self.major is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.minor is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.patch is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.suffix is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -152,19 +152,19 @@ pub(all) struct CodeGeneratorRequest {
 pub impl @lib.Sized for CodeGeneratorRequest with fn size_of(self) {
   let mut size = 0U
   for s in self.file_to_generate {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.parameter is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.proto_file {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.source_file_descriptors {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.compiler_version is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -362,16 +362,16 @@ pub(all) struct CodeGeneratorResponse_File {
 pub impl @lib.Sized for CodeGeneratorResponse_File with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.insertion_point is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.content is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.generated_code_info is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -507,19 +507,19 @@ pub(all) struct CodeGeneratorResponse {
 pub impl @lib.Sized for CodeGeneratorResponse with fn size_of(self) {
   let mut size = 0U
   if self.error is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.supported_features is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.minimum_edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.maximum_edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   for s in self.file {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }

--- a/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
@@ -8,7 +8,7 @@ pub impl @lib.Sized for Timestamp with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(self.seconds))
   }
   if self.nanos != Default::default() {
-    size += @lib.size_of_field(1U, @lib.size_of(self.nanos))
+    size += @lib.size_of_field(2U, @lib.size_of(self.nanos))
   }
   size
 }

--- a/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
@@ -5,10 +5,10 @@ pub(all) struct Timestamp {
 pub impl @lib.Sized for Timestamp with fn size_of(self) {
   let mut size = 0U
   if self.seconds != Default::default() {
-    size += 1U + @lib.size_of(self.seconds)
+    size += @lib.size_of_field(1U, @lib.size_of(self.seconds))
   }
   if self.nanos != Default::default() {
-    size += 1U + @lib.size_of(self.nanos)
+    size += @lib.size_of_field(1U, @lib.size_of(self.nanos))
   }
   size
 }

--- a/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
+++ b/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
@@ -9,16 +9,16 @@ pub impl @lib.Sized for TreeNode with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   if self.value is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.parent is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   for s in self.children {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   if self.sibling is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
   }
   size
 }
@@ -165,10 +165,10 @@ pub impl @lib.Sized for ListNode with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.data))
   if self.next is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.prev is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -278,13 +278,13 @@ pub impl @lib.Sized for GraphNode with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.id))
   if self.label is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.neighbors {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   if self.visited is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   size
 }
@@ -414,10 +414,10 @@ pub impl @lib.Sized for NestedSelfRef_Inner with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.outer_ref is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.inner_ref is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -533,10 +533,10 @@ pub impl @lib.Sized for NestedSelfRef with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   if self.inner is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.self_ref is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -647,16 +647,16 @@ pub impl @lib.Sized for Organization with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   if self.description is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.parent_org is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   for s in self.sub_orgs {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   for s in self.employees {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   size
 }
@@ -804,15 +804,15 @@ pub(all) struct Employee {
 pub impl @lib.Sized for Employee with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
-  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.id))
+  size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.id))
   if self.organization is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.manager is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   for s in self.subordinates {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   size
 }

--- a/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
+++ b/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
@@ -7,18 +7,18 @@ pub(all) struct TreeNode {
 } derive(Eq, Debug)
 pub impl @lib.Sized for TreeNode with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   if self.value is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.parent is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.children {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.sibling is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -163,12 +163,12 @@ pub(all) struct ListNode {
 } derive(Eq, Debug)
 pub impl @lib.Sized for ListNode with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.data); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.data))
   if self.next is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.prev is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -276,15 +276,15 @@ pub(all) struct GraphNode {
 } derive(Eq, Debug)
 pub impl @lib.Sized for GraphNode with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.id); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.id))
   if self.label is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.neighbors {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.visited is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -411,13 +411,13 @@ pub(all) struct NestedSelfRef_Inner {
 pub impl @lib.Sized for NestedSelfRef_Inner with fn size_of(self) {
   let mut size = 0U
   if self.inner_name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.outer_ref is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.inner_ref is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -531,12 +531,12 @@ pub(all) struct NestedSelfRef {
 } derive(Eq, Debug)
 pub impl @lib.Sized for NestedSelfRef with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   if self.inner is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.self_ref is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -645,18 +645,18 @@ pub(all) struct Organization {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Organization with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   if self.description is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.parent_org is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.sub_orgs {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.employees {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -803,16 +803,16 @@ pub(all) struct Employee {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Employee with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
-  size += 1U + { let size = @lib.size_of(self.id); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.id))
   if self.organization is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.manager is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.subordinates {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }

--- a/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
+++ b/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
@@ -7,16 +7,16 @@ pub(all) struct User {
 } derive(Eq, Debug)
 pub impl @lib.Sized for User with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.user_id); @lib.size_of(size) + size }
-  size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.user_id))
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   if self.email is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.orders {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.friends {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -156,16 +156,16 @@ pub(all) struct Order {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Order with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.order_id); @lib.size_of(size) + size }
-  size += 1U + { let size = @lib.size_of(self.product_name); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.order_id))
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.product_name))
   if self.amount is Some(_) {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.customer is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.related_orders {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -305,16 +305,16 @@ pub(all) struct Department {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Department with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.dept_id); @lib.size_of(size) + size }
-  size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.dept_id))
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   for s in self.employees {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.projects {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.parent_dept is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -455,19 +455,19 @@ pub(all) struct Employee {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Employee with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.emp_id); @lib.size_of(size) + size }
-  size += 1U + { let size = @lib.size_of(self.name); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.emp_id))
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
   if self.department is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.projects {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.supervisor is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.subordinates {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -628,22 +628,22 @@ pub(all) struct Project {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Project with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.project_id); @lib.size_of(size) + size }
-  size += 1U + { let size = @lib.size_of(self.title); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.project_id))
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.title))
   if self.description is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.department is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.members {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.dependencies {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.dependents {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -821,18 +821,18 @@ pub(all) struct Node_Connection {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Node_Connection with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.connection_id); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.connection_id))
   if self.type_ is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.source is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.target is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.weight is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -978,15 +978,15 @@ pub(all) struct Node {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Node with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.id); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.id))
   if self.data is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.connections {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.neighbors {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -1113,15 +1113,15 @@ pub(all) struct Weight {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Weight with fn size_of(self) {
   let mut size = 0U
-  size += 1U + 8U
+  size += @lib.size_of_field(1U, 8U)
   if self.unit is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.connection is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.related_nodes {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -1248,15 +1248,15 @@ pub(all) struct Graph {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Graph with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.graph_id); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.graph_id))
   if self.name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.vertices {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.edges {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -1385,21 +1385,21 @@ pub(all) struct Vertex {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Vertex with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.vertex_id); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.vertex_id))
   if self.label is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.graph is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.incoming_edges {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.outgoing_edges {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.adjacent_vertices {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -1566,21 +1566,21 @@ pub(all) struct Edge {
 } derive(Eq, Debug)
 pub impl @lib.Sized for Edge with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.edge_id); @lib.size_of(size) + size }
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.edge_id))
   if self.weight is Some(_) {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.graph is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.source_vertex is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.target_vertex is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.parallel_edges {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }

--- a/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
+++ b/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
@@ -8,15 +8,15 @@ pub(all) struct User {
 pub impl @lib.Sized for User with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.user_id))
-  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
+  size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.name))
   if self.email is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   for s in self.orders {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   for s in self.friends {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   size
 }
@@ -157,15 +157,15 @@ pub(all) struct Order {
 pub impl @lib.Sized for Order with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.order_id))
-  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.product_name))
+  size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.product_name))
   if self.amount is Some(_) {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(3U, 8U)
   }
   if self.customer is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   for s in self.related_orders {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   size
 }
@@ -306,15 +306,15 @@ pub(all) struct Department {
 pub impl @lib.Sized for Department with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.dept_id))
-  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
+  size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.name))
   for s in self.employees {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   for s in self.projects {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   if self.parent_dept is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
   }
   size
 }
@@ -456,18 +456,18 @@ pub(all) struct Employee {
 pub impl @lib.Sized for Employee with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.emp_id))
-  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name))
+  size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.name))
   if self.department is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   for s in self.projects {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   if self.supervisor is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
   }
   for s in self.subordinates {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   size
 }
@@ -629,21 +629,21 @@ pub(all) struct Project {
 pub impl @lib.Sized for Project with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.project_id))
-  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.title))
+  size += @lib.size_of_length_delimited_field(2U, @lib.size_of(self.title))
   if self.description is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.department is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   for s in self.members {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   for s in self.dependencies {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   for s in self.dependents {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(s))
   }
   size
 }
@@ -823,16 +823,16 @@ pub impl @lib.Sized for Node_Connection with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.connection_id))
   if self.type_ is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.source is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.target is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   if self.weight is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
   }
   size
 }
@@ -980,13 +980,13 @@ pub impl @lib.Sized for Node with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.id))
   if self.data is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.connections {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   for s in self.neighbors {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   size
 }
@@ -1115,13 +1115,13 @@ pub impl @lib.Sized for Weight with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_field(1U, 8U)
   if self.unit is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.connection is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   for s in self.related_nodes {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   size
 }
@@ -1250,13 +1250,13 @@ pub impl @lib.Sized for Graph with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.graph_id))
   if self.name is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.vertices {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   for s in self.edges {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   size
 }
@@ -1387,19 +1387,19 @@ pub impl @lib.Sized for Vertex with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.vertex_id))
   if self.label is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.graph is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   for s in self.incoming_edges {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   for s in self.outgoing_edges {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   for s in self.adjacent_vertices {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   size
 }
@@ -1568,19 +1568,19 @@ pub impl @lib.Sized for Edge with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.edge_id))
   if self.weight is Some(_) {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(2U, 8U)
   }
   if self.graph is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.source_vertex is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   if self.target_vertex is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
   }
   for s in self.parallel_edges {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   size
 }

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -237,43 +237,43 @@ pub impl @lib.Sized for FileDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.package_ is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.dependency {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   for s in self.public_dependency {
-    size += @lib.size_of_field(1U, @lib.size_of(s))
+    size += @lib.size_of_field(10U, @lib.size_of(s))
   }
   for s in self.weak_dependency {
-    size += @lib.size_of_field(1U, @lib.size_of(s))
+    size += @lib.size_of_field(11U, @lib.size_of(s))
   }
   for s in self.option_dependency {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(15U, @lib.size_of(s))
   }
   for s in self.message_type {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   for s in self.enum_type {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   for s in self.service {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   for s in self.extension {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(v))
   }
   if self.source_code_info is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(9U, @lib.size_of(v))
   }
   if self.syntax is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(12U, @lib.size_of(v))
   }
   if self.edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(14U, @lib.size_of(v))
   }
   size
 }
@@ -604,10 +604,10 @@ pub impl @lib.Sized for DescriptorProto_ExtensionRange with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -724,7 +724,7 @@ pub impl @lib.Sized for DescriptorProto_ReservedRange with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -831,34 +831,34 @@ pub impl @lib.Sized for DescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.field {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   for s in self.extension {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   for s in self.nested_type {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(s))
   }
   for s in self.enum_type {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   for s in self.extension_range {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   for s in self.oneof_decl {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(v))
   }
   for s in self.reserved_range {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(9U, @lib.size_of(s))
   }
   for s in self.reserved_name {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(10U, @lib.size_of(s))
   }
   if self.visibility is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(11U, @lib.size_of(v))
   }
   size
 }
@@ -1168,16 +1168,16 @@ pub impl @lib.Sized for ExtensionRangeOptions_Declaration with fn size_of(self) 
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.full_name is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.type_ is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.reserved is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.repeated is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   size
 }
@@ -1331,16 +1331,16 @@ pub(all) struct ExtensionRangeOptions {
 pub impl @lib.Sized for ExtensionRangeOptions with fn size_of(self) {
   let mut size = 0U
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   for s in self.declaration {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(50U, @lib.size_of(v))
   }
   if self.verification is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -1663,34 +1663,34 @@ pub impl @lib.Sized for FieldDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.number is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.label is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   if self.type_ is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.type_name is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(v))
   }
   if self.extendee is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.default_value is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(v))
   }
   if self.oneof_index is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(9U, @lib.size_of(v))
   }
   if self.json_name is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(10U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(v))
   }
   if self.proto3_optional is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(17U, @lib.size_of(v))
   }
   size
 }
@@ -1959,7 +1959,7 @@ pub impl @lib.Sized for OneofDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -2057,7 +2057,7 @@ pub impl @lib.Sized for EnumDescriptorProto_EnumReservedRange with fn size_of(se
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -2159,19 +2159,19 @@ pub impl @lib.Sized for EnumDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.value {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   for s in self.reserved_range {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(s))
   }
   for s in self.reserved_name {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(s))
   }
   if self.visibility is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   size
 }
@@ -2346,10 +2346,10 @@ pub impl @lib.Sized for EnumValueDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.number is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -2467,10 +2467,10 @@ pub impl @lib.Sized for ServiceDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.method_ {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   size
 }
@@ -2591,19 +2591,19 @@ pub impl @lib.Sized for MethodDescriptorProto with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.input_type is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.output_type is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   if self.client_streaming is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.server_streaming is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   size
 }
@@ -2840,64 +2840,64 @@ pub impl @lib.Sized for FileOptions with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.java_outer_classname is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(v))
   }
   if self.java_multiple_files is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(10U, @lib.size_of(v))
   }
   if self.java_generate_equals_and_hash is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(20U, @lib.size_of(v))
   }
   if self.java_string_check_utf8 is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(27U, @lib.size_of(v))
   }
   if self.optimize_for is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(9U, @lib.size_of(v))
   }
   if self.go_package is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(11U, @lib.size_of(v))
   }
   if self.cc_generic_services is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(16U, @lib.size_of(v))
   }
   if self.java_generic_services is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(17U, @lib.size_of(v))
   }
   if self.py_generic_services is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(18U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(23U, @lib.size_of(v))
   }
   if self.cc_enable_arenas is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(31U, @lib.size_of(v))
   }
   if self.objc_class_prefix is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(36U, @lib.size_of(v))
   }
   if self.csharp_namespace is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(37U, @lib.size_of(v))
   }
   if self.swift_prefix is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(39U, @lib.size_of(v))
   }
   if self.php_class_prefix is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(40U, @lib.size_of(v))
   }
   if self.php_namespace is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(41U, @lib.size_of(v))
   }
   if self.php_metadata_namespace is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(44U, @lib.size_of(v))
   }
   if self.ruby_package is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(45U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(50U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -3361,22 +3361,22 @@ pub impl @lib.Sized for MessageOptions with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.no_standard_descriptor_accessor is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.map_entry is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(7U, @lib.size_of(v))
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(11U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(12U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -3784,10 +3784,10 @@ pub(all) struct FieldOptions_EditionDefault {
 pub impl @lib.Sized for FieldOptions_EditionDefault with fn size_of(self) {
   let mut size = 0U
   if self.edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.value is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -3887,13 +3887,13 @@ pub impl @lib.Sized for FieldOptions_FeatureSupport with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.edition_deprecated is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.deprecation_warning is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.edition_removed is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   size
 }
@@ -4041,43 +4041,43 @@ pub impl @lib.Sized for FieldOptions with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.packed is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.jstype is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   if self.lazy_ is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.unverified_lazy is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(15U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.weak is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(10U, @lib.size_of(v))
   }
   if self.debug_redact is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(16U, @lib.size_of(v))
   }
   if self.retention is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(17U, @lib.size_of(v))
   }
   for s in self.targets {
-    size += @lib.size_of_field(2U, @lib.size_of(s))
+    size += @lib.size_of_field(19U, @lib.size_of(s))
   }
   for s in self.edition_defaults {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(20U, @lib.size_of(s))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(21U, @lib.size_of(v))
   }
   if self.feature_support is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(22U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -4405,7 +4405,7 @@ pub impl @lib.Sized for OneofOptions with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -4503,19 +4503,19 @@ pub(all) struct EnumOptions {
 pub impl @lib.Sized for EnumOptions with fn size_of(self) {
   let mut size = 0U
   if self.allow_alias is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -4673,16 +4673,16 @@ pub impl @lib.Sized for EnumValueOptions with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.debug_redact is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.feature_support is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -4835,13 +4835,13 @@ pub(all) struct ServiceOptions {
 pub impl @lib.Sized for ServiceOptions with fn size_of(self) {
   let mut size = 0U
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(34U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(33U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -5001,16 +5001,16 @@ pub(all) struct MethodOptions {
 pub impl @lib.Sized for MethodOptions with fn size_of(self) {
   let mut size = 0U
   if self.deprecated is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(33U, @lib.size_of(v))
   }
   if self.idempotency_level is Some(v) {
-    size += @lib.size_of_field(2U, @lib.size_of(v))
+    size += @lib.size_of_field(34U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(35U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(999U, @lib.size_of(s))
   }
   size
 }
@@ -5143,7 +5143,7 @@ pub(all) struct UninterpretedOption_NamePart {
 pub impl @lib.Sized for UninterpretedOption_NamePart with fn size_of(self) {
   let mut size = 0U
   size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name_part))
-  size += @lib.size_of_field(1U, @lib.size_of(self.is_extension))
+  size += @lib.size_of_field(2U, @lib.size_of(self.is_extension))
   size
 }
 pub impl Default for UninterpretedOption_NamePart with fn default() -> UninterpretedOption_NamePart {
@@ -5228,25 +5228,25 @@ pub(all) struct UninterpretedOption {
 pub impl @lib.Sized for UninterpretedOption with fn size_of(self) {
   let mut size = 0U
   for s in self.name {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.identifier_value is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.positive_int_value is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   if self.negative_int_value is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.double_value is Some(_) {
-    size += @lib.size_of_field(1U, 8U)
+    size += @lib.size_of_field(6U, 8U)
   }
   if self.string_value is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(7U, @lib.size_of(v))
   }
   if self.aggregate_value is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(8U, @lib.size_of(v))
   }
   size
 }
@@ -5844,25 +5844,25 @@ pub impl @lib.Sized for FeatureSet with fn size_of(self) {
     size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.enum_type is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.repeated_field_encoding is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.utf8_validation is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   if self.message_encoding is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   if self.json_format is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(6U, @lib.size_of(v))
   }
   if self.enforce_naming_style is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(7U, @lib.size_of(v))
   }
   if self.default_symbol_visibility is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(8U, @lib.size_of(v))
   }
   size
 }
@@ -6072,13 +6072,13 @@ pub(all) struct FeatureSetDefaults_FeatureSetEditionDefault {
 pub impl @lib.Sized for FeatureSetDefaults_FeatureSetEditionDefault with fn size_of(self) {
   let mut size = 0U
   if self.edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.overridable_features is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   if self.fixed_features is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(5U, @lib.size_of(v))
   }
   size
 }
@@ -6196,10 +6196,10 @@ pub impl @lib.Sized for FeatureSetDefaults with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.minimum_edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   if self.maximum_edition is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   size
 }
@@ -6319,16 +6319,16 @@ pub impl @lib.Sized for SourceCodeInfo_Location with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add))
   }
   if !self.span.is_empty() {
-    size += @lib.size_of_length_delimited_field(1U, self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add))
+    size += @lib.size_of_length_delimited_field(2U, self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add))
   }
   if self.leading_comments is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(3U, @lib.size_of(v))
   }
   if self.trailing_comments is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(4U, @lib.size_of(v))
   }
   for s in self.leading_detached_comments {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
+    size += @lib.size_of_length_delimited_field(6U, @lib.size_of(s))
   }
   size
 }
@@ -6625,16 +6625,16 @@ pub impl @lib.Sized for GeneratedCodeInfo_Annotation with fn size_of(self) {
     size += @lib.size_of_length_delimited_field(1U, self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add))
   }
   if self.source_file is Some(v) {
-    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.begin is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(3U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(4U, @lib.size_of(v))
   }
   if self.semantic is Some(v) {
-    size += @lib.size_of_field(1U, @lib.size_of(v))
+    size += @lib.size_of_field(5U, @lib.size_of(v))
   }
   size
 }

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -146,7 +146,7 @@ pub(all) struct FileDescriptorSet {
 pub impl @lib.Sized for FileDescriptorSet with fn size_of(self) {
   let mut size = 0U
   for s in self.file {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -234,46 +234,46 @@ pub(all) struct FileDescriptorProto {
 pub impl @lib.Sized for FileDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.package_ is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.dependency {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.public_dependency {
-    size += 1U + @lib.size_of(s)
+    size += @lib.size_of_field(1U, @lib.size_of(s))
   }
   for s in self.weak_dependency {
-    size += 1U + @lib.size_of(s)
+    size += @lib.size_of_field(1U, @lib.size_of(s))
   }
   for s in self.option_dependency {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.message_type {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.enum_type {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.service {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.extension {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.source_code_info is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.syntax is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -601,13 +601,13 @@ pub(all) struct DescriptorProto_ExtensionRange {
 pub impl @lib.Sized for DescriptorProto_ExtensionRange with fn size_of(self) {
   let mut size = 0U
   if self.start is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -721,10 +721,10 @@ pub(all) struct DescriptorProto_ReservedRange {
 pub impl @lib.Sized for DescriptorProto_ReservedRange with fn size_of(self) {
   let mut size = 0U
   if self.start is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -828,37 +828,37 @@ pub(all) struct DescriptorProto {
 pub impl @lib.Sized for DescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.field {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.extension {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.nested_type {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.enum_type {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.extension_range {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.oneof_decl {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.reserved_range {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.reserved_name {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.visibility is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -1165,19 +1165,19 @@ pub(all) struct ExtensionRangeOptions_Declaration {
 pub impl @lib.Sized for ExtensionRangeOptions_Declaration with fn size_of(self) {
   let mut size = 0U
   if self.number is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.full_name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.type_ is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.reserved is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.repeated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -1331,16 +1331,16 @@ pub(all) struct ExtensionRangeOptions {
 pub impl @lib.Sized for ExtensionRangeOptions with fn size_of(self) {
   let mut size = 0U
   for s in self.uninterpreted_option {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   for s in self.declaration {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.features is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.verification is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -1660,37 +1660,37 @@ pub(all) struct FieldDescriptorProto {
 pub impl @lib.Sized for FieldDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.number is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.label is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.type_ is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.type_name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.extendee is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.default_value is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.oneof_index is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.json_name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.proto3_optional is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   size
 }
@@ -1956,10 +1956,10 @@ pub(all) struct OneofDescriptorProto {
 pub impl @lib.Sized for OneofDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -2054,10 +2054,10 @@ pub(all) struct EnumDescriptorProto_EnumReservedRange {
 pub impl @lib.Sized for EnumDescriptorProto_EnumReservedRange with fn size_of(self) {
   let mut size = 0U
   if self.start is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -2156,22 +2156,22 @@ pub(all) struct EnumDescriptorProto {
 pub impl @lib.Sized for EnumDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.value {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.reserved_range {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   for s in self.reserved_name {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.visibility is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -2343,13 +2343,13 @@ pub(all) struct EnumValueDescriptorProto {
 pub impl @lib.Sized for EnumValueDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.number is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -2464,13 +2464,13 @@ pub(all) struct ServiceDescriptorProto {
 pub impl @lib.Sized for ServiceDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.method_ {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.options is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -2588,22 +2588,22 @@ pub(all) struct MethodDescriptorProto {
 pub impl @lib.Sized for MethodDescriptorProto with fn size_of(self) {
   let mut size = 0U
   if self.name is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.input_type is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.output_type is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.options is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.client_streaming is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.server_streaming is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -2837,67 +2837,67 @@ pub(all) struct FileOptions {
 pub impl @lib.Sized for FileOptions with fn size_of(self) {
   let mut size = 0U
   if self.java_package is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.java_outer_classname is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.java_multiple_files is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.java_generate_equals_and_hash is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.java_string_check_utf8 is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.optimize_for is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.go_package is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.cc_generic_services is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.java_generic_services is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.py_generic_services is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.cc_enable_arenas is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.objc_class_prefix is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.csharp_namespace is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.swift_prefix is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.php_class_prefix is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.php_namespace is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.php_metadata_namespace is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.ruby_package is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -3358,25 +3358,25 @@ pub(all) struct MessageOptions {
 pub impl @lib.Sized for MessageOptions with fn size_of(self) {
   let mut size = 0U
   if self.message_set_wire_format is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.no_standard_descriptor_accessor is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.map_entry is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -3784,10 +3784,10 @@ pub(all) struct FieldOptions_EditionDefault {
 pub impl @lib.Sized for FieldOptions_EditionDefault with fn size_of(self) {
   let mut size = 0U
   if self.edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.value is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -3884,16 +3884,16 @@ pub(all) struct FieldOptions_FeatureSupport {
 pub impl @lib.Sized for FieldOptions_FeatureSupport with fn size_of(self) {
   let mut size = 0U
   if self.edition_introduced is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.edition_deprecated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecation_warning is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.edition_removed is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -4038,46 +4038,46 @@ pub(all) struct FieldOptions {
 pub impl @lib.Sized for FieldOptions with fn size_of(self) {
   let mut size = 0U
   if self.ctype is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.packed is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.jstype is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.lazy_ is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.unverified_lazy is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.weak is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.debug_redact is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.retention is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   for s in self.targets {
-    size += 2U + @lib.size_of(s)
+    size += @lib.size_of_field(2U, @lib.size_of(s))
   }
   for s in self.edition_defaults {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   if self.features is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.feature_support is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -4402,10 +4402,10 @@ pub(all) struct OneofOptions {
 pub impl @lib.Sized for OneofOptions with fn size_of(self) {
   let mut size = 0U
   if self.features is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -4503,19 +4503,19 @@ pub(all) struct EnumOptions {
 pub impl @lib.Sized for EnumOptions with fn size_of(self) {
   let mut size = 0U
   if self.allow_alias is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -4670,19 +4670,19 @@ pub(all) struct EnumValueOptions {
 pub impl @lib.Sized for EnumValueOptions with fn size_of(self) {
   let mut size = 0U
   if self.deprecated is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.debug_redact is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.feature_support is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -4835,13 +4835,13 @@ pub(all) struct ServiceOptions {
 pub impl @lib.Sized for ServiceOptions with fn size_of(self) {
   let mut size = 0U
   if self.features is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   if self.deprecated is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -5001,16 +5001,16 @@ pub(all) struct MethodOptions {
 pub impl @lib.Sized for MethodOptions with fn size_of(self) {
   let mut size = 0U
   if self.deprecated is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.idempotency_level is Some(v) {
-    size += 2U + @lib.size_of(v)
+    size += @lib.size_of_field(2U, @lib.size_of(v))
   }
   if self.features is Some(v) {
-    size += 2U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(v))
   }
   for s in self.uninterpreted_option {
-    size += 2U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(2U, @lib.size_of(s))
   }
   size
 }
@@ -5142,8 +5142,8 @@ pub(all) struct UninterpretedOption_NamePart {
 } derive(Eq, Debug)
 pub impl @lib.Sized for UninterpretedOption_NamePart with fn size_of(self) {
   let mut size = 0U
-  size += 1U + { let size = @lib.size_of(self.name_part); @lib.size_of(size) + size }
-  size += 1U + @lib.size_of(self.is_extension)
+  size += @lib.size_of_length_delimited_field(1U, @lib.size_of(self.name_part))
+  size += @lib.size_of_field(1U, @lib.size_of(self.is_extension))
   size
 }
 pub impl Default for UninterpretedOption_NamePart with fn default() -> UninterpretedOption_NamePart {
@@ -5228,25 +5228,25 @@ pub(all) struct UninterpretedOption {
 pub impl @lib.Sized for UninterpretedOption with fn size_of(self) {
   let mut size = 0U
   for s in self.name {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.identifier_value is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.positive_int_value is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.negative_int_value is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.double_value is Some(_) {
-    size += 1U + 8U
+    size += @lib.size_of_field(1U, 8U)
   }
   if self.string_value is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.aggregate_value is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -5841,28 +5841,28 @@ pub(all) struct FeatureSet {
 pub impl @lib.Sized for FeatureSet with fn size_of(self) {
   let mut size = 0U
   if self.field_presence is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.enum_type is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.repeated_field_encoding is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.utf8_validation is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.message_encoding is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.json_format is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.enforce_naming_style is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.default_symbol_visibility is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -6072,13 +6072,13 @@ pub(all) struct FeatureSetDefaults_FeatureSetEditionDefault {
 pub impl @lib.Sized for FeatureSetDefaults_FeatureSetEditionDefault with fn size_of(self) {
   let mut size = 0U
   if self.edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.overridable_features is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.fixed_features is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -6193,13 +6193,13 @@ pub(all) struct FeatureSetDefaults {
 pub impl @lib.Sized for FeatureSetDefaults with fn size_of(self) {
   let mut size = 0U
   for s in self.defaults {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   if self.minimum_edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.maximum_edition is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -6316,19 +6316,19 @@ pub(all) struct SourceCodeInfo_Location {
 pub impl @lib.Sized for SourceCodeInfo_Location with fn size_of(self) {
   let mut size = 0U
   if !self.path.is_empty() {
-    size += 1U + { let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add))
   }
   if !self.span.is_empty() {
-    size += 1U + { let size = self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, self.span.iter().map(@lib.size_of).fold(init=0U, UInt::add))
   }
   if self.leading_comments is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.trailing_comments is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   for s in self.leading_detached_comments {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -6499,7 +6499,7 @@ pub(all) struct SourceCodeInfo {
 pub impl @lib.Sized for SourceCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.location {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }
@@ -6622,19 +6622,19 @@ pub(all) struct GeneratedCodeInfo_Annotation {
 pub impl @lib.Sized for GeneratedCodeInfo_Annotation with fn size_of(self) {
   let mut size = 0U
   if !self.path.is_empty() {
-    size += 1U + { let size = self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, self.path.iter().map(@lib.size_of).fold(init=0U, UInt::add))
   }
   if self.source_file is Some(v) {
-    size += 1U + { let size = @lib.size_of(v); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(v))
   }
   if self.begin is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.end is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   if self.semantic is Some(v) {
-    size += 1U + @lib.size_of(v)
+    size += @lib.size_of_field(1U, @lib.size_of(v))
   }
   size
 }
@@ -6795,7 +6795,7 @@ pub(all) struct GeneratedCodeInfo {
 pub impl @lib.Sized for GeneratedCodeInfo with fn size_of(self) {
   let mut size = 0U
   for s in self.annotation {
-    size += 1U + { let size = @lib.size_of(s); @lib.size_of(size) + size }
+    size += @lib.size_of_length_delimited_field(1U, @lib.size_of(s))
   }
   size
 }


### PR DESCRIPTION
## Why

Generated size code still repeated protobuf field-envelope arithmetic: encoded tag size plus payload size, and encoded tag size plus length-prefix size plus payload size. Generated writers already route framing behavior through Runtime helpers, so size generation had weaker locality and could drift from the same framing rules.

## What

- Add two public Runtime helpers for plain and length-delimited field-envelope sizing.
- Make those helpers take protobuf field number plus payload size, so Runtime owns tag-size calculation instead of exposing generated tag-size constants.
- Keep length-prefix sizing as an internal Runtime detail rather than a separate public API.
- Route generated size expressions for scalar, fixed, bytes/string/message, packed, map, and oneof cases through those helpers.
- Regenerate standard protobuf sources, reader fixtures, and snapshots.
- Add Runtime tests for one-byte and two-byte field-number envelope sizes.

## Why This Is Correct

The helpers preserve the existing arithmetic exactly: a plain field size is encoded tag size plus payload size, and a length-delimited field size is encoded tag size plus varint-encoded payload length plus payload size. The encoded tag size is derived from the protobuf field number, which is independent of wire type for valid protobuf field numbers. Generated writers still keep precomputed tag constants, so this does not add runtime tag encoding to the write hot path.

## Scope

This PR centralizes field-envelope sizing only. It does not change write emission, writer tag constants, packed payload calculation, protobuf wire semantics, or Field/Oneof/Message shape interfaces.