### PR TITLE
Name field codec read mode

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,7 +8,7 @@
 - **Feature resolver**: Generator logic that turns protobuf Editions feature options, inheritance, and syntax defaults into semantic questions used by templates.
 - **Field shape semantics**: Generator-side decisions that turn protobuf field descriptors and Feature resolver answers into generated MoonBit shape decisions, such as presence, packing, maps, defaults, names, and per-field read/write/size/JSON categories.
 - **Field storage shape**: The first Field shape semantics slice that resolves a generated field's MoonBit storage declaration: field name, base MoonBit type, optional/list/map wrapping, and default expression when it follows directly from storage.
-- **Field codec shape**: The Field shape semantics slice that resolves generated binary read/write/size categories for normal fields, including singular, optional, repeated, packed repeated, and map field handling.
+- **Field codec shape**: The Field shape semantics slice that resolves generated binary read/write/size categories for normal fields, including singular, optional, repeated, packed repeated, map field handling, and packed/unpacked read compatibility.
 - **Field JSON shape**: The Field shape semantics slice that resolves generated JSON categories for normal fields, including JSON names, default comparison expressions, optional/list/map handling, and scalar JSON adapters.
 - **Oneof shape**: Generator-side decisions that turn protobuf oneof descriptors into generated enum names, message storage fields, enum variants, field numbers, value types, and oneof read/write/size/JSON cases.
 - **Message shape**: Generator-side decisions that collect a message's generated MoonBit name, normal Field shape slices, Oneof shapes, and Runtime-owned JSON implementation status for template emission.

--- a/cli/field_codec_shape.mbt
+++ b/cli/field_codec_shape.mbt
@@ -49,6 +49,11 @@ fn CodeGenerator::field_codec_shape(
         FieldCodecPresence::AlwaysEmitField
       }
   }
+  let read_mode = if field.is_list() && field.is_packable_scalar() {
+    FieldCodecReadMode::ReadPackedAndUnpackedField
+  } else {
+    FieldCodecReadMode::ReadUnpackedField
+  }
   {
     field_name: field.import_path.name() |> pascal_to_snake,
     field_number: value.number,
@@ -57,7 +62,7 @@ fn CodeGenerator::field_codec_shape(
     key,
     map_value,
     presence,
-    accepts_packed_read: field.is_list() && field.is_packable_scalar(),
+    read_mode,
   }
 }
 
@@ -291,27 +296,30 @@ fn CodeGenerator::gen_field_codec_read(
 ) -> Unit raise {
   let async_keyword = if is_async { "async" } else { "" }
   let async_keyword_to_snake = async_keyword |> pascal_to_snake
-  if shape.accepts_packed_read {
-    let packed_read = "reader |> @lib.\{async_keyword_to_snake}read_packed(\{shape.value.packed_reader_func(is_async~)}, \{shape.value.packed_element_size()})"
-    match shape.value.type_ {
-      FieldDescriptorProto_Type::TYPE_SINT32
-      | FieldDescriptorProto_Type::TYPE_SINT64 =>
-        content.write_string(
-          "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) } }\n",
-        )
-      FieldDescriptorProto_Type::TYPE_ENUM =>
-        content.write_string(
-          "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) } }\n",
-        )
-      _ =>
-        content.write_string(
-          "      (\{shape.field_number}, 2) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()) }\n",
-        )
+  match shape.read_mode {
+    FieldCodecReadMode::ReadPackedAndUnpackedField => {
+      let packed_read = "reader |> @lib.\{async_keyword_to_snake}read_packed(\{shape.value.packed_reader_func(is_async~)}, \{shape.value.packed_element_size()})"
+      match shape.value.type_ {
+        FieldDescriptorProto_Type::TYPE_SINT32
+        | FieldDescriptorProto_Type::TYPE_SINT64 =>
+          content.write_string(
+            "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) } }\n",
+          )
+        FieldDescriptorProto_Type::TYPE_ENUM =>
+          content.write_string(
+            "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) } }\n",
+          )
+        _ =>
+          content.write_string(
+            "      (\{shape.field_number}, 2) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()) }\n",
+          )
+      }
+      content.write_string(
+        "      (\{shape.field_number}, \{shape.value.unpacked_wire_type()}) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
+      )
+      return
     }
-    content.write_string(
-      "      (\{shape.field_number}, \{shape.value.unpacked_wire_type()}) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
-    )
-    return
+    FieldCodecReadMode::ReadUnpackedField => ()
   }
   match shape.cardinality {
     PackedField => raise @model.UnexpectedType("unpackable packed field")

--- a/cli/model/pkg.generated.mbti
+++ b/cli/model/pkg.generated.mbti
@@ -67,6 +67,11 @@ pub(all) enum FieldCodecPresence {
   EmitFieldWhenNonEmpty
 } derive(Eq, @debug.Debug)
 
+pub(all) enum FieldCodecReadMode {
+  ReadUnpackedField
+  ReadPackedAndUnpackedField
+} derive(Eq, @debug.Debug)
+
 pub(all) struct FieldCodecShape {
   field_name : String
   field_number : Int
@@ -75,7 +80,7 @@ pub(all) struct FieldCodecShape {
   key : FieldCodecValue?
   map_value : FieldCodecValue?
   presence : FieldCodecPresence
-  accepts_packed_read : Bool
+  read_mode : FieldCodecReadMode
 } derive(Eq, @debug.Debug)
 
 pub(all) struct FieldCodecValue {

--- a/cli/model/types.mbt
+++ b/cli/model/types.mbt
@@ -125,6 +125,12 @@ pub(all) enum FieldCodecPresence {
 } derive(Eq, Debug)
 
 ///|
+pub(all) enum FieldCodecReadMode {
+  ReadUnpackedField
+  ReadPackedAndUnpackedField
+} derive(Eq, Debug)
+
+///|
 pub(all) struct FieldCodecShape {
   field_name : String
   field_number : Int
@@ -133,7 +139,7 @@ pub(all) struct FieldCodecShape {
   key : FieldCodecValue?
   map_value : FieldCodecValue?
   presence : FieldCodecPresence
-  accepts_packed_read : Bool
+  read_mode : FieldCodecReadMode
 } derive(Eq, Debug)
 
 ///|

--- a/cli/model_imports.mbt
+++ b/cli/model_imports.mbt
@@ -7,6 +7,7 @@ using @model {
   type Field,
   type FieldCodecCardinality,
   type FieldCodecPresence,
+  type FieldCodecReadMode,
   type FieldCodecShape,
   type FieldCodecValue,
   type FieldJsonCardinality,


### PR DESCRIPTION
## Why

Field codec generation still exposed packed read compatibility as a boolean on `FieldCodecShape`. The read template interpreted `accepts_packed_read` separately from cardinality, which made packed/unpacked read compatibility a template concern instead of a named Field codec shape decision.

## What

- Add `FieldCodecReadMode` to the Generator model.
- Store the resolved read compatibility on `FieldCodecShape`.
- Route read generation through the named read mode instead of `accepts_packed_read`.
- Update the Field codec shape vocabulary to include packed/unpacked read compatibility.
- Keep generated protobuf output unchanged.

## Why This Is Correct

The new read modes preserve the existing behavior: packable repeated fields read both packed and unpacked encodings, while all other fields use the existing unpacked read path. The branch body and generated read cases remain unchanged.

## Scope

This PR does not change Runtime APIs, generated protobuf output, wire behavior, write/size generation, JSON shape handling, storage shape handling, or oneof shape handling.