### PR TITLE
Support delimited message encoding and proto2 groups

### DIFF
--- a/cli/field_codec_shape.mbt
+++ b/cli/field_codec_shape.mbt
@@ -187,13 +187,13 @@ fn FieldCodecValue::unpacked_wire_type(self : FieldCodecValue) -> Int raise {
     | FieldDescriptorProto_Type::TYPE_SINT32
     | FieldDescriptorProto_Type::TYPE_SINT64
     | FieldDescriptorProto_Type::TYPE_UINT32
-    | FieldDescriptorProto_Type::TYPE_UINT64 => 0
+    | FieldDescriptorProto_Type::TYPE_UINT64 => WIRE_TYPE_VARINT
     FieldDescriptorProto_Type::TYPE_SFIXED64
     | FieldDescriptorProto_Type::TYPE_FIXED64
-    | FieldDescriptorProto_Type::TYPE_DOUBLE => 1
+    | FieldDescriptorProto_Type::TYPE_DOUBLE => WIRE_TYPE_FIXED64
     FieldDescriptorProto_Type::TYPE_SFIXED32
     | FieldDescriptorProto_Type::TYPE_FIXED32
-    | FieldDescriptorProto_Type::TYPE_FLOAT => 5
+    | FieldDescriptorProto_Type::TYPE_FLOAT => WIRE_TYPE_FIXED32
     _ => raise @model.UnexpectedType("unexpected packable field type")
   }
 }
@@ -318,19 +318,19 @@ fn CodeGenerator::gen_field_codec_read(
         FieldDescriptorProto_Type::TYPE_SINT32
         | FieldDescriptorProto_Type::TYPE_SINT64 =>
           content.write_string(
-            "      (\{shape.envelope.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) } }\n",
+            "      (\{shape.envelope.field_number}, \{runtime_wire_type_const(WIRE_TYPE_LENGTH_DELIMITED)}) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) } }\n",
           )
         FieldDescriptorProto_Type::TYPE_ENUM =>
           content.write_string(
-            "      (\{shape.envelope.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) } }\n",
+            "      (\{shape.envelope.field_number}, \{runtime_wire_type_const(WIRE_TYPE_LENGTH_DELIMITED)}) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) } }\n",
           )
         _ =>
           content.write_string(
-            "      (\{shape.envelope.field_number}, 2) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()) }\n",
+            "      (\{shape.envelope.field_number}, \{runtime_wire_type_const(WIRE_TYPE_LENGTH_DELIMITED)}) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()) }\n",
           )
       }
       content.write_string(
-        "      (\{shape.envelope.field_number}, \{shape.value.unpacked_wire_type()}) => msg.\{shape.field_name}.push(\{shape.value.read_expr(shape.envelope, is_async~)})\n",
+        "      (\{shape.envelope.field_number}, \{runtime_wire_type_const(shape.value.unpacked_wire_type())}) => msg.\{shape.field_name}.push(\{shape.value.read_expr(shape.envelope, is_async~)})\n",
       )
       return
     }
@@ -426,7 +426,7 @@ fn CodeGenerator::gen_field_codec_write(
               $|    \{field_write_type_k}
               $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{value_tag_val}UL);
               $|    \{field_write_type_v}
-              $|    writer |> @lib.\{async_keyword_to_snake}write_tag((\{shape.envelope.field_number}U, 4U))
+              $|    writer |> @lib.\{async_keyword_to_snake}write_tag((\{shape.envelope.field_number}U, @lib.WIRE_TYPE_END_GROUP))
               $|  }
               $|
             ),

--- a/cli/field_codec_shape.mbt
+++ b/cli/field_codec_shape.mbt
@@ -14,7 +14,7 @@ fn CodeGenerator::field_codec_value(
   } else {
     ""
   }
-  { type_, type_name, number: field.number.unwrap() }
+  { type_, type_name }
 }
 
 ///|
@@ -24,15 +24,20 @@ fn CodeGenerator::field_codec_shape(
   parent_path : ImportPath,
 ) -> FieldCodecShape raise {
   let value = self.field_codec_value(field, parent_path)
+  let envelope = self.field_envelope_shape(field, is_packed=field.is_pack())
   let mut cardinality = FieldCodecCardinality::SingularField
   let mut key = None
+  let mut key_envelope = None
   let mut map_value = None
+  let mut map_value_envelope = None
   if field.is_pack() {
     cardinality = FieldCodecCardinality::PackedField
   } else if field.map_key_value() is Some(map_entry) {
     cardinality = FieldCodecCardinality::MapField
     key = Some(self.field_codec_value(map_entry.fields[0], parent_path))
+    key_envelope = Some(self.field_envelope_shape(map_entry.fields[0]))
     map_value = Some(self.field_codec_value(map_entry.fields[1], parent_path))
+    map_value_envelope = Some(self.field_envelope_shape(map_entry.fields[1]))
   } else if field.is_list() {
     cardinality = FieldCodecCardinality::RepeatedField
   } else if field.is_optional() {
@@ -56,11 +61,13 @@ fn CodeGenerator::field_codec_shape(
   }
   {
     field_name: field.import_path.name() |> pascal_to_snake,
-    field_number: value.number,
     value,
+    envelope,
     cardinality,
     key,
+    key_envelope,
     map_value,
+    map_value_envelope,
     presence,
     read_mode,
   }
@@ -69,6 +76,7 @@ fn CodeGenerator::field_codec_shape(
 ///|
 fn FieldCodecValue::read_expr(
   self : FieldCodecValue,
+  envelope : FieldEnvelopeShape,
   is_async? : Bool = false,
 ) -> String raise {
   let async_keyword = if is_async { "async_" } else { "" }
@@ -92,16 +100,22 @@ fn FieldCodecValue::read_expr(
       "(reader |> \{kind_read_func(self.type_, is_async~)}()).0"
     FieldDescriptorProto_Type::TYPE_ENUM =>
       "reader |> @lib.\{async_keyword}read_enum() |> \{self.type_name}::from_enum"
-    FieldDescriptorProto_Type::TYPE_MESSAGE =>
-      "(reader |> @lib.\{async_keyword}read_message() : \{self.type_name})"
-    FieldDescriptorProto_Type::TYPE_GROUP =>
-      raise @model.UnsupportedType("Group")
+    FieldDescriptorProto_Type::TYPE_MESSAGE
+    | FieldDescriptorProto_Type::TYPE_GROUP =>
+      match envelope.kind {
+        DelimitedMessageEnvelope =>
+          "(reader |> @lib.\{async_keyword}read_delimited_message(\{envelope.field_number}U) : \{self.type_name})"
+        LengthDelimitedEnvelope =>
+          "(reader |> @lib.\{async_keyword}read_message() : \{self.type_name})"
+        _ => raise @model.UnexpectedType("unexpected message field envelope")
+      }
   }
 }
 
 ///|
 fn FieldCodecValue::write_expr(
   self : FieldCodecValue,
+  envelope : FieldEnvelopeShape,
   variable : String,
   is_async? : Bool = false,
 ) -> String raise {
@@ -111,8 +125,15 @@ fn FieldCodecValue::write_expr(
       "writer |> @lib.\{async_keyword}write_string(\{variable})\n"
     FieldDescriptorProto_Type::TYPE_BYTES =>
       "writer |> @lib.\{async_keyword}write_bytes(\{variable})\n"
-    FieldDescriptorProto_Type::TYPE_MESSAGE =>
-      "writer |> @lib.\{async_keyword}write_message(\{variable})\n"
+    FieldDescriptorProto_Type::TYPE_MESSAGE
+    | FieldDescriptorProto_Type::TYPE_GROUP =>
+      match envelope.kind {
+        DelimitedMessageEnvelope =>
+          "writer |> @lib.\{async_keyword}write_delimited_message(\{envelope.field_number}U, \{variable})\n"
+        LengthDelimitedEnvelope =>
+          "writer |> @lib.\{async_keyword}write_message(\{variable})\n"
+        _ => raise @model.UnexpectedType("unexpected message field envelope")
+      }
     FieldDescriptorProto_Type::TYPE_FIXED32 =>
       "writer |> @lib.\{async_keyword}write_fixed32(\{variable})\n"
     FieldDescriptorProto_Type::TYPE_SFIXED32 =>
@@ -141,7 +162,6 @@ fn FieldCodecValue::write_expr(
       "writer |> @lib.\{async_keyword}write_uint64(\{variable})\n"
     FieldDescriptorProto_Type::TYPE_ENUM =>
       "writer |> @lib.\{async_keyword}write_enum(\{variable}.to_enum())\n"
-    _ => raise @model.UnexpectedType("unsupported field type")
   }
 }
 
@@ -200,36 +220,31 @@ fn FieldCodecValue::packed_element_size(self : FieldCodecValue) -> String raise 
 }
 
 ///|
-fn FieldCodecValue::unpacked_size_expr(
+fn FieldCodecValue::field_size_expr(
   self : FieldCodecValue,
+  envelope : FieldEnvelopeShape,
   value_expr : String,
-  field_number : Int,
 ) -> (String, Bool) {
   match self.type_ {
     FieldDescriptorProto_Type::TYPE_STRING
-    | FieldDescriptorProto_Type::TYPE_BYTES
-    | FieldDescriptorProto_Type::TYPE_MESSAGE =>
-      (
-        "@lib.size_of_length_delimited_field(\{field_number}U, @lib.size_of(\{value_expr}))",
-        true,
-      )
+    | FieldDescriptorProto_Type::TYPE_BYTES =>
+      (envelope.size_expr("@lib.size_of(\{value_expr})"), true)
+    FieldDescriptorProto_Type::TYPE_MESSAGE
+    | FieldDescriptorProto_Type::TYPE_GROUP =>
+      (envelope.size_expr("@lib.size_of(\{value_expr})"), true)
     FieldDescriptorProto_Type::TYPE_FIXED32
     | FieldDescriptorProto_Type::TYPE_SFIXED32
     | FieldDescriptorProto_Type::TYPE_FLOAT => {
       let fixed_size = sizeFixed32()
-      ("@lib.size_of_field(\{field_number}U, \{fixed_size}U)", false)
+      (envelope.size_expr("\{fixed_size}U"), false)
     }
     FieldDescriptorProto_Type::TYPE_FIXED64
     | FieldDescriptorProto_Type::TYPE_SFIXED64
     | FieldDescriptorProto_Type::TYPE_DOUBLE => {
       let fixed_size = sizeFixed64()
-      ("@lib.size_of_field(\{field_number}U, \{fixed_size}U)", false)
+      (envelope.size_expr("\{fixed_size}U"), false)
     }
-    _ =>
-      (
-        "@lib.size_of_field(\{field_number}U, @lib.size_of(\{value_expr}))",
-        true,
-      )
+    _ => (envelope.size_expr("@lib.size_of(\{value_expr})"), true)
   }
 }
 
@@ -268,7 +283,7 @@ fn FieldCodecShape::packed_delta_size_expr(
   self : FieldCodecShape,
 ) -> String raise {
   let data_size = self.packed_data_size_expr()
-  "@lib.size_of_length_delimited_field(\{self.field_number}U, \{data_size})"
+  self.envelope.size_expr(data_size)
 }
 
 ///|
@@ -303,19 +318,19 @@ fn CodeGenerator::gen_field_codec_read(
         FieldDescriptorProto_Type::TYPE_SINT32
         | FieldDescriptorProto_Type::TYPE_SINT64 =>
           content.write_string(
-            "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) } }\n",
+            "      (\{shape.envelope.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(item.0) } }\n",
           )
         FieldDescriptorProto_Type::TYPE_ENUM =>
           content.write_string(
-            "      (\{shape.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) } }\n",
+            "      (\{shape.envelope.field_number}, 2) => { let packed = \{packed_read}; for item in packed { msg.\{shape.field_name}.push(\{shape.value.type_name}::from_enum(item)) } }\n",
           )
         _ =>
           content.write_string(
-            "      (\{shape.field_number}, 2) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()) }\n",
+            "      (\{shape.envelope.field_number}, 2) => { msg.\{shape.field_name}.push_iter((\{packed_read}).iter()) }\n",
           )
       }
       content.write_string(
-        "      (\{shape.field_number}, \{shape.value.unpacked_wire_type()}) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
+        "      (\{shape.envelope.field_number}, \{shape.value.unpacked_wire_type()}) => msg.\{shape.field_name}.push(\{shape.value.read_expr(shape.envelope, is_async~)})\n",
       )
       return
     }
@@ -325,19 +340,19 @@ fn CodeGenerator::gen_field_codec_read(
     PackedField => raise @model.UnexpectedType("unpackable packed field")
     MapField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => { let {key, value} = \{shape.value.read_expr(is_async~)}; msg.\{shape.field_name}[key] = value }\n",
+        "      (\{shape.envelope.field_number}, \{shape.envelope.read_wire_pattern(shape.value)}) => { let {key, value} = \{shape.value.read_expr(shape.envelope, is_async~)}; msg.\{shape.field_name}[key] = value }\n",
       )
     RepeatedField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => msg.\{shape.field_name}.push(\{shape.value.read_expr(is_async~)})\n",
+        "      (\{shape.envelope.field_number}, \{shape.envelope.read_wire_pattern(shape.value)}) => msg.\{shape.field_name}.push(\{shape.value.read_expr(shape.envelope, is_async~)})\n",
       )
     OptionalField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)} |> Some\n",
+        "      (\{shape.envelope.field_number}, \{shape.envelope.read_wire_pattern(shape.value)}) => msg.\{shape.field_name} = \{shape.value.read_expr(shape.envelope, is_async~)} |> Some\n",
       )
     SingularField =>
       content.write_string(
-        "      (\{shape.field_number}, _) => msg.\{shape.field_name} = \{shape.value.read_expr(is_async~)}\n",
+        "      (\{shape.envelope.field_number}, \{shape.envelope.read_wire_pattern(shape.value)}) => msg.\{shape.field_name} = \{shape.value.read_expr(shape.envelope, is_async~)}\n",
       )
   }
 }
@@ -353,7 +368,7 @@ fn CodeGenerator::gen_field_codec_write(
   let async_keyword_to_snake = async_keyword |> pascal_to_snake
   match shape.cardinality {
     PackedField => {
-      let tag_val = tag(shape.value.type_, shape.field_number, true)
+      let tag_val = shape.envelope.tag_value()
       guard shape.presence_guard_expr() is Some(presence_guard) else {
         raise @model.UnexpectedType("packed field without presence guard")
       }
@@ -362,7 +377,11 @@ fn CodeGenerator::gen_field_codec_write(
         "    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL)\n",
       )
       content.write_string("    let size = \{shape.packed_data_size_expr()}\n")
-      let field_write_type = shape.value.write_expr("item", is_async~)
+      let field_write_type = shape.value.write_expr(
+        shape.envelope,
+        "item",
+        is_async~,
+      )
       content.write_string(
         (
           $|    writer |> @lib.\{async_keyword_to_snake}write_uint32(size)
@@ -377,42 +396,79 @@ fn CodeGenerator::gen_field_codec_write(
     MapField => {
       let key_field = shape.key.unwrap()
       let value_field = shape.map_value.unwrap()
-      let tag_val = tag(shape.value.type_, shape.field_number, false)
-      let (key_size, _) = key_field.unpacked_size_expr("k", key_field.number)
-      let (value_size, _) = value_field.unpacked_size_expr(
+      let key_envelope = shape.key_envelope.unwrap()
+      let value_envelope = shape.map_value_envelope.unwrap()
+      let tag_val = shape.envelope.tag_value()
+      let (key_size, _) = key_field.field_size_expr(key_envelope, "k")
+      let (value_size, _) = value_field.field_size_expr(value_envelope, "v")
+      let key_tag_val = key_envelope.tag_value()
+      let value_tag_val = value_envelope.tag_value()
+      let field_write_type_k = key_field.write_expr(
+        key_envelope,
+        "k",
+        is_async~,
+      )
+      let field_write_type_v = value_field.write_expr(
+        value_envelope,
         "v",
-        value_field.number,
+        is_async~,
       )
-      let key_tag_val = tag(key_field.type_, key_field.number, false)
-      let value_tag_val = tag(value_field.type_, value_field.number, false)
-      let field_write_type_k = key_field.write_expr("k", is_async~)
-      let field_write_type_v = value_field.write_expr("v", is_async~)
-      content.write_string(
-        (
-          $|  let keys = self.\{shape.field_name}.keys().collect()
-          $|  for i in 0..<keys.length() {
-          $|    let k = keys[i]
-          $|    let v = self.\{shape.field_name}.get(k).unwrap()
-          $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL)
-          $|    let key_size = \{key_size}
-          $|    let value_size = \{value_size}
-          $|    writer |> @lib.\{async_keyword_to_snake}write_uint32(key_size + value_size)
-          $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{key_tag_val}UL)
-          $|    \{field_write_type_k}
-          $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{value_tag_val}UL);
-          $|    \{field_write_type_v}
-          $|  }
-          $| 
-        ),
-      )
+      match shape.envelope.kind {
+        DelimitedMessageEnvelope =>
+          content.write_string(
+            (
+              $|  let keys = self.\{shape.field_name}.keys().collect()
+              $|  for i in 0..<keys.length() {
+              $|    let k = keys[i]
+              $|    let v = self.\{shape.field_name}.get(k).unwrap()
+              $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL)
+              $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{key_tag_val}UL)
+              $|    \{field_write_type_k}
+              $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{value_tag_val}UL);
+              $|    \{field_write_type_v}
+              $|    writer |> @lib.\{async_keyword_to_snake}write_tag((\{shape.envelope.field_number}U, 4U))
+              $|  }
+              $|
+            ),
+          )
+        LengthDelimitedEnvelope =>
+          content.write_string(
+            (
+              $|  let keys = self.\{shape.field_name}.keys().collect()
+              $|  for i in 0..<keys.length() {
+              $|    let k = keys[i]
+              $|    let v = self.\{shape.field_name}.get(k).unwrap()
+              $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL)
+              $|    let key_size = \{key_size}
+              $|    let value_size = \{value_size}
+              $|    writer |> @lib.\{async_keyword_to_snake}write_uint32(key_size + value_size)
+              $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{key_tag_val}UL)
+              $|    \{field_write_type_k}
+              $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{value_tag_val}UL);
+              $|    \{field_write_type_v}
+              $|  }
+              $|
+            ),
+          )
+        _ => raise @model.UnexpectedType("unexpected map field envelope")
+      }
     }
     RepeatedField => {
-      let tag_val = tag(shape.value.type_, shape.field_number, false)
-      let field_write_type = shape.value.write_expr("item", is_async~)
+      let tag_val = shape.envelope.tag_value()
+      let field_write_type = shape.value.write_expr(
+        shape.envelope,
+        "item",
+        is_async~,
+      )
+      let tag_write = if shape.envelope.writes_own_field_tags() {
+        ""
+      } else {
+        "    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL)\n"
+      }
       content.write_string(
         (
           $|  for item in self.\{shape.field_name} {
-          $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL)
+          $|\{tag_write}
           $|    \{field_write_type}
           $|  }
           $|
@@ -420,15 +476,24 @@ fn CodeGenerator::gen_field_codec_write(
       )
     }
     OptionalField => {
-      let field_write_type = shape.value.write_expr("v", is_async~)
-      let tag_val = tag(shape.value.type_, shape.field_number, false)
+      let field_write_type = shape.value.write_expr(
+        shape.envelope,
+        "v",
+        is_async~,
+      )
+      let tag_val = shape.envelope.tag_value()
+      let tag_write = if shape.envelope.writes_own_field_tags() {
+        ""
+      } else {
+        "    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL);\n"
+      }
       guard shape.presence_guard_expr() is Some(presence_guard) else {
         raise @model.UnexpectedType("optional field without presence guard")
       }
       content.write_string(
         (
           $|  if \{presence_guard} {
-          $|    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL);
+          $|\{tag_write}
           $|    \{field_write_type}
           $|  }
           $|
@@ -437,13 +502,21 @@ fn CodeGenerator::gen_field_codec_write(
     }
     SingularField => {
       let field_write_type = shape.value.write_expr(
+        shape.envelope,
         "self.\{shape.field_name}",
         is_async~,
       )
-      let tag_val = tag(shape.value.type_, shape.field_number, false)
-      let field_write =
-        $|  writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL);
-        $|  \{field_write_type}
+      let tag_val = shape.envelope.tag_value()
+      let field_write = if shape.envelope.writes_own_field_tags() {
+        (
+          $|  \{field_write_type}
+        )
+      } else {
+        (
+          $|  writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL);
+          $|  \{field_write_type}
+        )
+      }
       match shape.presence_guard_expr() {
         Some(presence_guard) => {
           content.write_string("  if \{presence_guard} {\n")
@@ -480,27 +553,24 @@ fn CodeGenerator::gen_field_codec_size(
     MapField => {
       let key_field = shape.key.unwrap()
       let value_field = shape.map_value.unwrap()
-      let (key_size, _) = key_field.unpacked_size_expr("k", key_field.number)
-      let (value_size, _) = value_field.unpacked_size_expr(
-        "v",
-        value_field.number,
-      )
+      let key_envelope = shape.key_envelope.unwrap()
+      let value_envelope = shape.map_value_envelope.unwrap()
+      let (key_size, _) = key_field.field_size_expr(key_envelope, "k")
+      let (value_size, _) = value_field.field_size_expr(value_envelope, "v")
+      let field_size = shape.envelope.size_expr("key_size + value_size")
       content.write_string(
         (
           $|  for k, v in self.\{shape.field_name} {
           $|    let key_size = \{key_size}
           $|    let value_size = \{value_size}
-          $|    size += @lib.size_of_length_delimited_field(\{shape.field_number}U, key_size + value_size)
+          $|    size += \{field_size}
           $|  }
           $|
         ),
       )
     }
     RepeatedField => {
-      let (delta_size, _) = shape.value.unpacked_size_expr(
-        "s",
-        shape.field_number,
-      )
+      let (delta_size, _) = shape.value.field_size_expr(shape.envelope, "s")
       content.write_string(
         (
           $|  for s in self.\{shape.field_name} {
@@ -511,9 +581,9 @@ fn CodeGenerator::gen_field_codec_size(
       )
     }
     OptionalField => {
-      let (delta_size, need_v) = shape.value.unpacked_size_expr(
+      let (delta_size, need_v) = shape.value.field_size_expr(
+        shape.envelope,
         "v",
-        shape.field_number,
       )
       let value_binding = if need_v { "v" } else { "_" }
       guard shape.presence_guard_expr(value_binding~) is Some(presence_guard) else {
@@ -529,9 +599,9 @@ fn CodeGenerator::gen_field_codec_size(
       )
     }
     SingularField => {
-      let (delta_size, _) = shape.value.unpacked_size_expr(
+      let (delta_size, _) = shape.value.field_size_expr(
+        shape.envelope,
         "self.\{shape.field_name}",
-        shape.field_number,
       )
       match shape.presence_guard_expr() {
         Some(presence_guard) =>

--- a/cli/field_codec_shape.mbt
+++ b/cli/field_codec_shape.mbt
@@ -122,46 +122,46 @@ fn FieldCodecValue::write_expr(
   let async_keyword = if is_async { "async_" } else { "" }
   match self.type_ {
     FieldDescriptorProto_Type::TYPE_STRING =>
-      "writer |> @lib.\{async_keyword}write_string(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_string(\{variable})"
     FieldDescriptorProto_Type::TYPE_BYTES =>
-      "writer |> @lib.\{async_keyword}write_bytes(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_bytes(\{variable})"
     FieldDescriptorProto_Type::TYPE_MESSAGE
     | FieldDescriptorProto_Type::TYPE_GROUP =>
       match envelope.kind {
         DelimitedMessageEnvelope =>
-          "writer |> @lib.\{async_keyword}write_delimited_message(\{envelope.field_number}U, \{variable})\n"
+          "writer |> @lib.\{async_keyword}write_delimited_message(\{envelope.field_number}U, \{variable})"
         LengthDelimitedEnvelope =>
-          "writer |> @lib.\{async_keyword}write_message(\{variable})\n"
+          "writer |> @lib.\{async_keyword}write_message(\{variable})"
         _ => raise @model.UnexpectedType("unexpected message field envelope")
       }
     FieldDescriptorProto_Type::TYPE_FIXED32 =>
-      "writer |> @lib.\{async_keyword}write_fixed32(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_fixed32(\{variable})"
     FieldDescriptorProto_Type::TYPE_SFIXED32 =>
-      "writer |> @lib.\{async_keyword}write_sfixed32(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_sfixed32(\{variable})"
     FieldDescriptorProto_Type::TYPE_FLOAT =>
-      "writer |> @lib.\{async_keyword}write_float(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_float(\{variable})"
     FieldDescriptorProto_Type::TYPE_FIXED64 =>
-      "writer |> @lib.\{async_keyword}write_fixed64(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_fixed64(\{variable})"
     FieldDescriptorProto_Type::TYPE_SFIXED64 =>
-      "writer |> @lib.\{async_keyword}write_sfixed64(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_sfixed64(\{variable})"
     FieldDescriptorProto_Type::TYPE_DOUBLE =>
-      "writer |> @lib.\{async_keyword}write_double(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_double(\{variable})"
     FieldDescriptorProto_Type::TYPE_BOOL =>
-      "writer |> @lib.\{async_keyword}write_bool(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_bool(\{variable})"
     FieldDescriptorProto_Type::TYPE_INT32 =>
-      "writer |> @lib.\{async_keyword}write_int32(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_int32(\{variable})"
     FieldDescriptorProto_Type::TYPE_INT64 =>
-      "writer |> @lib.\{async_keyword}write_int64(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_int64(\{variable})"
     FieldDescriptorProto_Type::TYPE_SINT32 =>
-      "writer |> @lib.\{async_keyword}write_sint32(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_sint32(\{variable})"
     FieldDescriptorProto_Type::TYPE_SINT64 =>
-      "writer |> @lib.\{async_keyword}write_sint64(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_sint64(\{variable})"
     FieldDescriptorProto_Type::TYPE_UINT32 =>
-      "writer |> @lib.\{async_keyword}write_uint32(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_uint32(\{variable})"
     FieldDescriptorProto_Type::TYPE_UINT64 =>
-      "writer |> @lib.\{async_keyword}write_uint64(\{variable})\n"
+      "writer |> @lib.\{async_keyword}write_uint64(\{variable})"
     FieldDescriptorProto_Type::TYPE_ENUM =>
-      "writer |> @lib.\{async_keyword}write_enum(\{variable}.to_enum())\n"
+      "writer |> @lib.\{async_keyword}write_enum(\{variable}.to_enum())"
   }
 }
 
@@ -460,20 +460,14 @@ fn CodeGenerator::gen_field_codec_write(
         "item",
         is_async~,
       )
-      let tag_write = if shape.envelope.writes_own_field_tags() {
-        ""
-      } else {
-        "    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL)\n"
+      content.write_string("  for item in self.\{shape.field_name} {\n")
+      if !shape.envelope.writes_own_field_tags() {
+        content.write_string(
+          "    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL)\n",
+        )
       }
-      content.write_string(
-        (
-          $|  for item in self.\{shape.field_name} {
-          $|\{tag_write}
-          $|    \{field_write_type}
-          $|  }
-          $|
-        ),
-      )
+      content.write_string("    \{field_write_type}\n")
+      content.write_string("  }\n")
     }
     OptionalField => {
       let field_write_type = shape.value.write_expr(
@@ -482,23 +476,17 @@ fn CodeGenerator::gen_field_codec_write(
         is_async~,
       )
       let tag_val = shape.envelope.tag_value()
-      let tag_write = if shape.envelope.writes_own_field_tags() {
-        ""
-      } else {
-        "    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL);\n"
-      }
       guard shape.presence_guard_expr() is Some(presence_guard) else {
         raise @model.UnexpectedType("optional field without presence guard")
       }
-      content.write_string(
-        (
-          $|  if \{presence_guard} {
-          $|\{tag_write}
-          $|    \{field_write_type}
-          $|  }
-          $|
-        ),
-      )
+      content.write_string("  if \{presence_guard} {\n")
+      if !shape.envelope.writes_own_field_tags() {
+        content.write_string(
+          "    writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL);\n",
+        )
+      }
+      content.write_string("    \{field_write_type}\n")
+      content.write_string("  }\n")
     }
     SingularField => {
       let field_write_type = shape.value.write_expr(
@@ -508,14 +496,9 @@ fn CodeGenerator::gen_field_codec_write(
       )
       let tag_val = shape.envelope.tag_value()
       let field_write = if shape.envelope.writes_own_field_tags() {
-        (
-          $|  \{field_write_type}
-        )
+        "  \{field_write_type}\n"
       } else {
-        (
-          $|  writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL);
-          $|  \{field_write_type}
-        )
+        "  writer |> @lib.\{async_keyword_to_snake}write_varint(\{tag_val}UL);\n  \{field_write_type}\n"
       }
       match shape.presence_guard_expr() {
         Some(presence_guard) => {

--- a/cli/field_envelope_shape.mbt
+++ b/cli/field_envelope_shape.mbt
@@ -1,0 +1,83 @@
+///|
+fn CodeGenerator::field_envelope_shape(
+  _ : CodeGenerator,
+  field : Field,
+  is_packed? : Bool = false,
+) -> FieldEnvelopeShape raise {
+  let field_number = field.number.unwrap()
+  if is_packed {
+    return { field_number, wire_type: 2, kind: PackedEnvelope }
+  }
+  guard field.type_ is Some(type_) else {
+    raise @model.UnexpectedType(
+      "Field type is not set: \{field.import_path.name()}",
+    )
+  }
+  match type_ {
+    FieldDescriptorProto_Type::TYPE_BOOL
+    | FieldDescriptorProto_Type::TYPE_ENUM
+    | FieldDescriptorProto_Type::TYPE_INT32
+    | FieldDescriptorProto_Type::TYPE_INT64
+    | FieldDescriptorProto_Type::TYPE_SINT32
+    | FieldDescriptorProto_Type::TYPE_SINT64
+    | FieldDescriptorProto_Type::TYPE_UINT32
+    | FieldDescriptorProto_Type::TYPE_UINT64 =>
+      { field_number, wire_type: 0, kind: ScalarEnvelope }
+    FieldDescriptorProto_Type::TYPE_FIXED64
+    | FieldDescriptorProto_Type::TYPE_SFIXED64
+    | FieldDescriptorProto_Type::TYPE_DOUBLE =>
+      { field_number, wire_type: 1, kind: ScalarEnvelope }
+    FieldDescriptorProto_Type::TYPE_STRING
+    | FieldDescriptorProto_Type::TYPE_BYTES =>
+      { field_number, wire_type: 2, kind: LengthDelimitedEnvelope }
+    FieldDescriptorProto_Type::TYPE_MESSAGE
+    | FieldDescriptorProto_Type::TYPE_GROUP =>
+      match field.codec_message_encoding() {
+        DelimitedMessage =>
+          { field_number, wire_type: 3, kind: DelimitedMessageEnvelope }
+        LengthPrefixedMessage =>
+          { field_number, wire_type: 2, kind: LengthDelimitedEnvelope }
+      }
+    FieldDescriptorProto_Type::TYPE_FIXED32
+    | FieldDescriptorProto_Type::TYPE_SFIXED32
+    | FieldDescriptorProto_Type::TYPE_FLOAT =>
+      { field_number, wire_type: 5, kind: ScalarEnvelope }
+  }
+}
+
+///|
+fn FieldEnvelopeShape::tag_value(self : FieldEnvelopeShape) -> UInt64 {
+  encode_tag(self.field_number, self.wire_type)
+}
+
+///|
+fn FieldEnvelopeShape::writes_own_field_tags(self : FieldEnvelopeShape) -> Bool {
+  self.kind == DelimitedMessageEnvelope
+}
+
+///|
+fn FieldEnvelopeShape::read_wire_pattern(
+  self : FieldEnvelopeShape,
+  value : FieldCodecValue,
+) -> String {
+  match value.type_ {
+    FieldDescriptorProto_Type::TYPE_MESSAGE
+    | FieldDescriptorProto_Type::TYPE_GROUP => "\{self.wire_type}"
+    _ => "_"
+  }
+}
+
+///|
+fn FieldEnvelopeShape::size_expr(
+  self : FieldEnvelopeShape,
+  payload_size_expr : String,
+) -> String {
+  match self.kind {
+    DelimitedMessageEnvelope =>
+      "@lib.size_of_delimited_field(\{self.field_number}U, \{payload_size_expr})"
+    LengthDelimitedEnvelope | PackedEnvelope =>
+      "@lib.size_of_length_delimited_field(\{self.field_number}U, \{payload_size_expr})"
+    ScalarEnvelope =>
+      "@lib.size_of_field(\{self.field_number}U, \{payload_size_expr})"
+  }
+}

--- a/cli/field_envelope_shape.mbt
+++ b/cli/field_envelope_shape.mbt
@@ -6,7 +6,11 @@ fn CodeGenerator::field_envelope_shape(
 ) -> FieldEnvelopeShape raise {
   let field_number = field.number.unwrap()
   if is_packed {
-    return { field_number, wire_type: 2, kind: PackedEnvelope }
+    return {
+      field_number,
+      wire_type: WIRE_TYPE_LENGTH_DELIMITED,
+      kind: PackedEnvelope,
+    }
   }
   guard field.type_ is Some(type_) else {
     raise @model.UnexpectedType(
@@ -22,26 +26,38 @@ fn CodeGenerator::field_envelope_shape(
     | FieldDescriptorProto_Type::TYPE_SINT64
     | FieldDescriptorProto_Type::TYPE_UINT32
     | FieldDescriptorProto_Type::TYPE_UINT64 =>
-      { field_number, wire_type: 0, kind: ScalarEnvelope }
+      { field_number, wire_type: WIRE_TYPE_VARINT, kind: ScalarEnvelope }
     FieldDescriptorProto_Type::TYPE_FIXED64
     | FieldDescriptorProto_Type::TYPE_SFIXED64
     | FieldDescriptorProto_Type::TYPE_DOUBLE =>
-      { field_number, wire_type: 1, kind: ScalarEnvelope }
+      { field_number, wire_type: WIRE_TYPE_FIXED64, kind: ScalarEnvelope }
     FieldDescriptorProto_Type::TYPE_STRING
     | FieldDescriptorProto_Type::TYPE_BYTES =>
-      { field_number, wire_type: 2, kind: LengthDelimitedEnvelope }
+      {
+        field_number,
+        wire_type: WIRE_TYPE_LENGTH_DELIMITED,
+        kind: LengthDelimitedEnvelope,
+      }
     FieldDescriptorProto_Type::TYPE_MESSAGE
     | FieldDescriptorProto_Type::TYPE_GROUP =>
       match field.codec_message_encoding() {
         DelimitedMessage =>
-          { field_number, wire_type: 3, kind: DelimitedMessageEnvelope }
+          {
+            field_number,
+            wire_type: WIRE_TYPE_START_GROUP,
+            kind: DelimitedMessageEnvelope,
+          }
         LengthPrefixedMessage =>
-          { field_number, wire_type: 2, kind: LengthDelimitedEnvelope }
+          {
+            field_number,
+            wire_type: WIRE_TYPE_LENGTH_DELIMITED,
+            kind: LengthDelimitedEnvelope,
+          }
       }
     FieldDescriptorProto_Type::TYPE_FIXED32
     | FieldDescriptorProto_Type::TYPE_SFIXED32
     | FieldDescriptorProto_Type::TYPE_FLOAT =>
-      { field_number, wire_type: 5, kind: ScalarEnvelope }
+      { field_number, wire_type: WIRE_TYPE_FIXED32, kind: ScalarEnvelope }
   }
 }
 
@@ -59,10 +75,11 @@ fn FieldEnvelopeShape::writes_own_field_tags(self : FieldEnvelopeShape) -> Bool 
 fn FieldEnvelopeShape::read_wire_pattern(
   self : FieldEnvelopeShape,
   value : FieldCodecValue,
-) -> String {
+) -> String raise {
   match value.type_ {
     FieldDescriptorProto_Type::TYPE_MESSAGE
-    | FieldDescriptorProto_Type::TYPE_GROUP => "\{self.wire_type}"
+    | FieldDescriptorProto_Type::TYPE_GROUP =>
+      runtime_wire_type_const(self.wire_type)
     _ => "_"
   }
 }

--- a/cli/message_template.mbt
+++ b/cli/message_template.mbt
@@ -15,9 +15,8 @@ fn CodeGenerator::get_moonbit_type(
     FieldDescriptorProto_Type::TYPE_FIXED32 => "UInt"
     FieldDescriptorProto_Type::TYPE_BOOL => "Bool"
     FieldDescriptorProto_Type::TYPE_STRING => "String"
-    FieldDescriptorProto_Type::TYPE_GROUP =>
-      raise @model.UnsupportedType("Group")
-    FieldDescriptorProto_Type::TYPE_MESSAGE => {
+    FieldDescriptorProto_Type::TYPE_MESSAGE
+    | FieldDescriptorProto_Type::TYPE_GROUP => {
       let message_name = field.type_name.unwrap()
       if self.find_message(message_name) is Some(message) {
         let message_path = message.import_path

--- a/cli/model/features.mbt
+++ b/cli/model/features.mbt
@@ -142,6 +142,11 @@ fn Field::message_encoding_feature_behavior(
 
 ///|
 pub fn Field::codec_message_encoding(self : Field) -> FieldCodecMessageEncoding {
+  // Map entries are synthetic protobuf messages and always use the standard
+  // length-delimited map-entry envelope, even under inherited DELIMITED.
+  if self.map_key_value() is Some(_) || self.parent.is_map() {
+    return LengthPrefixedMessage
+  }
   if self.is_message() &&
     self.message_encoding_feature_behavior() ==
     @protobuf.FeatureSet_MessageEncoding::DELIMITED {

--- a/cli/model/features.mbt
+++ b/cli/model/features.mbt
@@ -60,6 +60,29 @@ fn known_feature_enum_type(
 }
 
 ///|
+fn known_feature_message_encoding(
+  features : @protobuf.FeatureSet?,
+) -> @protobuf.FeatureSet_MessageEncoding? {
+  match features {
+    Some(
+      {
+        message_encoding: Some(
+          @protobuf.FeatureSet_MessageEncoding::LENGTH_PREFIXED
+        ),
+        ..,
+      }
+    ) => Some(@protobuf.FeatureSet_MessageEncoding::LENGTH_PREFIXED)
+    Some(
+      {
+        message_encoding: Some(@protobuf.FeatureSet_MessageEncoding::DELIMITED),
+        ..,
+      }
+    ) => Some(@protobuf.FeatureSet_MessageEncoding::DELIMITED)
+    _ => None
+  }
+}
+
+///|
 fn Field::field_presence_feature_behavior(
   self : Field,
 ) -> @protobuf.FeatureSet_FieldPresence {
@@ -96,6 +119,36 @@ fn Field::presence_behavior(self : Field) -> @protobuf.FeatureSet_FieldPresence 
     return @protobuf.FeatureSet_FieldPresence::EXPLICIT
   }
   presence
+}
+
+///|
+fn Field::message_encoding_feature_behavior(
+  self : Field,
+) -> @protobuf.FeatureSet_MessageEncoding {
+  if self.options is Some({ features, .. }) {
+    if known_feature_message_encoding(features) is Some(encoding) {
+      return encoding
+    }
+  }
+  if self.type_ is Some(TYPE_GROUP) {
+    return @protobuf.FeatureSet_MessageEncoding::DELIMITED
+  }
+  if self.parent.file is Some(file) {
+    file.message_encoding_feature_behavior()
+  } else {
+    @protobuf.FeatureSet_MessageEncoding::LENGTH_PREFIXED
+  }
+}
+
+///|
+pub fn Field::codec_message_encoding(self : Field) -> FieldCodecMessageEncoding {
+  if self.is_message() &&
+    self.message_encoding_feature_behavior() ==
+    @protobuf.FeatureSet_MessageEncoding::DELIMITED {
+    DelimitedMessage
+  } else {
+    LengthPrefixedMessage
+  }
 }
 
 ///|
@@ -178,6 +231,18 @@ fn Package::repeated_field_encoding_feature_behavior(
     Proto3 | Editions => @protobuf.FeatureSet_RepeatedFieldEncoding::PACKED
     Proto2 => @protobuf.FeatureSet_RepeatedFieldEncoding::EXPANDED
   }
+}
+
+///|
+fn Package::message_encoding_feature_behavior(
+  self : Package,
+) -> @protobuf.FeatureSet_MessageEncoding {
+  if self.options is Some({ features, .. }) {
+    if known_feature_message_encoding(features) is Some(encoding) {
+      return encoding
+    }
+  }
+  @protobuf.FeatureSet_MessageEncoding::LENGTH_PREFIXED
 }
 
 ///|

--- a/cli/model/pkg.generated.mbti
+++ b/cli/model/pkg.generated.mbti
@@ -39,6 +39,7 @@ pub(all) struct Field {
   number : Int?
   proto3optional : Bool?
 } derive(Eq, @debug.Debug)
+pub fn Field::codec_message_encoding(Self) -> FieldCodecMessageEncoding
 pub fn Field::default_value(Self) -> String?
 pub fn Field::has_implicit_presence(Self) -> Bool
 pub fn Field::is_enum(Self) -> Bool
@@ -60,6 +61,11 @@ pub(all) enum FieldCodecCardinality {
   MapField
 } derive(Eq, @debug.Debug)
 
+pub(all) enum FieldCodecMessageEncoding {
+  LengthPrefixedMessage
+  DelimitedMessage
+} derive(Eq, @debug.Debug)
+
 pub(all) enum FieldCodecPresence {
   AlwaysEmitField
   EmitFieldWhenSome
@@ -74,11 +80,13 @@ pub(all) enum FieldCodecReadMode {
 
 pub(all) struct FieldCodecShape {
   field_name : String
-  field_number : Int
   value : FieldCodecValue
+  envelope : FieldEnvelopeShape
   cardinality : FieldCodecCardinality
   key : FieldCodecValue?
+  key_envelope : FieldEnvelopeShape?
   map_value : FieldCodecValue?
+  map_value_envelope : FieldEnvelopeShape?
   presence : FieldCodecPresence
   read_mode : FieldCodecReadMode
 } derive(Eq, @debug.Debug)
@@ -86,7 +94,19 @@ pub(all) struct FieldCodecShape {
 pub(all) struct FieldCodecValue {
   type_ : @protobuf.FieldDescriptorProto_Type
   type_name : String
-  number : Int
+} derive(Eq, @debug.Debug)
+
+pub(all) enum FieldEnvelopeKind {
+  ScalarEnvelope
+  LengthDelimitedEnvelope
+  DelimitedMessageEnvelope
+  PackedEnvelope
+} derive(Eq, @debug.Debug)
+
+pub(all) struct FieldEnvelopeShape {
+  field_number : Int
+  wire_type : Int
+  kind : FieldEnvelopeKind
 } derive(Eq, @debug.Debug)
 
 pub(all) enum FieldJsonCardinality {
@@ -160,10 +180,10 @@ pub(all) struct OneOf {
 
 pub(all) struct OneofFieldShape {
   constructor_name : String
-  field_number : Int
   json_name : String
   value_type : String
   value : FieldCodecValue
+  envelope : FieldEnvelopeShape
 } derive(Eq, @debug.Debug)
 
 pub(all) struct OneofShape {

--- a/cli/model/types.mbt
+++ b/cli/model/types.mbt
@@ -104,7 +104,27 @@ pub(all) struct FieldStorageShape {
 pub(all) struct FieldCodecValue {
   type_ : FieldDescriptorProto_Type
   type_name : String
-  number : Int
+} derive(Eq, Debug)
+
+///|
+pub(all) enum FieldCodecMessageEncoding {
+  LengthPrefixedMessage
+  DelimitedMessage
+} derive(Eq, Debug)
+
+///|
+pub(all) enum FieldEnvelopeKind {
+  ScalarEnvelope
+  LengthDelimitedEnvelope
+  DelimitedMessageEnvelope
+  PackedEnvelope
+} derive(Eq, Debug)
+
+///|
+pub(all) struct FieldEnvelopeShape {
+  field_number : Int
+  wire_type : Int
+  kind : FieldEnvelopeKind
 } derive(Eq, Debug)
 
 ///|
@@ -133,11 +153,13 @@ pub(all) enum FieldCodecReadMode {
 ///|
 pub(all) struct FieldCodecShape {
   field_name : String
-  field_number : Int
   value : FieldCodecValue
+  envelope : FieldEnvelopeShape
   cardinality : FieldCodecCardinality
   key : FieldCodecValue?
+  key_envelope : FieldEnvelopeShape?
   map_value : FieldCodecValue?
+  map_value_envelope : FieldEnvelopeShape?
   presence : FieldCodecPresence
   read_mode : FieldCodecReadMode
 } derive(Eq, Debug)
@@ -165,10 +187,10 @@ pub(all) struct FieldJsonShape {
 ///|
 pub(all) struct OneofFieldShape {
   constructor_name : String
-  field_number : Int
   json_name : String
   value_type : String
   value : FieldCodecValue
+  envelope : FieldEnvelopeShape
 } derive(Eq, Debug)
 
 ///|
@@ -242,7 +264,11 @@ pub fn Field::is_packable_scalar(self : Field) -> Bool {
 
 ///|
 pub fn Field::is_message(self : Field) -> Bool {
-  return self.desc.type_ is Some(FieldDescriptorProto_Type::TYPE_MESSAGE)
+  return self.desc.type_
+    is Some(
+      FieldDescriptorProto_Type::TYPE_MESSAGE
+      | FieldDescriptorProto_Type::TYPE_GROUP
+    )
 }
 
 ///|

--- a/cli/model_imports.mbt
+++ b/cli/model_imports.mbt
@@ -10,6 +10,7 @@ using @model {
   type FieldCodecReadMode,
   type FieldCodecShape,
   type FieldCodecValue,
+  type FieldEnvelopeShape,
   type FieldJsonCardinality,
   type FieldJsonShape,
   type FieldStorageShape,

--- a/cli/oneof_shape.mbt
+++ b/cli/oneof_shape.mbt
@@ -49,20 +49,16 @@ fn CodeGenerator::gen_oneof_codec_write(
   content.write_string("  match self.\{shape.field_name} {\n")
   for field in shape.fields {
     let field_write = field.value.write_expr(field.envelope, "v", is_async~)
-    let tag_write = if field.envelope.writes_own_field_tags() {
-      ""
-    } else {
-      "      writer |> @lib.\{async_keyword_to_snake}write_varint(\{field.envelope.tag_value()}UL)\n"
-    }
     content.write_string(
-      (
-        $|    \{shape.enum_name}::\{field.constructor_name}(v) => {
-        $|\{tag_write}
-        $|      \{field_write}
-        $|     }
-        $|
-      ),
+      "    \{shape.enum_name}::\{field.constructor_name}(v) => {\n",
     )
+    if !field.envelope.writes_own_field_tags() {
+      content.write_string(
+        "      writer |> @lib.\{async_keyword_to_snake}write_varint(\{field.envelope.tag_value()}UL)\n",
+      )
+    }
+    content.write_string("      \{field_write}\n")
+    content.write_string("     }\n")
   }
   content.write_string(
     (

--- a/cli/oneof_shape.mbt
+++ b/cli/oneof_shape.mbt
@@ -9,10 +9,10 @@ fn CodeGenerator::oneof_shape(
   for field in oneof.field {
     let field_shape : OneofFieldShape = {
       constructor_name: field.import_path.name() |> to_camel_case,
-      field_number: field.number.unwrap(),
       json_name: field.json_name.unwrap(),
       value_type: self.get_moonbit_type(field, parent_path=message.import_path),
       value: self.field_codec_value(field, message.import_path),
+      envelope: self.field_envelope_shape(field),
     }
     fields.push(field_shape)
   }
@@ -24,11 +24,6 @@ fn CodeGenerator::oneof_shape(
 }
 
 ///|
-fn OneofFieldShape::tag_value(self : OneofFieldShape) -> UInt64 {
-  tag(self.value.type_, self.field_number, false)
-}
-
-///|
 fn CodeGenerator::gen_oneof_codec_read(
   _ : CodeGenerator,
   shape : OneofShape,
@@ -37,7 +32,7 @@ fn CodeGenerator::gen_oneof_codec_read(
 ) -> Unit raise {
   for field in shape.fields {
     content.write_string(
-      "      (\{field.field_number}, _) => msg.\{shape.field_name} = \{field.value.read_expr(is_async~)} |> \{shape.enum_name}::\{field.constructor_name}\n",
+      "      (\{field.envelope.field_number}, \{field.envelope.read_wire_pattern(field.value)}) => msg.\{shape.field_name} = \{field.value.read_expr(field.envelope, is_async~)} |> \{shape.enum_name}::\{field.constructor_name}\n",
     )
   }
 }
@@ -53,11 +48,16 @@ fn CodeGenerator::gen_oneof_codec_write(
   let async_keyword_to_snake = async_keyword |> pascal_to_snake
   content.write_string("  match self.\{shape.field_name} {\n")
   for field in shape.fields {
-    let field_write = field.value.write_expr("v", is_async~)
+    let field_write = field.value.write_expr(field.envelope, "v", is_async~)
+    let tag_write = if field.envelope.writes_own_field_tags() {
+      ""
+    } else {
+      "      writer |> @lib.\{async_keyword_to_snake}write_varint(\{field.envelope.tag_value()}UL)\n"
+    }
     content.write_string(
       (
         $|    \{shape.enum_name}::\{field.constructor_name}(v) => {
-        $|      writer |> @lib.\{async_keyword_to_snake}write_varint(\{field.tag_value()}UL)
+        $|\{tag_write}
         $|      \{field_write}
         $|     }
         $|
@@ -81,10 +81,7 @@ fn CodeGenerator::gen_oneof_codec_size(
 ) -> Unit {
   content.write_string("  match self.\{shape.field_name} {\n")
   for field in shape.fields {
-    let (delta_size, need_v) = field.value.unpacked_size_expr(
-      "v",
-      field.field_number,
-    )
+    let (delta_size, need_v) = field.value.field_size_expr(field.envelope, "v")
     let value_binding = if need_v { "v" } else { "_" }
     content.write_string(
       (

--- a/cli/reader_template.mbt
+++ b/cli/reader_template.mbt
@@ -41,7 +41,7 @@ fn CodeGenerator::gen_message_reader(
   }
   content.write_string(
     (
-      $|      _ => reader |> @lib.\{async_keyword_to_snake}skip_message_field(wire)
+      $|      _ => reader |> @lib.\{async_keyword_to_snake}skip_message_field_by_number(field_number, wire)
       $|    }
       $|  }
       $|  msg

--- a/cli/utils.mbt
+++ b/cli/utils.mbt
@@ -188,37 +188,6 @@ fn encode_tag(num : Int, typ : Int) -> UInt64 {
 }
 
 ///|
-fn tag(
-  kind : FieldDescriptorProto_Type,
-  number : Int,
-  is_packed : Bool,
-) -> UInt64 {
-  if is_packed {
-    return encode_tag(number, 2) // BytesType
-  }
-  match kind {
-    FieldDescriptorProto_Type::TYPE_BOOL
-    | FieldDescriptorProto_Type::TYPE_ENUM
-    | FieldDescriptorProto_Type::TYPE_INT32
-    | FieldDescriptorProto_Type::TYPE_INT64
-    | FieldDescriptorProto_Type::TYPE_SINT32
-    | FieldDescriptorProto_Type::TYPE_SINT64
-    | FieldDescriptorProto_Type::TYPE_UINT32
-    | FieldDescriptorProto_Type::TYPE_UINT64 => encode_tag(number, 0) // VarintType
-    FieldDescriptorProto_Type::TYPE_FIXED32
-    | FieldDescriptorProto_Type::TYPE_SFIXED32
-    | FieldDescriptorProto_Type::TYPE_FLOAT => encode_tag(number, 5) // Fixed32Type
-    FieldDescriptorProto_Type::TYPE_FIXED64
-    | FieldDescriptorProto_Type::TYPE_SFIXED64
-    | FieldDescriptorProto_Type::TYPE_DOUBLE => encode_tag(number, 1) // Fixed64Type
-    FieldDescriptorProto_Type::TYPE_STRING
-    | FieldDescriptorProto_Type::TYPE_BYTES
-    | FieldDescriptorProto_Type::TYPE_MESSAGE => encode_tag(number, 2) // BytesType
-    _ => panic()
-  }
-}
-
-///|
 test "pascal_to_snake" {
   inspect(pascal_to_snake("PascalCase"), content="pascal_case")
   inspect(pascal_to_snake("SimpleWord"), content="simple_word")

--- a/cli/wire_type.mbt
+++ b/cli/wire_type.mbt
@@ -1,0 +1,30 @@
+///|
+const WIRE_TYPE_VARINT = 0
+
+///|
+const WIRE_TYPE_FIXED64 = 1
+
+///|
+const WIRE_TYPE_LENGTH_DELIMITED = 2
+
+///|
+const WIRE_TYPE_START_GROUP = 3
+
+///|
+const WIRE_TYPE_END_GROUP = 4
+
+///|
+const WIRE_TYPE_FIXED32 = 5
+
+///|
+fn runtime_wire_type_const(wire_type : Int) -> String raise {
+  match wire_type {
+    WIRE_TYPE_VARINT => "@lib.WIRE_TYPE_VARINT"
+    WIRE_TYPE_FIXED64 => "@lib.WIRE_TYPE_FIXED64"
+    WIRE_TYPE_LENGTH_DELIMITED => "@lib.WIRE_TYPE_LENGTH_DELIMITED"
+    WIRE_TYPE_START_GROUP => "@lib.WIRE_TYPE_START_GROUP"
+    WIRE_TYPE_END_GROUP => "@lib.WIRE_TYPE_END_GROUP"
+    WIRE_TYPE_FIXED32 => "@lib.WIRE_TYPE_FIXED32"
+    _ => raise @model.UnexpectedType("unknown wire type \{wire_type}")
+  }
+}

--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -206,7 +206,20 @@ pub async fn[M : AsyncRead + Default] async_read_message(
         None
       }
       reader.limit = Some(len)
-      let msg = reader |> M::read_with_limit()
+      let previous_end_group = reader.end_group
+      let previous_end_group_seen = reader.end_group_seen
+      reader.end_group = None
+      reader.end_group_seen = false
+      let msg = try reader |> M::read_with_limit() catch {
+        err => {
+          reader.limit = new_limit
+          reader.end_group = previous_end_group
+          reader.end_group_seen = previous_end_group_seen
+          raise err
+        }
+      }
+      reader.end_group = previous_end_group
+      reader.end_group_seen = previous_end_group_seen
       reader.limit = new_limit
       msg
     }
@@ -214,10 +227,49 @@ pub async fn[M : AsyncRead + Default] async_read_message(
 }
 
 ///|
+pub async fn[M : AsyncRead] async_read_delimited_message(
+  reader : LimitedReader[&AsyncReader],
+  field_number : UInt,
+) -> M {
+  let previous_end_group = reader.end_group
+  let previous_end_group_seen = reader.end_group_seen
+  reader.end_group = Some(field_number)
+  reader.end_group_seen = false
+  let msg = try reader |> M::read_with_limit() catch {
+    err => {
+      reader.end_group = previous_end_group
+      reader.end_group_seen = previous_end_group_seen
+      raise err
+    }
+  }
+  let end_group_seen = reader.end_group_seen
+  reader.end_group = previous_end_group
+  reader.end_group_seen = previous_end_group_seen
+  if !end_group_seen {
+    raise EndOfStream
+  }
+  msg
+}
+
+///|
 pub async fn[R : AsyncReader] async_read_next_message_field(
   reader : LimitedReader[R],
 ) -> (UInt, UInt)? {
-  Some(reader |> async_read_tag()) catch {
+  Some(
+    {
+      let (field_number, wire) = reader |> async_read_tag()
+      if wire == 4 {
+        match reader.end_group {
+          Some(end_group) if field_number == end_group => {
+            reader.end_group_seen = true
+            return None
+          }
+          _ => raise ReaderError::UnknownWireType(wire)
+        }
+      }
+      (field_number, wire)
+    },
+  ) catch {
     EndOfStream => None
     err => raise err
   }
@@ -271,9 +323,42 @@ pub async fn[T : AsyncReader] async_read_unknown(
 }
 
 ///|
+async fn[T : AsyncReader] async_read_unknown_field(
+  reader : T,
+  field_number : UInt,
+  wire_type : UInt,
+) -> Unit {
+  match wire_type {
+    3 =>
+      while true {
+        let (nested_field_number, nested_wire_type) = reader |> async_read_tag()
+        if nested_wire_type == 4 {
+          if nested_field_number == field_number {
+            return
+          }
+          raise ReaderError::UnknownWireType(nested_wire_type)
+        }
+        reader
+        |> async_read_unknown_field(nested_field_number, nested_wire_type)
+      }
+    4 => raise ReaderError::UnknownWireType(wire_type)
+    _ => reader |> async_read_unknown(wire_type)
+  }
+}
+
+///|
 pub async fn[T : AsyncReader] async_skip_message_field(
   reader : T,
   wire_type : UInt,
 ) -> Unit {
   reader |> async_read_unknown(wire_type)
+}
+
+///|
+pub async fn[T : AsyncReader] async_skip_message_field_by_number(
+  reader : T,
+  field_number : UInt,
+  wire_type : UInt,
+) -> Unit {
+  reader |> async_read_unknown_field(field_number, wire_type)
 }

--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -187,6 +187,7 @@ pub async fn[T : AsyncReader] async_read_string(reader : T) -> String {
 }
 
 ///|
+/// Reads a length-delimited embedded message after its size prefix.
 pub async fn[M : AsyncRead + Default] async_read_message(
   reader : LimitedReader[&AsyncReader],
 ) -> M {
@@ -227,6 +228,11 @@ pub async fn[M : AsyncRead + Default] async_read_message(
 }
 
 ///|
+/// Reads a delimited message payload after its start-group tag has already
+/// been consumed, then consumes the matching end-group tag for `field_number`.
+///
+/// This helper is used by generated code for proto2 groups and Editions
+/// `features.message_encoding = DELIMITED`.
 pub async fn[M : AsyncRead] async_read_delimited_message(
   reader : LimitedReader[&AsyncReader],
   field_number : UInt,
@@ -235,7 +241,13 @@ pub async fn[M : AsyncRead] async_read_delimited_message(
   let previous_end_group_seen = reader.end_group_seen
   reader.end_group = Some(field_number)
   reader.end_group_seen = false
-  let msg = try reader |> M::read_with_limit() catch {
+  let msg = try {
+    let msg = reader |> M::read_with_limit()
+    if !reader.end_group_seen {
+      reader |> async_read_delimited_message_tail(field_number)
+    }
+    msg
+  } catch {
     err => {
       reader.end_group = previous_end_group
       reader.end_group_seen = previous_end_group_seen
@@ -252,6 +264,37 @@ pub async fn[M : AsyncRead] async_read_delimited_message(
 }
 
 ///|
+async fn[T : AsyncReader] async_read_delimited_message_tail(
+  reader : LimitedReader[T],
+  field_number : UInt,
+) -> Unit {
+  while !reader.end_group_seen {
+    let next = Some(reader |> async_read_tag()) catch {
+      EndOfStream => None
+      err => raise err
+    }
+    match next {
+      Some((nested_field_number, 4)) =>
+        if nested_field_number == field_number {
+          reader.end_group_seen = true
+        } else {
+          raise ReaderError::UnknownWireType(4)
+        }
+      Some((nested_field_number, nested_wire_type)) =>
+        reader
+        |> async_skip_message_field_by_number(
+          nested_field_number, nested_wire_type,
+        )
+      None => break
+    }
+  }
+}
+
+///|
+/// Reads the next field number and wire type within a message body.
+///
+/// Returns `None` at the end of a length-delimited message or after consuming
+/// the matching end-group tag for a delimited message.
 pub async fn[R : AsyncReader] async_read_next_message_field(
   reader : LimitedReader[R],
 ) -> (UInt, UInt)? {
@@ -309,6 +352,11 @@ pub async fn[M : Sized, R : AsyncReader] async_read_packed(
 }
 
 ///|
+/// Skips an unknown non-group field payload by wire type.
+///
+/// Use `async_skip_message_field_by_number` while parsing message bodies so
+/// unknown group fields can be skipped with their matching end-group field
+/// number.
 pub async fn[T : AsyncReader] async_read_unknown(
   reader : T,
   wire_type : UInt,
@@ -347,6 +395,10 @@ async fn[T : AsyncReader] async_read_unknown_field(
 }
 
 ///|
+/// Skips an unknown non-group message field by wire type.
+///
+/// This legacy helper cannot skip wire type 3 groups because the matching
+/// end-group tag requires the field number.
 pub async fn[T : AsyncReader] async_skip_message_field(
   reader : T,
   wire_type : UInt,
@@ -355,6 +407,10 @@ pub async fn[T : AsyncReader] async_skip_message_field(
 }
 
 ///|
+/// Skips an unknown message field by field number and wire type.
+///
+/// Unlike `async_skip_message_field`, this handles wire type 3 groups by
+/// reading nested fields until the matching wire type 4 end-group tag is found.
 pub async fn[T : AsyncReader] async_skip_message_field_by_number(
   reader : T,
   field_number : UInt,

--- a/lib/async_reader.mbt
+++ b/lib/async_reader.mbt
@@ -43,7 +43,7 @@ pub async fn[T : AsyncReader] async_read_tag(reader : T) -> (UInt, UInt) {
   let value = reader |> async_read_varint32()
   let tag = value >> 3
   let wire_type = value & 0x7
-  if wire_type > 5 {
+  if wire_type > WIRE_TYPE_FIXED32 {
     raise ReaderError::UnknownWireType(wire_type)
   }
   (tag, wire_type)
@@ -274,11 +274,11 @@ async fn[T : AsyncReader] async_read_delimited_message_tail(
       err => raise err
     }
     match next {
-      Some((nested_field_number, 4)) =>
+      Some((nested_field_number, WIRE_TYPE_END_GROUP)) =>
         if nested_field_number == field_number {
           reader.end_group_seen = true
         } else {
-          raise ReaderError::UnknownWireType(4)
+          raise ReaderError::UnknownWireType(WIRE_TYPE_END_GROUP)
         }
       Some((nested_field_number, nested_wire_type)) =>
         reader
@@ -301,7 +301,7 @@ pub async fn[R : AsyncReader] async_read_next_message_field(
   Some(
     {
       let (field_number, wire) = reader |> async_read_tag()
-      if wire == 4 {
+      if wire == WIRE_TYPE_END_GROUP {
         match reader.end_group {
           Some(end_group) if field_number == end_group => {
             reader.end_group_seen = true
@@ -362,10 +362,10 @@ pub async fn[T : AsyncReader] async_read_unknown(
   wire_type : UInt,
 ) -> Unit {
   match wire_type {
-    0 => reader |> async_read_varint64() |> ignore
-    1 => reader |> async_read_fixed64() |> ignore
-    2 => reader |> async_read_bytes() |> ignore
-    5 => reader |> async_read_fixed32() |> ignore
+    WIRE_TYPE_VARINT => reader |> async_read_varint64() |> ignore
+    WIRE_TYPE_FIXED64 => reader |> async_read_fixed64() |> ignore
+    WIRE_TYPE_LENGTH_DELIMITED => reader |> async_read_bytes() |> ignore
+    WIRE_TYPE_FIXED32 => reader |> async_read_fixed32() |> ignore
     _ => raise ReaderError::UnknownWireType(wire_type)
   }
 }
@@ -377,10 +377,10 @@ async fn[T : AsyncReader] async_read_unknown_field(
   wire_type : UInt,
 ) -> Unit {
   match wire_type {
-    3 =>
+    WIRE_TYPE_START_GROUP =>
       while true {
         let (nested_field_number, nested_wire_type) = reader |> async_read_tag()
-        if nested_wire_type == 4 {
+        if nested_wire_type == WIRE_TYPE_END_GROUP {
           if nested_field_number == field_number {
             return
           }
@@ -389,7 +389,7 @@ async fn[T : AsyncReader] async_read_unknown_field(
         reader
         |> async_read_unknown_field(nested_field_number, nested_wire_type)
       }
-    4 => raise ReaderError::UnknownWireType(wire_type)
+    WIRE_TYPE_END_GROUP => raise ReaderError::UnknownWireType(wire_type)
     _ => reader |> async_read_unknown(wire_type)
   }
 }
@@ -397,8 +397,8 @@ async fn[T : AsyncReader] async_read_unknown_field(
 ///|
 /// Skips an unknown non-group message field by wire type.
 ///
-/// This legacy helper cannot skip wire type 3 groups because the matching
-/// end-group tag requires the field number.
+/// This legacy helper cannot skip `WIRE_TYPE_START_GROUP` fields because the
+/// matching end-group tag requires the field number.
 pub async fn[T : AsyncReader] async_skip_message_field(
   reader : T,
   wire_type : UInt,
@@ -409,8 +409,9 @@ pub async fn[T : AsyncReader] async_skip_message_field(
 ///|
 /// Skips an unknown message field by field number and wire type.
 ///
-/// Unlike `async_skip_message_field`, this handles wire type 3 groups by
-/// reading nested fields until the matching wire type 4 end-group tag is found.
+/// Unlike `async_skip_message_field`, this handles `WIRE_TYPE_START_GROUP`
+/// fields by reading nested fields until the matching `WIRE_TYPE_END_GROUP`
+/// tag is found.
 pub async fn[T : AsyncReader] async_skip_message_field_by_number(
   reader : T,
   field_number : UInt,

--- a/lib/async_writer.mbt
+++ b/lib/async_writer.mbt
@@ -137,6 +137,7 @@ pub async fn[T : AsyncWriter] async_write_string(
 }
 
 ///|
+/// Writes a length-delimited embedded message with a size prefix.
 pub async fn[M : AsyncWrite + Sized, T : AsyncWriter] async_write_message(
   writer : T,
   message : M,
@@ -146,6 +147,11 @@ pub async fn[M : AsyncWrite + Sized, T : AsyncWriter] async_write_message(
 }
 
 ///|
+/// Writes a delimited message field envelope for `field_number`.
+///
+/// The encoded form is start-group tag, message payload, then the matching
+/// end-group tag. Generated code uses this for proto2 groups and Editions
+/// `features.message_encoding = DELIMITED`.
 pub async fn[M : AsyncWrite, T : AsyncWriter] async_write_delimited_message(
   writer : T,
   field_number : UInt,

--- a/lib/async_writer.mbt
+++ b/lib/async_writer.mbt
@@ -157,7 +157,7 @@ pub async fn[M : AsyncWrite, T : AsyncWriter] async_write_delimited_message(
   field_number : UInt,
   message : M,
 ) -> Unit {
-  writer |> async_write_tag((field_number, 3U))
+  writer |> async_write_tag((field_number, WIRE_TYPE_START_GROUP))
   AsyncWrite::write(message, writer)
-  writer |> async_write_tag((field_number, 4U))
+  writer |> async_write_tag((field_number, WIRE_TYPE_END_GROUP))
 }

--- a/lib/async_writer.mbt
+++ b/lib/async_writer.mbt
@@ -144,3 +144,14 @@ pub async fn[M : AsyncWrite + Sized, T : AsyncWriter] async_write_message(
   writer |> async_write_uint32(size_of(message))
   AsyncWrite::write(message, writer)
 }
+
+///|
+pub async fn[M : AsyncWrite, T : AsyncWriter] async_write_delimited_message(
+  writer : T,
+  field_number : UInt,
+  message : M,
+) -> Unit {
+  writer |> async_write_tag((field_number, 3U))
+  AsyncWrite::write(message, writer)
+  writer |> async_write_tag((field_number, 4U))
+}

--- a/lib/google/protobuf/any.mbt
+++ b/lib/google/protobuf/any.mbt
@@ -35,7 +35,7 @@ pub impl @lib.Read for Any with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.type_url = reader |> @lib.read_string()
       (2, _) => msg.value = reader |> @lib.read_bytes()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -97,7 +97,7 @@ pub impl @lib.AsyncRead for Any with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.type_url = reader |> @lib.async_read_string()
       (2, _) => msg.value = reader |> @lib.async_read_bytes()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/lib/google/protobuf/api.mbt
+++ b/lib/google/protobuf/api.mbt
@@ -85,16 +85,16 @@ pub impl @lib.Read for Api with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
-      (2, _) => msg.methods.push((reader |> @lib.read_message() : Method))
-      (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
+      (2, 2) => msg.methods.push((reader |> @lib.read_message() : Method))
+      (3, 2) => msg.options.push((reader |> @lib.read_message() : Option))
       (4, _) => msg.version = reader |> @lib.read_string()
-      (5, _) =>
+      (5, 2) =>
         msg.source_context = (reader |> @lib.read_message() : SourceContext)
           |> Some
-      (6, _) => msg.mixins.push((reader |> @lib.read_message() : Mixin))
+      (6, 2) => msg.mixins.push((reader |> @lib.read_message() : Mixin))
       (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
       (8, _) => msg.edition = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -205,18 +205,18 @@ pub impl @lib.AsyncRead for Api with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, _) => msg.methods.push((reader |> @lib.async_read_message() : Method))
-      (3, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (2, 2) => msg.methods.push((reader |> @lib.async_read_message() : Method))
+      (3, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
       (4, _) => msg.version = reader |> @lib.async_read_string()
-      (5, _) =>
+      (5, 2) =>
         msg.source_context = (
             reader |> @lib.async_read_message() : SourceContext)
           |> Some
-      (6, _) => msg.mixins.push((reader |> @lib.async_read_message() : Mixin))
+      (6, 2) => msg.mixins.push((reader |> @lib.async_read_message() : Mixin))
       (7, _) =>
         msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
       (8, _) => msg.edition = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -358,10 +358,10 @@ pub impl @lib.Read for Method with fn read_with_limit(
       (3, _) => msg.request_streaming = reader |> @lib.read_bool()
       (4, _) => msg.response_type_url = reader |> @lib.read_string()
       (5, _) => msg.response_streaming = reader |> @lib.read_bool()
-      (6, _) => msg.options.push((reader |> @lib.read_message() : Option))
+      (6, 2) => msg.options.push((reader |> @lib.read_message() : Option))
       (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
       (8, _) => msg.edition = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -479,11 +479,11 @@ pub impl @lib.AsyncRead for Method with fn read_with_limit(
       (3, _) => msg.request_streaming = reader |> @lib.async_read_bool()
       (4, _) => msg.response_type_url = reader |> @lib.async_read_string()
       (5, _) => msg.response_streaming = reader |> @lib.async_read_bool()
-      (6, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (6, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
       (7, _) =>
         msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
       (8, _) => msg.edition = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -565,7 +565,7 @@ pub impl @lib.Read for Mixin with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.root = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -624,7 +624,7 @@ pub impl @lib.AsyncRead for Mixin with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.root = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/lib/google/protobuf/api.mbt
+++ b/lib/google/protobuf/api.mbt
@@ -85,13 +85,16 @@ pub impl @lib.Read for Api with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
-      (2, 2) => msg.methods.push((reader |> @lib.read_message() : Method))
-      (3, 2) => msg.options.push((reader |> @lib.read_message() : Option))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.methods.push((reader |> @lib.read_message() : Method))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.read_message() : Option))
       (4, _) => msg.version = reader |> @lib.read_string()
-      (5, 2) =>
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.source_context = (reader |> @lib.read_message() : SourceContext)
           |> Some
-      (6, 2) => msg.mixins.push((reader |> @lib.read_message() : Mixin))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.mixins.push((reader |> @lib.read_message() : Mixin))
       (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
       (8, _) => msg.edition = reader |> @lib.read_string()
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -205,14 +208,17 @@ pub impl @lib.AsyncRead for Api with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, 2) => msg.methods.push((reader |> @lib.async_read_message() : Method))
-      (3, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.methods.push((reader |> @lib.async_read_message() : Method))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.async_read_message() : Option))
       (4, _) => msg.version = reader |> @lib.async_read_string()
-      (5, 2) =>
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.source_context = (
             reader |> @lib.async_read_message() : SourceContext)
           |> Some
-      (6, 2) => msg.mixins.push((reader |> @lib.async_read_message() : Mixin))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.mixins.push((reader |> @lib.async_read_message() : Mixin))
       (7, _) =>
         msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
       (8, _) => msg.edition = reader |> @lib.async_read_string()
@@ -358,7 +364,8 @@ pub impl @lib.Read for Method with fn read_with_limit(
       (3, _) => msg.request_streaming = reader |> @lib.read_bool()
       (4, _) => msg.response_type_url = reader |> @lib.read_string()
       (5, _) => msg.response_streaming = reader |> @lib.read_bool()
-      (6, 2) => msg.options.push((reader |> @lib.read_message() : Option))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.read_message() : Option))
       (7, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
       (8, _) => msg.edition = reader |> @lib.read_string()
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -479,7 +486,8 @@ pub impl @lib.AsyncRead for Method with fn read_with_limit(
       (3, _) => msg.request_streaming = reader |> @lib.async_read_bool()
       (4, _) => msg.response_type_url = reader |> @lib.async_read_string()
       (5, _) => msg.response_streaming = reader |> @lib.async_read_bool()
-      (6, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.async_read_message() : Option))
       (7, _) =>
         msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
       (8, _) => msg.edition = reader |> @lib.async_read_string()

--- a/lib/google/protobuf/compiler/top.mbt
+++ b/lib/google/protobuf/compiler/top.mbt
@@ -230,15 +230,15 @@ pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
       (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
-      (15, 2) =>
+      (15, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.proto_file.push(
           (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
         )
-      (17, 2) =>
+      (17, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.source_file_descriptors.push(
           (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
         )
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
@@ -337,15 +337,15 @@ pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.file_to_generate.push(reader |> @lib.async_read_string())
       (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
-      (15, 2) =>
+      (15, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.proto_file.push(
           (reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto),
         )
-      (17, 2) =>
+      (17, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.source_file_descriptors.push(
           (reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto),
         )
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.compiler_version = (reader |> @lib.async_read_message() : Version)
           |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -518,7 +518,7 @@ pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
       (15, _) => msg.content = reader |> @lib.read_string() |> Some
-      (16, 2) =>
+      (16, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.generated_code_info = (
             reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo)
           |> Some
@@ -610,7 +610,7 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.insertion_point = reader |> @lib.async_read_string() |> Some
       (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
-      (16, 2) =>
+      (16, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.generated_code_info = (
             reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo)
           |> Some
@@ -712,7 +712,7 @@ pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(
       (2, _) => msg.supported_features = reader |> @lib.read_uint64() |> Some
       (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
       (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
-      (15, 2) =>
+      (15, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.file.push(
           (reader |> @lib.read_message() : CodeGeneratorResponse_File),
         )
@@ -815,7 +815,7 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(
         msg.supported_features = reader |> @lib.async_read_uint64() |> Some
       (3, _) => msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
       (4, _) => msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
-      (15, 2) =>
+      (15, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.file.push(
           (reader |> @lib.async_read_message() : CodeGeneratorResponse_File),
         )

--- a/lib/google/protobuf/compiler/top.mbt
+++ b/lib/google/protobuf/compiler/top.mbt
@@ -50,7 +50,7 @@ pub impl @lib.Read for Version with fn read_with_limit(
       (2, _) => msg.minor = reader |> @lib.read_int32() |> Some
       (3, _) => msg.patch = reader |> @lib.read_int32() |> Some
       (4, _) => msg.suffix = reader |> @lib.read_string() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -134,7 +134,7 @@ pub impl @lib.AsyncRead for Version with fn read_with_limit(
       (2, _) => msg.minor = reader |> @lib.async_read_int32() |> Some
       (3, _) => msg.patch = reader |> @lib.async_read_int32() |> Some
       (4, _) => msg.suffix = reader |> @lib.async_read_string() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -230,17 +230,17 @@ pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
       (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
-      (15, _) =>
+      (15, 2) =>
         msg.proto_file.push(
           (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
         )
-      (17, _) =>
+      (17, 2) =>
         msg.source_file_descriptors.push(
           (reader |> @lib.read_message() : @protobuf.FileDescriptorProto),
         )
-      (3, _) =>
+      (3, 2) =>
         msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -337,18 +337,18 @@ pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.file_to_generate.push(reader |> @lib.async_read_string())
       (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
-      (15, _) =>
+      (15, 2) =>
         msg.proto_file.push(
           (reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto),
         )
-      (17, _) =>
+      (17, 2) =>
         msg.source_file_descriptors.push(
           (reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto),
         )
-      (3, _) =>
+      (3, 2) =>
         msg.compiler_version = (reader |> @lib.async_read_message() : Version)
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -518,11 +518,11 @@ pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
       (15, _) => msg.content = reader |> @lib.read_string() |> Some
-      (16, _) =>
+      (16, 2) =>
         msg.generated_code_info = (
             reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo)
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -610,11 +610,11 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.insertion_point = reader |> @lib.async_read_string() |> Some
       (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
-      (16, _) =>
+      (16, 2) =>
         msg.generated_code_info = (
             reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo)
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -712,11 +712,11 @@ pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(
       (2, _) => msg.supported_features = reader |> @lib.read_uint64() |> Some
       (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
       (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
-      (15, _) =>
+      (15, 2) =>
         msg.file.push(
           (reader |> @lib.read_message() : CodeGeneratorResponse_File),
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -815,11 +815,11 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(
         msg.supported_features = reader |> @lib.async_read_uint64() |> Some
       (3, _) => msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
       (4, _) => msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
-      (15, _) =>
+      (15, 2) =>
         msg.file.push(
           (reader |> @lib.async_read_message() : CodeGeneratorResponse_File),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/lib/google/protobuf/descriptor.mbt
+++ b/lib/google/protobuf/descriptor.mbt
@@ -215,9 +215,9 @@ pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(
   let msg = FileDescriptorSet::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -272,11 +272,11 @@ pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.file.push(
           (reader |> @lib.async_read_message() : FileDescriptorProto),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -435,29 +435,29 @@ pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(
         )
       (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
       (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
-      (4, _) =>
+      (4, 2) =>
         msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
-      (5, _) =>
+      (5, 2) =>
         msg.enum_type.push(
           (reader |> @lib.read_message() : EnumDescriptorProto),
         )
-      (6, _) =>
+      (6, 2) =>
         msg.service.push(
           (reader |> @lib.read_message() : ServiceDescriptorProto),
         )
-      (7, _) =>
+      (7, 2) =>
         msg.extension.push(
           (reader |> @lib.read_message() : FieldDescriptorProto),
         )
-      (8, _) =>
+      (8, 2) =>
         msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
-      (9, _) =>
+      (9, 2) =>
         msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo)
           |> Some
       (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
       (14, _) =>
         msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -647,26 +647,26 @@ pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(
         )
       (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
       (15, _) => msg.option_dependency.push(reader |> @lib.async_read_string())
-      (4, _) =>
+      (4, 2) =>
         msg.message_type.push(
           (reader |> @lib.async_read_message() : DescriptorProto),
         )
-      (5, _) =>
+      (5, 2) =>
         msg.enum_type.push(
           (reader |> @lib.async_read_message() : EnumDescriptorProto),
         )
-      (6, _) =>
+      (6, 2) =>
         msg.service.push(
           (reader |> @lib.async_read_message() : ServiceDescriptorProto),
         )
-      (7, _) =>
+      (7, 2) =>
         msg.extension.push(
           (reader |> @lib.async_read_message() : FieldDescriptorProto),
         )
-      (8, _) =>
+      (8, 2) =>
         msg.options = (reader |> @lib.async_read_message() : FileOptions)
           |> Some
-      (9, _) =>
+      (9, 2) =>
         msg.source_code_info = (
             reader |> @lib.async_read_message() : SourceCodeInfo)
           |> Some
@@ -676,7 +676,7 @@ pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(
           |> @lib.async_read_enum()
           |> Edition::from_enum
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -790,10 +790,10 @@ pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-      (3, _) =>
+      (3, 2) =>
         msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions)
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -869,11 +869,11 @@ pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_lim
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-      (3, _) =>
+      (3, 2) =>
         msg.options = (
             reader |> @lib.async_read_message() : ExtensionRangeOptions)
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -938,7 +938,7 @@ pub impl @lib.Read for DescriptorProto_ReservedRange with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1004,7 +1004,7 @@ pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with fn read_with_limi
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1133,29 +1133,29 @@ pub impl @lib.Read for DescriptorProto with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) =>
+      (2, 2) =>
         msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
-      (6, _) =>
+      (6, 2) =>
         msg.extension.push(
           (reader |> @lib.read_message() : FieldDescriptorProto),
         )
-      (3, _) =>
+      (3, 2) =>
         msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto))
-      (4, _) =>
+      (4, 2) =>
         msg.enum_type.push(
           (reader |> @lib.read_message() : EnumDescriptorProto),
         )
-      (5, _) =>
+      (5, 2) =>
         msg.extension_range.push(
           (reader |> @lib.read_message() : DescriptorProto_ExtensionRange),
         )
-      (8, _) =>
+      (8, 2) =>
         msg.oneof_decl.push(
           (reader |> @lib.read_message() : OneofDescriptorProto),
         )
-      (7, _) =>
+      (7, 2) =>
         msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
-      (9, _) =>
+      (9, 2) =>
         msg.reserved_range.push(
           (reader |> @lib.read_message() : DescriptorProto_ReservedRange),
         )
@@ -1165,7 +1165,7 @@ pub impl @lib.Read for DescriptorProto with fn read_with_limit(
           |> @lib.read_enum()
           |> SymbolVisibility::from_enum
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1313,34 +1313,34 @@ pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) =>
+      (2, 2) =>
         msg.field.push(
           (reader |> @lib.async_read_message() : FieldDescriptorProto),
         )
-      (6, _) =>
+      (6, 2) =>
         msg.extension.push(
           (reader |> @lib.async_read_message() : FieldDescriptorProto),
         )
-      (3, _) =>
+      (3, 2) =>
         msg.nested_type.push(
           (reader |> @lib.async_read_message() : DescriptorProto),
         )
-      (4, _) =>
+      (4, 2) =>
         msg.enum_type.push(
           (reader |> @lib.async_read_message() : EnumDescriptorProto),
         )
-      (5, _) =>
+      (5, 2) =>
         msg.extension_range.push(
           (reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange),
         )
-      (8, _) =>
+      (8, 2) =>
         msg.oneof_decl.push(
           (reader |> @lib.async_read_message() : OneofDescriptorProto),
         )
-      (7, _) =>
+      (7, 2) =>
         msg.options = (reader |> @lib.async_read_message() : MessageOptions)
           |> Some
-      (9, _) =>
+      (9, 2) =>
         msg.reserved_range.push(
           (reader |> @lib.async_read_message() : DescriptorProto_ReservedRange),
         )
@@ -1350,7 +1350,7 @@ pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(
           |> @lib.async_read_enum()
           |> SymbolVisibility::from_enum
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1544,7 +1544,7 @@ pub impl @lib.Read for ExtensionRangeOptions_Declaration with fn read_with_limit
       (3, _) => msg.type_ = reader |> @lib.read_string() |> Some
       (5, _) => msg.reserved = reader |> @lib.read_bool() |> Some
       (6, _) => msg.repeated = reader |> @lib.read_bool() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1643,7 +1643,7 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with fn read_with_
       (3, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
       (5, _) => msg.reserved = reader |> @lib.async_read_bool() |> Some
       (6, _) => msg.repeated = reader |> @lib.async_read_bool() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1734,22 +1734,22 @@ pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(
   let msg = ExtensionRangeOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
-      (2, _) =>
+      (2, 2) =>
         msg.declaration.push(
           (reader |> @lib.read_message() : ExtensionRangeOptions_Declaration),
         )
-      (50, _) =>
+      (50, 2) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (3, _) =>
         msg.verification = reader
           |> @lib.read_enum()
           |> ExtensionRangeOptions_VerificationState::from_enum
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1834,17 +1834,17 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
-      (2, _) =>
+      (2, 2) =>
         msg.declaration.push(
           (
             reader |> @lib.async_read_message() :
             ExtensionRangeOptions_Declaration),
         )
-      (50, _) =>
+      (50, 2) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
       (3, _) =>
@@ -1852,7 +1852,7 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(
           |> @lib.async_read_enum()
           |> ExtensionRangeOptions_VerificationState::from_enum
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2239,10 +2239,10 @@ pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(
       (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
       (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
       (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
-      (8, _) =>
+      (8, 2) =>
         msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
       (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2411,11 +2411,11 @@ pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(
       (7, _) => msg.default_value = reader |> @lib.async_read_string() |> Some
       (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
       (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
-      (8, _) =>
+      (8, 2) =>
         msg.options = (reader |> @lib.async_read_message() : FieldOptions)
           |> Some
       (17, _) => msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2511,9 +2511,9 @@ pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) =>
+      (2, 2) =>
         msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2579,10 +2579,10 @@ pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) =>
+      (2, 2) =>
         msg.options = (reader |> @lib.async_read_message() : OneofOptions)
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2645,7 +2645,7 @@ pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with fn read_with_l
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2711,7 +2711,7 @@ pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with fn read_w
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2805,13 +2805,13 @@ pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) =>
+      (2, 2) =>
         msg.value.push(
           (reader |> @lib.read_message() : EnumValueDescriptorProto),
         )
-      (3, _) =>
+      (3, 2) =>
         msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
-      (4, _) =>
+      (4, 2) =>
         msg.reserved_range.push(
           (reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange),
         )
@@ -2821,7 +2821,7 @@ pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(
           |> @lib.read_enum()
           |> SymbolVisibility::from_enum
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2924,14 +2924,14 @@ pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) =>
+      (2, 2) =>
         msg.value.push(
           (reader |> @lib.async_read_message() : EnumValueDescriptorProto),
         )
-      (3, _) =>
+      (3, 2) =>
         msg.options = (reader |> @lib.async_read_message() : EnumOptions)
           |> Some
-      (4, _) =>
+      (4, 2) =>
         msg.reserved_range.push(
           (
             reader |> @lib.async_read_message() :
@@ -2943,7 +2943,7 @@ pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(
           |> @lib.async_read_enum()
           |> SymbolVisibility::from_enum
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3025,9 +3025,9 @@ pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.number = reader |> @lib.read_int32() |> Some
-      (3, _) =>
+      (3, 2) =>
         msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3103,10 +3103,10 @@ pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-      (3, _) =>
+      (3, 2) =>
         msg.options = (reader |> @lib.async_read_message() : EnumValueOptions)
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3175,13 +3175,13 @@ pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) =>
+      (2, 2) =>
         msg.method_.push(
           (reader |> @lib.read_message() : MethodDescriptorProto),
         )
-      (3, _) =>
+      (3, 2) =>
         msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3256,14 +3256,14 @@ pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) =>
+      (2, 2) =>
         msg.method_.push(
           (reader |> @lib.async_read_message() : MethodDescriptorProto),
         )
-      (3, _) =>
+      (3, 2) =>
         msg.options = (reader |> @lib.async_read_message() : ServiceOptions)
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3363,11 +3363,11 @@ pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
       (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
-      (4, _) =>
+      (4, 2) =>
         msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
       (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
       (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3475,12 +3475,12 @@ pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
       (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
-      (4, _) =>
+      (4, 2) =>
         msg.options = (reader |> @lib.async_read_message() : MethodOptions)
           |> Some
       (5, _) => msg.client_streaming = reader |> @lib.async_read_bool() |> Some
       (6, _) => msg.server_streaming = reader |> @lib.async_read_bool() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3791,13 +3791,13 @@ pub impl @lib.Read for FileOptions with fn read_with_limit(
       (44, _) =>
         msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
       (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
-      (50, _) =>
+      (50, 2) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4089,14 +4089,14 @@ pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(
       (44, _) =>
         msg.php_metadata_namespace = reader |> @lib.async_read_string() |> Some
       (45, _) => msg.ruby_package = reader |> @lib.async_read_string() |> Some
-      (50, _) =>
+      (50, 2) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4281,13 +4281,13 @@ pub impl @lib.Read for MessageOptions with fn read_with_limit(
         msg.deprecated_legacy_json_field_conflicts = reader
           |> @lib.read_bool()
           |> Some
-      (12, _) =>
+      (12, 2) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4416,14 +4416,14 @@ pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(
         msg.deprecated_legacy_json_field_conflicts = reader
           |> @lib.async_read_bool()
           |> Some
-      (12, _) =>
+      (12, 2) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4841,7 +4841,7 @@ pub impl @lib.Read for FieldOptions_EditionDefault with fn read_with_limit(
       (3, _) =>
         msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
       (2, _) => msg.value = reader |> @lib.read_string() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4912,7 +4912,7 @@ pub impl @lib.AsyncRead for FieldOptions_EditionDefault with fn read_with_limit(
           |> Edition::from_enum
           |> Some
       (2, _) => msg.value = reader |> @lib.async_read_string() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5007,7 +5007,7 @@ pub impl @lib.Read for FieldOptions_FeatureSupport with fn read_with_limit(
           |> @lib.read_enum()
           |> Edition::from_enum
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5110,7 +5110,7 @@ pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with fn read_with_limit(
           |> @lib.async_read_enum()
           |> Edition::from_enum
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5298,21 +5298,21 @@ pub impl @lib.Read for FieldOptions with fn read_with_limit(
         msg.targets.push(
           reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum,
         )
-      (20, _) =>
+      (20, 2) =>
         msg.edition_defaults.push(
           (reader |> @lib.read_message() : FieldOptions_EditionDefault),
         )
-      (21, _) =>
+      (21, 2) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (22, _) =>
+      (22, 2) =>
         msg.feature_support = (
             reader |> @lib.read_message() : FieldOptions_FeatureSupport)
           |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5523,22 +5523,22 @@ pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(
           |> @lib.async_read_enum()
           |> FieldOptions_OptionTargetType::from_enum,
         )
-      (20, _) =>
+      (20, 2) =>
         msg.edition_defaults.push(
           (reader |> @lib.async_read_message() : FieldOptions_EditionDefault),
         )
-      (21, _) =>
+      (21, 2) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (22, _) =>
+      (22, 2) =>
         msg.feature_support = (
             reader |> @lib.async_read_message() : FieldOptions_FeatureSupport)
           |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5645,13 +5645,13 @@ pub impl @lib.Read for OneofOptions with fn read_with_limit(
   let msg = OneofOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5714,14 +5714,14 @@ pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5813,13 +5813,13 @@ pub impl @lib.Read for EnumOptions with fn read_with_limit(
         msg.deprecated_legacy_json_field_conflicts = reader
           |> @lib.read_bool()
           |> Some
-      (7, _) =>
+      (7, 2) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5920,14 +5920,14 @@ pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(
         msg.deprecated_legacy_json_field_conflicts = reader
           |> @lib.async_read_bool()
           |> Some
-      (7, _) =>
+      (7, 2) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6026,18 +6026,18 @@ pub impl @lib.Read for EnumValueOptions with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (2, _) =>
+      (2, 2) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-      (4, _) =>
+      (4, 2) =>
         msg.feature_support = (
             reader |> @lib.read_message() : FieldOptions_FeatureSupport)
           |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6133,19 +6133,19 @@ pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (2, _) =>
+      (2, 2) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
       (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-      (4, _) =>
+      (4, 2) =>
         msg.feature_support = (
             reader |> @lib.async_read_message() : FieldOptions_FeatureSupport)
           |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6225,14 +6225,14 @@ pub impl @lib.Read for ServiceOptions with fn read_with_limit(
   let msg = ServiceOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (34, _) =>
+      (34, 2) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6305,15 +6305,15 @@ pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (34, _) =>
+      (34, 2) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
       (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6475,13 +6475,13 @@ pub impl @lib.Read for MethodOptions with fn read_with_limit(
           |> @lib.read_enum()
           |> MethodOptions_IdempotencyLevel::from_enum
           |> Some
-      (35, _) =>
+      (35, 2) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6571,14 +6571,14 @@ pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(
           |> @lib.async_read_enum()
           |> MethodOptions_IdempotencyLevel::from_enum
           |> Some
-      (35, _) =>
+      (35, 2) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (999, _) =>
+      (999, 2) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6646,7 +6646,7 @@ pub impl @lib.Read for UninterpretedOption_NamePart with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.name_part = reader |> @lib.read_string()
       (2, _) => msg.is_extension = reader |> @lib.read_bool()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6707,7 +6707,7 @@ pub impl @lib.AsyncRead for UninterpretedOption_NamePart with fn read_with_limit
     match (field_number, wire) {
       (1, _) => msg.name_part = reader |> @lib.async_read_string()
       (2, _) => msg.is_extension = reader |> @lib.async_read_bool()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6803,7 +6803,7 @@ pub impl @lib.Read for UninterpretedOption with fn read_with_limit(
   let msg = UninterpretedOption::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (2, _) =>
+      (2, 2) =>
         msg.name.push(
           (reader |> @lib.read_message() : UninterpretedOption_NamePart),
         )
@@ -6813,7 +6813,7 @@ pub impl @lib.Read for UninterpretedOption with fn read_with_limit(
       (6, _) => msg.double_value = reader |> @lib.read_double() |> Some
       (7, _) => msg.string_value = reader |> @lib.read_bytes() |> Some
       (8, _) => msg.aggregate_value = reader |> @lib.read_string() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6932,7 +6932,7 @@ pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (2, _) =>
+      (2, 2) =>
         msg.name.push(
           (reader |> @lib.async_read_message() : UninterpretedOption_NamePart),
         )
@@ -6945,7 +6945,7 @@ pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(
       (6, _) => msg.double_value = reader |> @lib.async_read_double() |> Some
       (7, _) => msg.string_value = reader |> @lib.async_read_bytes() |> Some
       (8, _) => msg.aggregate_value = reader |> @lib.async_read_string() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -7776,7 +7776,7 @@ pub impl @lib.Read for FeatureSet with fn read_with_limit(
           |> @lib.read_enum()
           |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -7940,7 +7940,7 @@ pub impl @lib.AsyncRead for FeatureSet with fn read_with_limit(
           |> @lib.async_read_enum()
           |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -8040,13 +8040,13 @@ pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_
     match (field_number, wire) {
       (3, _) =>
         msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      (4, _) =>
+      (4, 2) =>
         msg.overridable_features = (reader |> @lib.read_message() : FeatureSet)
           |> Some
-      (5, _) =>
+      (5, 2) =>
         msg.fixed_features = (reader |> @lib.read_message() : FeatureSet)
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -8131,14 +8131,14 @@ pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn 
           |> @lib.async_read_enum()
           |> Edition::from_enum
           |> Some
-      (4, _) =>
+      (4, 2) =>
         msg.overridable_features = (
             reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (5, _) =>
+      (5, 2) =>
         msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -8210,7 +8210,7 @@ pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(
   let msg = FeatureSetDefaults::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.defaults.push(
           (
             reader |> @lib.read_message() :
@@ -8226,7 +8226,7 @@ pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(
           |> @lib.read_enum()
           |> Edition::from_enum
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -8301,7 +8301,7 @@ pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.defaults.push(
           (
             reader |> @lib.async_read_message() :
@@ -8317,7 +8317,7 @@ pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(
           |> @lib.async_read_enum()
           |> Edition::from_enum
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -8426,7 +8426,7 @@ pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(
       (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
       (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
       (6, _) => msg.leading_detached_comments.push(reader |> @lib.read_string())
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -8545,7 +8545,7 @@ pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(
         msg.trailing_comments = reader |> @lib.async_read_string() |> Some
       (6, _) =>
         msg.leading_detached_comments.push(reader |> @lib.async_read_string())
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -8619,11 +8619,11 @@ pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(
   let msg = SourceCodeInfo::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.location.push(
           (reader |> @lib.read_message() : SourceCodeInfo_Location),
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -8676,11 +8676,11 @@ pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.location.push(
           (reader |> @lib.async_read_message() : SourceCodeInfo_Location),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -8844,7 +8844,7 @@ pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(
           |> @lib.read_enum()
           |> GeneratedCodeInfo_Annotation_Semantic::from_enum
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -8954,7 +8954,7 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit
           |> @lib.async_read_enum()
           |> GeneratedCodeInfo_Annotation_Semantic::from_enum
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -9024,11 +9024,11 @@ pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(
   let msg = GeneratedCodeInfo::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.annotation.push(
           (reader |> @lib.read_message() : GeneratedCodeInfo_Annotation),
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -9083,11 +9083,11 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.annotation.push(
           (reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/lib/google/protobuf/descriptor.mbt
+++ b/lib/google/protobuf/descriptor.mbt
@@ -215,7 +215,7 @@ pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(
   let msg = FileDescriptorSet::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
@@ -272,7 +272,7 @@ pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.file.push(
           (reader |> @lib.async_read_message() : FileDescriptorProto),
         )
@@ -424,34 +424,36 @@ pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
       (3, _) => msg.dependency.push(reader |> @lib.read_string())
-      (10, 2) =>
+      (10, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.public_dependency.push_iter(
           (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
         )
-      (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
-      (11, 2) =>
+      (10, @lib.WIRE_TYPE_VARINT) =>
+        msg.public_dependency.push(reader |> @lib.read_int32())
+      (11, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.weak_dependency.push_iter(
           (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
         )
-      (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
+      (11, @lib.WIRE_TYPE_VARINT) =>
+        msg.weak_dependency.push(reader |> @lib.read_int32())
       (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
-      (5, 2) =>
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.enum_type.push(
           (reader |> @lib.read_message() : EnumDescriptorProto),
         )
-      (6, 2) =>
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.service.push(
           (reader |> @lib.read_message() : ServiceDescriptorProto),
         )
-      (7, 2) =>
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.extension.push(
           (reader |> @lib.read_message() : FieldDescriptorProto),
         )
-      (8, 2) =>
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
-      (9, 2) =>
+      (9, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo)
           |> Some
       (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
@@ -636,37 +638,39 @@ pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
       (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
-      (10, 2) =>
+      (10, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.public_dependency.push_iter(
           (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
         )
-      (10, 0) => msg.public_dependency.push(reader |> @lib.async_read_int32())
-      (11, 2) =>
+      (10, @lib.WIRE_TYPE_VARINT) =>
+        msg.public_dependency.push(reader |> @lib.async_read_int32())
+      (11, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.weak_dependency.push_iter(
           (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
         )
-      (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
+      (11, @lib.WIRE_TYPE_VARINT) =>
+        msg.weak_dependency.push(reader |> @lib.async_read_int32())
       (15, _) => msg.option_dependency.push(reader |> @lib.async_read_string())
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.message_type.push(
           (reader |> @lib.async_read_message() : DescriptorProto),
         )
-      (5, 2) =>
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.enum_type.push(
           (reader |> @lib.async_read_message() : EnumDescriptorProto),
         )
-      (6, 2) =>
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.service.push(
           (reader |> @lib.async_read_message() : ServiceDescriptorProto),
         )
-      (7, 2) =>
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.extension.push(
           (reader |> @lib.async_read_message() : FieldDescriptorProto),
         )
-      (8, 2) =>
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.async_read_message() : FileOptions)
           |> Some
-      (9, 2) =>
+      (9, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.source_code_info = (
             reader |> @lib.async_read_message() : SourceCodeInfo)
           |> Some
@@ -790,7 +794,7 @@ pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions)
           |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -869,7 +873,7 @@ pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_lim
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (
             reader |> @lib.async_read_message() : ExtensionRangeOptions)
           |> Some
@@ -1133,29 +1137,29 @@ pub impl @lib.Read for DescriptorProto with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
-      (6, 2) =>
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.extension.push(
           (reader |> @lib.read_message() : FieldDescriptorProto),
         )
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto))
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.enum_type.push(
           (reader |> @lib.read_message() : EnumDescriptorProto),
         )
-      (5, 2) =>
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.extension_range.push(
           (reader |> @lib.read_message() : DescriptorProto_ExtensionRange),
         )
-      (8, 2) =>
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.oneof_decl.push(
           (reader |> @lib.read_message() : OneofDescriptorProto),
         )
-      (7, 2) =>
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
-      (9, 2) =>
+      (9, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.reserved_range.push(
           (reader |> @lib.read_message() : DescriptorProto_ReservedRange),
         )
@@ -1313,34 +1317,34 @@ pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.field.push(
           (reader |> @lib.async_read_message() : FieldDescriptorProto),
         )
-      (6, 2) =>
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.extension.push(
           (reader |> @lib.async_read_message() : FieldDescriptorProto),
         )
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.nested_type.push(
           (reader |> @lib.async_read_message() : DescriptorProto),
         )
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.enum_type.push(
           (reader |> @lib.async_read_message() : EnumDescriptorProto),
         )
-      (5, 2) =>
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.extension_range.push(
           (reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange),
         )
-      (8, 2) =>
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.oneof_decl.push(
           (reader |> @lib.async_read_message() : OneofDescriptorProto),
         )
-      (7, 2) =>
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.async_read_message() : MessageOptions)
           |> Some
-      (9, 2) =>
+      (9, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.reserved_range.push(
           (reader |> @lib.async_read_message() : DescriptorProto_ReservedRange),
         )
@@ -1734,15 +1738,15 @@ pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(
   let msg = ExtensionRangeOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.declaration.push(
           (reader |> @lib.read_message() : ExtensionRangeOptions_Declaration),
         )
-      (50, 2) =>
+      (50, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (3, _) =>
         msg.verification = reader
@@ -1834,17 +1838,17 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.declaration.push(
           (
             reader |> @lib.async_read_message() :
             ExtensionRangeOptions_Declaration),
         )
-      (50, 2) =>
+      (50, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
       (3, _) =>
@@ -2239,7 +2243,7 @@ pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(
       (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
       (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
       (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
-      (8, 2) =>
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
       (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -2411,7 +2415,7 @@ pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(
       (7, _) => msg.default_value = reader |> @lib.async_read_string() |> Some
       (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
       (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
-      (8, 2) =>
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.async_read_message() : FieldOptions)
           |> Some
       (17, _) => msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
@@ -2511,7 +2515,7 @@ pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
@@ -2579,7 +2583,7 @@ pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.async_read_message() : OneofOptions)
           |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -2805,13 +2809,13 @@ pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.value.push(
           (reader |> @lib.read_message() : EnumValueDescriptorProto),
         )
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.reserved_range.push(
           (reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange),
         )
@@ -2924,14 +2928,14 @@ pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.value.push(
           (reader |> @lib.async_read_message() : EnumValueDescriptorProto),
         )
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.async_read_message() : EnumOptions)
           |> Some
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.reserved_range.push(
           (
             reader |> @lib.async_read_message() :
@@ -3025,7 +3029,7 @@ pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.number = reader |> @lib.read_int32() |> Some
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
@@ -3103,7 +3107,7 @@ pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.async_read_message() : EnumValueOptions)
           |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -3175,11 +3179,11 @@ pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.method_.push(
           (reader |> @lib.read_message() : MethodDescriptorProto),
         )
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
@@ -3256,11 +3260,11 @@ pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.method_.push(
           (reader |> @lib.async_read_message() : MethodDescriptorProto),
         )
-      (3, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.async_read_message() : ServiceOptions)
           |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -3363,7 +3367,7 @@ pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
       (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
       (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
       (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
@@ -3475,7 +3479,7 @@ pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
       (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.options = (reader |> @lib.async_read_message() : MethodOptions)
           |> Some
       (5, _) => msg.client_streaming = reader |> @lib.async_read_bool() |> Some
@@ -3791,9 +3795,9 @@ pub impl @lib.Read for FileOptions with fn read_with_limit(
       (44, _) =>
         msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
       (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
-      (50, 2) =>
+      (50, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
@@ -4089,10 +4093,10 @@ pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(
       (44, _) =>
         msg.php_metadata_namespace = reader |> @lib.async_read_string() |> Some
       (45, _) => msg.ruby_package = reader |> @lib.async_read_string() |> Some
-      (50, 2) =>
+      (50, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
@@ -4281,9 +4285,9 @@ pub impl @lib.Read for MessageOptions with fn read_with_limit(
         msg.deprecated_legacy_json_field_conflicts = reader
           |> @lib.read_bool()
           |> Some
-      (12, 2) =>
+      (12, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
@@ -4416,10 +4420,10 @@ pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(
         msg.deprecated_legacy_json_field_conflicts = reader
           |> @lib.async_read_bool()
           |> Some
-      (12, 2) =>
+      (12, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
@@ -5288,27 +5292,27 @@ pub impl @lib.Read for FieldOptions with fn read_with_limit(
           |> @lib.read_enum()
           |> FieldOptions_OptionRetention::from_enum
           |> Some
-      (19, 2) => {
+      (19, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let packed = reader |> @lib.read_packed(@lib.read_enum, None)
         for item in packed {
           msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
         }
       }
-      (19, 0) =>
+      (19, @lib.WIRE_TYPE_VARINT) =>
         msg.targets.push(
           reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum,
         )
-      (20, 2) =>
+      (20, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.edition_defaults.push(
           (reader |> @lib.read_message() : FieldOptions_EditionDefault),
         )
-      (21, 2) =>
+      (21, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (22, 2) =>
+      (22, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.feature_support = (
             reader |> @lib.read_message() : FieldOptions_FeatureSupport)
           |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
@@ -5510,31 +5514,31 @@ pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(
           |> @lib.async_read_enum()
           |> FieldOptions_OptionRetention::from_enum
           |> Some
-      (19, 2) => {
+      (19, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let packed = reader
           |> @lib.async_read_packed(@lib.async_read_enum, None)
         for item in packed {
           msg.targets.push(FieldOptions_OptionTargetType::from_enum(item))
         }
       }
-      (19, 0) =>
+      (19, @lib.WIRE_TYPE_VARINT) =>
         msg.targets.push(
           reader
           |> @lib.async_read_enum()
           |> FieldOptions_OptionTargetType::from_enum,
         )
-      (20, 2) =>
+      (20, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.edition_defaults.push(
           (reader |> @lib.async_read_message() : FieldOptions_EditionDefault),
         )
-      (21, 2) =>
+      (21, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (22, 2) =>
+      (22, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.feature_support = (
             reader |> @lib.async_read_message() : FieldOptions_FeatureSupport)
           |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
@@ -5645,9 +5649,9 @@ pub impl @lib.Read for OneofOptions with fn read_with_limit(
   let msg = OneofOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
@@ -5714,10 +5718,10 @@ pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
@@ -5813,9 +5817,9 @@ pub impl @lib.Read for EnumOptions with fn read_with_limit(
         msg.deprecated_legacy_json_field_conflicts = reader
           |> @lib.read_bool()
           |> Some
-      (7, 2) =>
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
@@ -5920,10 +5924,10 @@ pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(
         msg.deprecated_legacy_json_field_conflicts = reader
           |> @lib.async_read_bool()
           |> Some
-      (7, 2) =>
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
@@ -6026,14 +6030,14 @@ pub impl @lib.Read for EnumValueOptions with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.feature_support = (
             reader |> @lib.read_message() : FieldOptions_FeatureSupport)
           |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
@@ -6133,15 +6137,15 @@ pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
       (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.feature_support = (
             reader |> @lib.async_read_message() : FieldOptions_FeatureSupport)
           |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
@@ -6225,10 +6229,10 @@ pub impl @lib.Read for ServiceOptions with fn read_with_limit(
   let msg = ServiceOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (34, 2) =>
+      (34, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
@@ -6305,11 +6309,11 @@ pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (34, 2) =>
+      (34, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
       (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
@@ -6475,9 +6479,9 @@ pub impl @lib.Read for MethodOptions with fn read_with_limit(
           |> @lib.read_enum()
           |> MethodOptions_IdempotencyLevel::from_enum
           |> Some
-      (35, 2) =>
+      (35, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.read_message() : UninterpretedOption),
         )
@@ -6571,10 +6575,10 @@ pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(
           |> @lib.async_read_enum()
           |> MethodOptions_IdempotencyLevel::from_enum
           |> Some
-      (35, 2) =>
+      (35, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (999, 2) =>
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.uninterpreted_option.push(
           (reader |> @lib.async_read_message() : UninterpretedOption),
         )
@@ -6803,7 +6807,7 @@ pub impl @lib.Read for UninterpretedOption with fn read_with_limit(
   let msg = UninterpretedOption::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.name.push(
           (reader |> @lib.read_message() : UninterpretedOption_NamePart),
         )
@@ -6932,7 +6936,7 @@ pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.name.push(
           (reader |> @lib.async_read_message() : UninterpretedOption_NamePart),
         )
@@ -8040,10 +8044,10 @@ pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_
     match (field_number, wire) {
       (3, _) =>
         msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.overridable_features = (reader |> @lib.read_message() : FeatureSet)
           |> Some
-      (5, 2) =>
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.fixed_features = (reader |> @lib.read_message() : FeatureSet)
           |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -8131,11 +8135,11 @@ pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn 
           |> @lib.async_read_enum()
           |> Edition::from_enum
           |> Some
-      (4, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.overridable_features = (
             reader |> @lib.async_read_message() : FeatureSet)
           |> Some
-      (5, 2) =>
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet)
           |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -8210,7 +8214,7 @@ pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(
   let msg = FeatureSetDefaults::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.defaults.push(
           (
             reader |> @lib.read_message() :
@@ -8301,7 +8305,7 @@ pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.defaults.push(
           (
             reader |> @lib.async_read_message() :
@@ -8413,16 +8417,16 @@ pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(
   let msg = SourceCodeInfo_Location::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.path.push_iter(
           (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
         )
-      (1, 0) => msg.path.push(reader |> @lib.read_int32())
-      (2, 2) =>
+      (1, @lib.WIRE_TYPE_VARINT) => msg.path.push(reader |> @lib.read_int32())
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.span.push_iter(
           (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
         )
-      (2, 0) => msg.span.push(reader |> @lib.read_int32())
+      (2, @lib.WIRE_TYPE_VARINT) => msg.span.push(reader |> @lib.read_int32())
       (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
       (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
       (6, _) => msg.leading_detached_comments.push(reader |> @lib.read_string())
@@ -8529,16 +8533,18 @@ pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.path.push_iter(
           (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
         )
-      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
-      (2, 2) =>
+      (1, @lib.WIRE_TYPE_VARINT) =>
+        msg.path.push(reader |> @lib.async_read_int32())
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.span.push_iter(
           (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
         )
-      (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
+      (2, @lib.WIRE_TYPE_VARINT) =>
+        msg.span.push(reader |> @lib.async_read_int32())
       (3, _) =>
         msg.leading_comments = reader |> @lib.async_read_string() |> Some
       (4, _) =>
@@ -8619,7 +8625,7 @@ pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(
   let msg = SourceCodeInfo::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.location.push(
           (reader |> @lib.read_message() : SourceCodeInfo_Location),
         )
@@ -8676,7 +8682,7 @@ pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.location.push(
           (reader |> @lib.async_read_message() : SourceCodeInfo_Location),
         )
@@ -8831,11 +8837,11 @@ pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(
   let msg = GeneratedCodeInfo_Annotation::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.path.push_iter(
           (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
         )
-      (1, 0) => msg.path.push(reader |> @lib.read_int32())
+      (1, @lib.WIRE_TYPE_VARINT) => msg.path.push(reader |> @lib.read_int32())
       (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
       (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
       (4, _) => msg.end = reader |> @lib.read_int32() |> Some
@@ -8941,11 +8947,12 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.path.push_iter(
           (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
         )
-      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+      (1, @lib.WIRE_TYPE_VARINT) =>
+        msg.path.push(reader |> @lib.async_read_int32())
       (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
       (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
       (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
@@ -9024,7 +9031,7 @@ pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(
   let msg = GeneratedCodeInfo::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.annotation.push(
           (reader |> @lib.read_message() : GeneratedCodeInfo_Annotation),
         )
@@ -9083,7 +9090,7 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.annotation.push(
           (reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation),
         )

--- a/lib/google/protobuf/duration.mbt
+++ b/lib/google/protobuf/duration.mbt
@@ -35,7 +35,7 @@ pub impl @lib.Read for Duration with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.seconds = reader |> @lib.read_int64()
       (2, _) => msg.nanos = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -66,7 +66,7 @@ pub impl @lib.AsyncRead for Duration with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.seconds = reader |> @lib.async_read_int64()
       (2, _) => msg.nanos = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/lib/google/protobuf/field_mask.mbt
+++ b/lib/google/protobuf/field_mask.mbt
@@ -30,7 +30,7 @@ pub impl @lib.Read for FieldMask with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.paths.push(reader |> @lib.read_string())
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -84,7 +84,7 @@ pub impl @lib.AsyncRead for FieldMask with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.paths.push(reader |> @lib.async_read_string())
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/lib/google/protobuf/group_skip_test.mbt
+++ b/lib/google/protobuf/group_skip_test.mbt
@@ -1,0 +1,30 @@
+///|
+test "descriptor reader skips unknown group fields" {
+  let source = @lib.BytesReader::from_bytes(b"\x0b\x08\x96\x01\x0c")
+    as &@lib.Reader
+  let message : FileDescriptorSet = @lib.Read::read(source)
+  if !message.file.is_empty() {
+    fail("expected unknown group to be skipped")
+  }
+}
+
+///|
+test "empty delimited message consumes end group" {
+  let source = @lib.BytesReader::from_bytes(b"\x0c\x96\x01") as &@lib.Reader
+  let reader = @lib.LimitedReader::new(source)
+  let _ : Empty = reader |> @lib.read_delimited_message(1U)
+  if (reader |> @lib.read_varint32()) != 150U {
+    fail("expected reader to continue after end group")
+  }
+}
+
+///|
+test "empty delimited message skips unknown payload fields" {
+  let source = @lib.BytesReader::from_bytes(b"\x10\x96\x01\x0c\x96\x01")
+    as &@lib.Reader
+  let reader = @lib.LimitedReader::new(source)
+  let _ : Empty = reader |> @lib.read_delimited_message(1U)
+  if (reader |> @lib.read_varint32()) != 150U {
+    fail("expected reader to continue after unknown group payload")
+  }
+}

--- a/lib/google/protobuf/source_context.mbt
+++ b/lib/google/protobuf/source_context.mbt
@@ -33,7 +33,7 @@ pub impl @lib.Read for SourceContext with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.file_name = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -86,7 +86,7 @@ pub impl @lib.AsyncRead for SourceContext with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.file_name = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/lib/google/protobuf/struct.mbt
+++ b/lib/google/protobuf/struct.mbt
@@ -98,8 +98,8 @@ pub impl @lib.Read for Struct_FieldsEntry with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.read_string()
-      (2, _) => msg.value = (reader |> @lib.read_message() : Value)
-      _ => reader |> @lib.skip_message_field(wire)
+      (2, 2) => msg.value = (reader |> @lib.read_message() : Value)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -160,8 +160,8 @@ pub impl @lib.AsyncRead for Struct_FieldsEntry with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.async_read_string()
-      (2, _) => msg.value = (reader |> @lib.async_read_message() : Value)
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (2, 2) => msg.value = (reader |> @lib.async_read_message() : Value)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -213,11 +213,11 @@ pub impl @lib.Read for Struct with fn read_with_limit(
   let msg = Struct::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => {
+      (1, 2) => {
         let { key, value } = (reader |> @lib.read_message() : Struct_FieldsEntry)
         msg.fields[key] = value
       }
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -238,7 +238,6 @@ pub impl @lib.Write for Struct with fn write(
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
-
     writer |> @lib.write_varint(18UL)
     writer |> @lib.write_message(v)
   }
@@ -279,12 +278,12 @@ pub impl @lib.AsyncRead for Struct with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => {
+      (1, 2) => {
         let { key, value } = (
           reader |> @lib.async_read_message() : Struct_FieldsEntry)
         msg.fields[key] = value
       }
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -305,7 +304,6 @@ pub impl @lib.AsyncWrite for Struct with fn write(
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)
-
     writer |> @lib.async_write_varint(18UL)
     writer |> @lib.async_write_message(v)
   }
@@ -428,13 +426,13 @@ pub impl @lib.Read for Value with fn read_with_limit(
       (3, _) =>
         msg.kind = reader |> @lib.read_string() |> Value_Kind::StringValue
       (4, _) => msg.kind = reader |> @lib.read_bool() |> Value_Kind::BoolValue
-      (5, _) =>
+      (5, 2) =>
         msg.kind = (reader |> @lib.read_message() : Struct)
           |> Value_Kind::StructValue
-      (6, _) =>
+      (6, 2) =>
         msg.kind = (reader |> @lib.read_message() : ListValue)
           |> Value_Kind::ListValue
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -528,13 +526,13 @@ pub impl @lib.AsyncRead for Value with fn read_with_limit(
         msg.kind = reader |> @lib.async_read_string() |> Value_Kind::StringValue
       (4, _) =>
         msg.kind = reader |> @lib.async_read_bool() |> Value_Kind::BoolValue
-      (5, _) =>
+      (5, 2) =>
         msg.kind = (reader |> @lib.async_read_message() : Struct)
           |> Value_Kind::StructValue
-      (6, _) =>
+      (6, 2) =>
         msg.kind = (reader |> @lib.async_read_message() : ListValue)
           |> Value_Kind::ListValue
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -605,8 +603,8 @@ pub impl @lib.Read for ListValue with fn read_with_limit(
   let msg = ListValue::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.values.push((reader |> @lib.read_message() : Value))
-      _ => reader |> @lib.skip_message_field(wire)
+      (1, 2) => msg.values.push((reader |> @lib.read_message() : Value))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -659,8 +657,8 @@ pub impl @lib.AsyncRead for ListValue with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.values.push((reader |> @lib.async_read_message() : Value))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (1, 2) => msg.values.push((reader |> @lib.async_read_message() : Value))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/lib/google/protobuf/struct.mbt
+++ b/lib/google/protobuf/struct.mbt
@@ -98,7 +98,8 @@ pub impl @lib.Read for Struct_FieldsEntry with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.read_string()
-      (2, 2) => msg.value = (reader |> @lib.read_message() : Value)
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.value = (reader |> @lib.read_message() : Value)
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -160,7 +161,8 @@ pub impl @lib.AsyncRead for Struct_FieldsEntry with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.async_read_string()
-      (2, 2) => msg.value = (reader |> @lib.async_read_message() : Value)
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.value = (reader |> @lib.async_read_message() : Value)
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -213,7 +215,7 @@ pub impl @lib.Read for Struct with fn read_with_limit(
   let msg = Struct::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => {
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let { key, value } = (reader |> @lib.read_message() : Struct_FieldsEntry)
         msg.fields[key] = value
       }
@@ -278,7 +280,7 @@ pub impl @lib.AsyncRead for Struct with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => {
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let { key, value } = (
           reader |> @lib.async_read_message() : Struct_FieldsEntry)
         msg.fields[key] = value
@@ -426,10 +428,10 @@ pub impl @lib.Read for Value with fn read_with_limit(
       (3, _) =>
         msg.kind = reader |> @lib.read_string() |> Value_Kind::StringValue
       (4, _) => msg.kind = reader |> @lib.read_bool() |> Value_Kind::BoolValue
-      (5, 2) =>
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.kind = (reader |> @lib.read_message() : Struct)
           |> Value_Kind::StructValue
-      (6, 2) =>
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.kind = (reader |> @lib.read_message() : ListValue)
           |> Value_Kind::ListValue
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -526,10 +528,10 @@ pub impl @lib.AsyncRead for Value with fn read_with_limit(
         msg.kind = reader |> @lib.async_read_string() |> Value_Kind::StringValue
       (4, _) =>
         msg.kind = reader |> @lib.async_read_bool() |> Value_Kind::BoolValue
-      (5, 2) =>
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.kind = (reader |> @lib.async_read_message() : Struct)
           |> Value_Kind::StructValue
-      (6, 2) =>
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.kind = (reader |> @lib.async_read_message() : ListValue)
           |> Value_Kind::ListValue
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -603,7 +605,8 @@ pub impl @lib.Read for ListValue with fn read_with_limit(
   let msg = ListValue::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.values.push((reader |> @lib.read_message() : Value))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.values.push((reader |> @lib.read_message() : Value))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -657,7 +660,8 @@ pub impl @lib.AsyncRead for ListValue with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.values.push((reader |> @lib.async_read_message() : Value))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.values.push((reader |> @lib.async_read_message() : Value))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/lib/google/protobuf/timestamp.mbt
+++ b/lib/google/protobuf/timestamp.mbt
@@ -35,7 +35,7 @@ pub impl @lib.Read for Timestamp with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.seconds = reader |> @lib.read_int64()
       (2, _) => msg.nanos = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -66,7 +66,7 @@ pub impl @lib.AsyncRead for Timestamp with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.seconds = reader |> @lib.async_read_int64()
       (2, _) => msg.nanos = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/lib/google/protobuf/type.mbt
+++ b/lib/google/protobuf/type.mbt
@@ -145,10 +145,12 @@ pub impl @lib.Read for Type with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
-      (2, 2) => msg.fields.push((reader |> @lib.read_message() : Field))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.fields.push((reader |> @lib.read_message() : Field))
       (3, _) => msg.oneofs.push(reader |> @lib.read_string())
-      (4, 2) => msg.options.push((reader |> @lib.read_message() : Option))
-      (5, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.read_message() : Option))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.source_context = (reader |> @lib.read_message() : SourceContext)
           |> Some
       (6, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
@@ -256,10 +258,12 @@ pub impl @lib.AsyncRead for Type with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, 2) => msg.fields.push((reader |> @lib.async_read_message() : Field))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.fields.push((reader |> @lib.async_read_message() : Field))
       (3, _) => msg.oneofs.push(reader |> @lib.async_read_string())
-      (4, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
-      (5, 2) =>
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.async_read_message() : Option))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.source_context = (
             reader |> @lib.async_read_message() : SourceContext)
           |> Some
@@ -677,7 +681,8 @@ pub impl @lib.Read for Field with fn read_with_limit(
       (6, _) => msg.type_url = reader |> @lib.read_string()
       (7, _) => msg.oneof_index = reader |> @lib.read_int32()
       (8, _) => msg.packed = reader |> @lib.read_bool()
-      (9, 2) => msg.options.push((reader |> @lib.read_message() : Option))
+      (9, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.read_message() : Option))
       (10, _) => msg.json_name = reader |> @lib.read_string()
       (11, _) => msg.default_value = reader |> @lib.read_string()
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -816,7 +821,8 @@ pub impl @lib.AsyncRead for Field with fn read_with_limit(
       (6, _) => msg.type_url = reader |> @lib.async_read_string()
       (7, _) => msg.oneof_index = reader |> @lib.async_read_int32()
       (8, _) => msg.packed = reader |> @lib.async_read_bool()
-      (9, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (9, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.async_read_message() : Option))
       (10, _) => msg.json_name = reader |> @lib.async_read_string()
       (11, _) => msg.default_value = reader |> @lib.async_read_string()
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -938,9 +944,11 @@ pub impl @lib.Read for Enum with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
-      (2, 2) => msg.enumvalue.push((reader |> @lib.read_message() : EnumValue))
-      (3, 2) => msg.options.push((reader |> @lib.read_message() : Option))
-      (4, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.enumvalue.push((reader |> @lib.read_message() : EnumValue))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.read_message() : Option))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.source_context = (reader |> @lib.read_message() : SourceContext)
           |> Some
       (5, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
@@ -1039,10 +1047,11 @@ pub impl @lib.AsyncRead for Enum with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, 2) =>
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.enumvalue.push((reader |> @lib.async_read_message() : EnumValue))
-      (3, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
-      (4, 2) =>
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.async_read_message() : Option))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.source_context = (
             reader |> @lib.async_read_message() : SourceContext)
           |> Some
@@ -1131,7 +1140,8 @@ pub impl @lib.Read for EnumValue with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.number = reader |> @lib.read_int32()
-      (3, 2) => msg.options.push((reader |> @lib.read_message() : Option))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.read_message() : Option))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1203,7 +1213,8 @@ pub impl @lib.AsyncRead for EnumValue with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.number = reader |> @lib.async_read_int32()
-      (3, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.options.push((reader |> @lib.async_read_message() : Option))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1265,7 +1276,8 @@ pub impl @lib.Read for Option with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
-      (2, 2) => msg.value = (reader |> @lib.read_message() : Any) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.value = (reader |> @lib.read_message() : Any) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1328,7 +1340,8 @@ pub impl @lib.AsyncRead for Option with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, 2) => msg.value = (reader |> @lib.async_read_message() : Any) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.value = (reader |> @lib.async_read_message() : Any) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/lib/google/protobuf/type.mbt
+++ b/lib/google/protobuf/type.mbt
@@ -145,15 +145,15 @@ pub impl @lib.Read for Type with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
-      (2, _) => msg.fields.push((reader |> @lib.read_message() : Field))
+      (2, 2) => msg.fields.push((reader |> @lib.read_message() : Field))
       (3, _) => msg.oneofs.push(reader |> @lib.read_string())
-      (4, _) => msg.options.push((reader |> @lib.read_message() : Option))
-      (5, _) =>
+      (4, 2) => msg.options.push((reader |> @lib.read_message() : Option))
+      (5, 2) =>
         msg.source_context = (reader |> @lib.read_message() : SourceContext)
           |> Some
       (6, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
       (7, _) => msg.edition = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -256,17 +256,17 @@ pub impl @lib.AsyncRead for Type with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, _) => msg.fields.push((reader |> @lib.async_read_message() : Field))
+      (2, 2) => msg.fields.push((reader |> @lib.async_read_message() : Field))
       (3, _) => msg.oneofs.push(reader |> @lib.async_read_string())
-      (4, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
-      (5, _) =>
+      (4, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (5, 2) =>
         msg.source_context = (
             reader |> @lib.async_read_message() : SourceContext)
           |> Some
       (6, _) =>
         msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
       (7, _) => msg.edition = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -677,10 +677,10 @@ pub impl @lib.Read for Field with fn read_with_limit(
       (6, _) => msg.type_url = reader |> @lib.read_string()
       (7, _) => msg.oneof_index = reader |> @lib.read_int32()
       (8, _) => msg.packed = reader |> @lib.read_bool()
-      (9, _) => msg.options.push((reader |> @lib.read_message() : Option))
+      (9, 2) => msg.options.push((reader |> @lib.read_message() : Option))
       (10, _) => msg.json_name = reader |> @lib.read_string()
       (11, _) => msg.default_value = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -816,10 +816,10 @@ pub impl @lib.AsyncRead for Field with fn read_with_limit(
       (6, _) => msg.type_url = reader |> @lib.async_read_string()
       (7, _) => msg.oneof_index = reader |> @lib.async_read_int32()
       (8, _) => msg.packed = reader |> @lib.async_read_bool()
-      (9, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (9, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
       (10, _) => msg.json_name = reader |> @lib.async_read_string()
       (11, _) => msg.default_value = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -938,14 +938,14 @@ pub impl @lib.Read for Enum with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
-      (2, _) => msg.enumvalue.push((reader |> @lib.read_message() : EnumValue))
-      (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
-      (4, _) =>
+      (2, 2) => msg.enumvalue.push((reader |> @lib.read_message() : EnumValue))
+      (3, 2) => msg.options.push((reader |> @lib.read_message() : Option))
+      (4, 2) =>
         msg.source_context = (reader |> @lib.read_message() : SourceContext)
           |> Some
       (5, _) => msg.syntax = reader |> @lib.read_enum() |> Syntax::from_enum
       (6, _) => msg.edition = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1039,17 +1039,17 @@ pub impl @lib.AsyncRead for Enum with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, _) =>
+      (2, 2) =>
         msg.enumvalue.push((reader |> @lib.async_read_message() : EnumValue))
-      (3, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
-      (4, _) =>
+      (3, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      (4, 2) =>
         msg.source_context = (
             reader |> @lib.async_read_message() : SourceContext)
           |> Some
       (5, _) =>
         msg.syntax = reader |> @lib.async_read_enum() |> Syntax::from_enum
       (6, _) => msg.edition = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1131,8 +1131,8 @@ pub impl @lib.Read for EnumValue with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.number = reader |> @lib.read_int32()
-      (3, _) => msg.options.push((reader |> @lib.read_message() : Option))
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.options.push((reader |> @lib.read_message() : Option))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1203,8 +1203,8 @@ pub impl @lib.AsyncRead for EnumValue with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.number = reader |> @lib.async_read_int32()
-      (3, _) => msg.options.push((reader |> @lib.async_read_message() : Option))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.options.push((reader |> @lib.async_read_message() : Option))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1265,8 +1265,8 @@ pub impl @lib.Read for Option with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
-      (2, _) => msg.value = (reader |> @lib.read_message() : Any) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (2, 2) => msg.value = (reader |> @lib.read_message() : Any) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1328,8 +1328,8 @@ pub impl @lib.AsyncRead for Option with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, _) => msg.value = (reader |> @lib.async_read_message() : Any) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (2, 2) => msg.value = (reader |> @lib.async_read_message() : Any) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/lib/google/protobuf/wrappers.mbt
+++ b/lib/google/protobuf/wrappers.mbt
@@ -30,7 +30,7 @@ pub impl @lib.Read for DoubleValue with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.read_double()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -83,7 +83,7 @@ pub impl @lib.AsyncRead for DoubleValue with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.async_read_double()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -132,7 +132,7 @@ pub impl @lib.Read for FloatValue with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.read_float()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -185,7 +185,7 @@ pub impl @lib.AsyncRead for FloatValue with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.async_read_float()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -234,7 +234,7 @@ pub impl @lib.Read for Int64Value with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.read_int64()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -287,7 +287,7 @@ pub impl @lib.AsyncRead for Int64Value with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.async_read_int64()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -336,7 +336,7 @@ pub impl @lib.Read for UInt64Value with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.read_uint64()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -389,7 +389,7 @@ pub impl @lib.AsyncRead for UInt64Value with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.async_read_uint64()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -438,7 +438,7 @@ pub impl @lib.Read for Int32Value with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -491,7 +491,7 @@ pub impl @lib.AsyncRead for Int32Value with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -540,7 +540,7 @@ pub impl @lib.Read for UInt32Value with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.read_uint32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -593,7 +593,7 @@ pub impl @lib.AsyncRead for UInt32Value with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.async_read_uint32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -642,7 +642,7 @@ pub impl @lib.Read for BoolValue with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.read_bool()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -695,7 +695,7 @@ pub impl @lib.AsyncRead for BoolValue with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.async_read_bool()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -744,7 +744,7 @@ pub impl @lib.Read for StringValue with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -797,7 +797,7 @@ pub impl @lib.AsyncRead for StringValue with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -846,7 +846,7 @@ pub impl @lib.Read for BytesValue with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.read_bytes()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -902,7 +902,7 @@ pub impl @lib.AsyncRead for BytesValue with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.async_read_bytes()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -8,6 +8,18 @@ import {
 }
 
 // Values
+pub const WIRE_TYPE_END_GROUP : UInt = 4
+
+pub const WIRE_TYPE_FIXED32 : UInt = 5
+
+pub const WIRE_TYPE_FIXED64 : UInt = 1
+
+pub const WIRE_TYPE_LENGTH_DELIMITED : UInt = 2
+
+pub const WIRE_TYPE_START_GROUP : UInt = 3
+
+pub const WIRE_TYPE_VARINT : UInt = 0
+
 pub async fn[T : AsyncReader] async_read_bool(T) -> Bool
 
 pub async fn[T : AsyncReader] async_read_bytes(T) -> Bytes

--- a/lib/pkg.generated.mbti
+++ b/lib/pkg.generated.mbti
@@ -12,6 +12,8 @@ pub async fn[T : AsyncReader] async_read_bool(T) -> Bool
 
 pub async fn[T : AsyncReader] async_read_bytes(T) -> Bytes
 
+pub async fn[M : AsyncRead] async_read_delimited_message(LimitedReader[&AsyncReader], UInt) -> M
+
 pub async fn[T : AsyncReader] async_read_double(T) -> Double
 
 pub async fn[T : AsyncReader] async_read_enum(T) -> Enum
@@ -54,9 +56,13 @@ pub async fn[T : AsyncReader] async_read_varint32(T) -> UInt
 
 pub async fn[T : AsyncReader] async_skip_message_field(T, UInt) -> Unit
 
+pub async fn[T : AsyncReader] async_skip_message_field_by_number(T, UInt, UInt) -> Unit
+
 pub async fn[T : AsyncWriter] async_write_bool(T, Bool) -> Unit
 
 pub async fn[T : AsyncWriter] async_write_bytes(T, Bytes) -> Unit
+
+pub async fn[M : AsyncWrite, T : AsyncWriter] async_write_delimited_message(T, UInt, M) -> Unit
 
 pub async fn[T : AsyncWriter] async_write_double(T, Double) -> Unit
 
@@ -100,6 +106,8 @@ pub fn[T : Reader] read_bool(T) -> Bool raise
 
 pub fn[T : Reader] read_bytes(T) -> Bytes raise
 
+pub fn[M : Read] read_delimited_message(LimitedReader[&Reader], UInt) -> M raise
+
 pub fn[T : Reader] read_double(T) -> Double raise
 
 pub fn[T : Reader] read_enum(T) -> Enum raise
@@ -142,15 +150,21 @@ pub fn[T : Reader] read_varint32(T) -> UInt raise
 
 pub fn[T : Sized] size_of(T) -> UInt
 
+pub fn size_of_delimited_field(UInt, UInt) -> UInt
+
 pub fn size_of_field(UInt, UInt) -> UInt
 
 pub fn size_of_length_delimited_field(UInt, UInt) -> UInt
 
 pub fn[T : Reader] skip_message_field(T, UInt) -> Unit raise
 
+pub fn[T : Reader] skip_message_field_by_number(T, UInt, UInt) -> Unit raise
+
 pub fn[T : Writer] write_bool(T, Bool) -> Unit raise
 
 pub fn[T : Writer] write_bytes(T, Bytes) -> Unit raise
+
+pub fn[M : Write, T : Writer] write_delimited_message(T, UInt, M) -> Unit raise
 
 pub fn[T : Writer] write_double(T, Double) -> Unit raise
 
@@ -212,10 +226,7 @@ pub impl Sized for Enum
 pub(all) struct Len(Int) derive(Default, Eq, @debug.Debug)
 pub impl Show for Len
 
-pub(all) struct LimitedReader[T] {
-  reader : T
-  mut limit : Int?
-}
+type LimitedReader[T]
 pub fn[T] LimitedReader::new(T, limit? : Int) -> Self[T]
 pub impl[T : AsyncReader] AsyncReader for LimitedReader[T]
 pub impl[T : Reader] Reader for LimitedReader[T]

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -60,7 +60,7 @@ pub fn[T : Reader] read_tag(reader : T) -> (UInt, UInt) raise {
   let value = reader |> read_varint32()
   let tag = value >> 3
   let wire_type = value & 0x7
-  if wire_type > 5 {
+  if wire_type > WIRE_TYPE_FIXED32 {
     raise ReaderError::UnknownWireType(wire_type)
   }
   (tag, wire_type)
@@ -289,11 +289,11 @@ fn[T : Reader] read_delimited_message_tail(
       err => raise err
     }
     match next {
-      Some((nested_field_number, 4)) =>
+      Some((nested_field_number, WIRE_TYPE_END_GROUP)) =>
         if nested_field_number == field_number {
           reader.end_group_seen = true
         } else {
-          raise ReaderError::UnknownWireType(4)
+          raise ReaderError::UnknownWireType(WIRE_TYPE_END_GROUP)
         }
       Some((nested_field_number, nested_wire_type)) =>
         reader
@@ -314,7 +314,7 @@ pub fn[R : Reader] read_next_message_field(
   Some(
     {
       let (field_number, wire) = reader |> read_tag()
-      if wire == 4 {
+      if wire == WIRE_TYPE_END_GROUP {
         match reader.end_group {
           Some(end_group) if field_number == end_group => {
             reader.end_group_seen = true
@@ -371,10 +371,10 @@ pub fn[M : Sized, R : Reader] read_packed(
 /// group fields can be skipped with their matching end-group field number.
 pub fn[T : Reader] read_unknown(reader : T, wire_type : UInt) -> Unit raise {
   match wire_type {
-    0 => reader |> read_varint64() |> ignore
-    1 => reader |> read_fixed64() |> ignore
-    2 => reader |> read_bytes() |> ignore
-    5 => reader |> read_fixed32() |> ignore
+    WIRE_TYPE_VARINT => reader |> read_varint64() |> ignore
+    WIRE_TYPE_FIXED64 => reader |> read_fixed64() |> ignore
+    WIRE_TYPE_LENGTH_DELIMITED => reader |> read_bytes() |> ignore
+    WIRE_TYPE_FIXED32 => reader |> read_fixed32() |> ignore
     _ => raise ReaderError::UnknownWireType(wire_type)
   }
 }
@@ -386,10 +386,10 @@ fn[T : Reader] read_unknown_field(
   wire_type : UInt,
 ) -> Unit raise {
   match wire_type {
-    3 =>
+    WIRE_TYPE_START_GROUP =>
       while true {
         let (nested_field_number, nested_wire_type) = reader |> read_tag()
-        if nested_wire_type == 4 {
+        if nested_wire_type == WIRE_TYPE_END_GROUP {
           if nested_field_number == field_number {
             return
           }
@@ -397,7 +397,7 @@ fn[T : Reader] read_unknown_field(
         }
         reader |> read_unknown_field(nested_field_number, nested_wire_type)
       }
-    4 => raise ReaderError::UnknownWireType(wire_type)
+    WIRE_TYPE_END_GROUP => raise ReaderError::UnknownWireType(wire_type)
     _ => reader |> read_unknown(wire_type)
   }
 }
@@ -405,8 +405,8 @@ fn[T : Reader] read_unknown_field(
 ///|
 /// Skips an unknown non-group message field by wire type.
 ///
-/// This legacy helper cannot skip wire type 3 groups because the matching
-/// end-group tag requires the field number.
+/// This legacy helper cannot skip `WIRE_TYPE_START_GROUP` fields because the
+/// matching end-group tag requires the field number.
 pub fn[T : Reader] skip_message_field(
   reader : T,
   wire_type : UInt,
@@ -417,8 +417,8 @@ pub fn[T : Reader] skip_message_field(
 ///|
 /// Skips an unknown message field by field number and wire type.
 ///
-/// Unlike `skip_message_field`, this handles wire type 3 groups by reading
-/// nested fields until the matching wire type 4 end-group tag is found.
+/// Unlike `skip_message_field`, this handles `WIRE_TYPE_START_GROUP` fields by
+/// reading nested fields until the matching `WIRE_TYPE_END_GROUP` tag is found.
 pub fn[T : Reader] skip_message_field_by_number(
   reader : T,
   field_number : UInt,

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -221,7 +221,20 @@ pub fn[M : Read + Default] read_message(
         None
       }
       reader.limit = Some(len)
-      let msg = reader |> M::read_with_limit()
+      let previous_end_group = reader.end_group
+      let previous_end_group_seen = reader.end_group_seen
+      reader.end_group = None
+      reader.end_group_seen = false
+      let msg = try reader |> M::read_with_limit() catch {
+        err => {
+          reader.limit = new_limit
+          reader.end_group = previous_end_group
+          reader.end_group_seen = previous_end_group_seen
+          raise err
+        }
+      }
+      reader.end_group = previous_end_group
+      reader.end_group_seen = previous_end_group_seen
       reader.limit = new_limit
       msg
     }
@@ -229,10 +242,49 @@ pub fn[M : Read + Default] read_message(
 }
 
 ///|
+pub fn[M : Read] read_delimited_message(
+  reader : LimitedReader[&Reader],
+  field_number : UInt,
+) -> M raise {
+  let previous_end_group = reader.end_group
+  let previous_end_group_seen = reader.end_group_seen
+  reader.end_group = Some(field_number)
+  reader.end_group_seen = false
+  let msg = try reader |> M::read_with_limit() catch {
+    err => {
+      reader.end_group = previous_end_group
+      reader.end_group_seen = previous_end_group_seen
+      raise err
+    }
+  }
+  let end_group_seen = reader.end_group_seen
+  reader.end_group = previous_end_group
+  reader.end_group_seen = previous_end_group_seen
+  if !end_group_seen {
+    raise EndOfStream
+  }
+  msg
+}
+
+///|
 pub fn[R : Reader] read_next_message_field(
   reader : LimitedReader[R],
 ) -> (UInt, UInt)? raise {
-  Some(reader |> read_tag()) catch {
+  Some(
+    {
+      let (field_number, wire) = reader |> read_tag()
+      if wire == 4 {
+        match reader.end_group {
+          Some(end_group) if field_number == end_group => {
+            reader.end_group_seen = true
+            return None
+          }
+          _ => raise ReaderError::UnknownWireType(wire)
+        }
+      }
+      (field_number, wire)
+    },
+  ) catch {
     EndOfStream => None
     err => raise err
   }
@@ -283,9 +335,41 @@ pub fn[T : Reader] read_unknown(reader : T, wire_type : UInt) -> Unit raise {
 }
 
 ///|
+fn[T : Reader] read_unknown_field(
+  reader : T,
+  field_number : UInt,
+  wire_type : UInt,
+) -> Unit raise {
+  match wire_type {
+    3 =>
+      while true {
+        let (nested_field_number, nested_wire_type) = reader |> read_tag()
+        if nested_wire_type == 4 {
+          if nested_field_number == field_number {
+            return
+          }
+          raise ReaderError::UnknownWireType(nested_wire_type)
+        }
+        reader |> read_unknown_field(nested_field_number, nested_wire_type)
+      }
+    4 => raise ReaderError::UnknownWireType(wire_type)
+    _ => reader |> read_unknown(wire_type)
+  }
+}
+
+///|
 pub fn[T : Reader] skip_message_field(
   reader : T,
   wire_type : UInt,
 ) -> Unit raise {
   reader |> read_unknown(wire_type)
+}
+
+///|
+pub fn[T : Reader] skip_message_field_by_number(
+  reader : T,
+  field_number : UInt,
+  wire_type : UInt,
+) -> Unit raise {
+  reader |> read_unknown_field(field_number, wire_type)
 }

--- a/lib/reader.mbt
+++ b/lib/reader.mbt
@@ -202,6 +202,7 @@ pub fn[T : Reader] read_string(reader : T) -> String raise {
 }
 
 ///|
+/// Reads a length-delimited embedded message after its size prefix.
 pub fn[M : Read + Default] read_message(
   reader : LimitedReader[&Reader],
 ) -> M raise {
@@ -242,6 +243,11 @@ pub fn[M : Read + Default] read_message(
 }
 
 ///|
+/// Reads a delimited message payload after its start-group tag has already
+/// been consumed, then consumes the matching end-group tag for `field_number`.
+///
+/// This helper is used by generated code for proto2 groups and Editions
+/// `features.message_encoding = DELIMITED`.
 pub fn[M : Read] read_delimited_message(
   reader : LimitedReader[&Reader],
   field_number : UInt,
@@ -250,7 +256,13 @@ pub fn[M : Read] read_delimited_message(
   let previous_end_group_seen = reader.end_group_seen
   reader.end_group = Some(field_number)
   reader.end_group_seen = false
-  let msg = try reader |> M::read_with_limit() catch {
+  let msg = try {
+    let msg = reader |> M::read_with_limit()
+    if !reader.end_group_seen {
+      reader |> read_delimited_message_tail(field_number)
+    }
+    msg
+  } catch {
     err => {
       reader.end_group = previous_end_group
       reader.end_group_seen = previous_end_group_seen
@@ -267,6 +279,35 @@ pub fn[M : Read] read_delimited_message(
 }
 
 ///|
+fn[T : Reader] read_delimited_message_tail(
+  reader : LimitedReader[T],
+  field_number : UInt,
+) -> Unit raise {
+  while !reader.end_group_seen {
+    let next = Some(reader |> read_tag()) catch {
+      EndOfStream => None
+      err => raise err
+    }
+    match next {
+      Some((nested_field_number, 4)) =>
+        if nested_field_number == field_number {
+          reader.end_group_seen = true
+        } else {
+          raise ReaderError::UnknownWireType(4)
+        }
+      Some((nested_field_number, nested_wire_type)) =>
+        reader
+        |> skip_message_field_by_number(nested_field_number, nested_wire_type)
+      None => break
+    }
+  }
+}
+
+///|
+/// Reads the next field number and wire type within a message body.
+///
+/// Returns `None` at the end of a length-delimited message or after consuming
+/// the matching end-group tag for a delimited message.
 pub fn[R : Reader] read_next_message_field(
   reader : LimitedReader[R],
 ) -> (UInt, UInt)? raise {
@@ -324,6 +365,10 @@ pub fn[M : Sized, R : Reader] read_packed(
 }
 
 ///|
+/// Skips an unknown non-group field payload by wire type.
+///
+/// Use `skip_message_field_by_number` while parsing message bodies so unknown
+/// group fields can be skipped with their matching end-group field number.
 pub fn[T : Reader] read_unknown(reader : T, wire_type : UInt) -> Unit raise {
   match wire_type {
     0 => reader |> read_varint64() |> ignore
@@ -358,6 +403,10 @@ fn[T : Reader] read_unknown_field(
 }
 
 ///|
+/// Skips an unknown non-group message field by wire type.
+///
+/// This legacy helper cannot skip wire type 3 groups because the matching
+/// end-group tag requires the field number.
 pub fn[T : Reader] skip_message_field(
   reader : T,
   wire_type : UInt,
@@ -366,6 +415,10 @@ pub fn[T : Reader] skip_message_field(
 }
 
 ///|
+/// Skips an unknown message field by field number and wire type.
+///
+/// Unlike `skip_message_field`, this handles wire type 3 groups by reading
+/// nested fields until the matching wire type 4 end-group tag is found.
 pub fn[T : Reader] skip_message_field_by_number(
   reader : T,
   field_number : UInt,

--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -111,14 +111,16 @@ pub impl AsyncReader for BytesReader with fn read(
 }
 
 ///|
-pub(all) struct LimitedReader[T] {
+struct LimitedReader[T] {
   reader : T
   mut limit : Int?
+  mut end_group : UInt?
+  mut end_group_seen : Bool
 }
 
 ///|
 pub fn[T] LimitedReader::new(reader : T, limit? : Int) -> LimitedReader[T] {
-  { reader, limit }
+  { reader, limit, end_group: None, end_group_seen: false }
 }
 
 ///|

--- a/lib/reader_impl.mbt
+++ b/lib/reader_impl.mbt
@@ -119,6 +119,8 @@ struct LimitedReader[T] {
 }
 
 ///|
+/// Creates a reader wrapper that optionally limits how many bytes a nested
+/// length-delimited message can consume.
 pub fn[T] LimitedReader::new(reader : T, limit? : Int) -> LimitedReader[T] {
   { reader, limit, end_group: None, end_group_seen: false }
 }

--- a/lib/sizeof.mbt
+++ b/lib/sizeof.mbt
@@ -47,6 +47,16 @@ pub fn size_of_length_delimited_field(
 }
 
 ///|
+/// Size of a delimited message field envelope around an already-sized payload.
+/// `field_number` is the protobuf field number, not an encoded tag size.
+pub fn size_of_delimited_field(
+  field_number : UInt,
+  payload_size : UInt,
+) -> UInt {
+  size_of_tag(field_number) + payload_size + size_of_tag(field_number)
+}
+
+///|
 fn size_of_varint(v : UInt64) -> UInt {
   if v < 0x80UL {
     1

--- a/lib/wire_type.mbt
+++ b/lib/wire_type.mbt
@@ -1,0 +1,23 @@
+///|
+/// Protobuf varint wire type.
+pub const WIRE_TYPE_VARINT : UInt = 0U
+
+///|
+/// Protobuf 64-bit fixed-width wire type.
+pub const WIRE_TYPE_FIXED64 : UInt = 1U
+
+///|
+/// Protobuf length-delimited wire type.
+pub const WIRE_TYPE_LENGTH_DELIMITED : UInt = 2U
+
+///|
+/// Protobuf start-group wire type.
+pub const WIRE_TYPE_START_GROUP : UInt = 3U
+
+///|
+/// Protobuf end-group wire type.
+pub const WIRE_TYPE_END_GROUP : UInt = 4U
+
+///|
+/// Protobuf 32-bit fixed-width wire type.
+pub const WIRE_TYPE_FIXED32 : UInt = 5U

--- a/lib/writer.mbt
+++ b/lib/writer.mbt
@@ -136,3 +136,14 @@ pub fn[M : Write + Sized, T : Writer] write_message(
   writer |> write_uint32(size_of(message))
   Write::write(message, writer)
 }
+
+///|
+pub fn[M : Write, T : Writer] write_delimited_message(
+  writer : T,
+  field_number : UInt,
+  message : M,
+) -> Unit raise {
+  writer |> write_tag((field_number, 3U))
+  Write::write(message, writer)
+  writer |> write_tag((field_number, 4U))
+}

--- a/lib/writer.mbt
+++ b/lib/writer.mbt
@@ -149,7 +149,7 @@ pub fn[M : Write, T : Writer] write_delimited_message(
   field_number : UInt,
   message : M,
 ) -> Unit raise {
-  writer |> write_tag((field_number, 3U))
+  writer |> write_tag((field_number, WIRE_TYPE_START_GROUP))
   Write::write(message, writer)
-  writer |> write_tag((field_number, 4U))
+  writer |> write_tag((field_number, WIRE_TYPE_END_GROUP))
 }

--- a/lib/writer.mbt
+++ b/lib/writer.mbt
@@ -129,6 +129,7 @@ pub fn[T : Writer] write_string(writer : T, v : String) -> Unit raise {
 }
 
 ///|
+/// Writes a length-delimited embedded message with a size prefix.
 pub fn[M : Write + Sized, T : Writer] write_message(
   writer : T,
   message : M,
@@ -138,6 +139,11 @@ pub fn[M : Write + Sized, T : Writer] write_message(
 }
 
 ///|
+/// Writes a delimited message field envelope for `field_number`.
+///
+/// The encoded form is start-group tag, message payload, then the matching
+/// end-group tag. Generated code uses this for proto2 groups and Editions
+/// `features.message_encoding = DELIMITED`.
 pub fn[M : Write, T : Writer] write_delimited_message(
   writer : T,
   field_number : UInt,

--- a/scripts/workflow.py
+++ b/scripts/workflow.py
@@ -167,7 +167,7 @@ def generate_plugin(_: argparse.Namespace) -> None:
     build_plugin()
     runtime_support_files = {"well_known_json.mbt"}
     for path in (LIB_DIR / "google" / "protobuf").rglob("*.mbt"):
-        if path.name not in runtime_support_files:
+        if path.name not in runtime_support_files and not path.name.endswith("_test.mbt"):
             path.unlink()
     for path in (LIB_DIR / "google" / "protobuf").rglob("pkg.generated.mbti"):
         path.unlink()

--- a/test/harness/cases/edition/case.toml
+++ b/test/harness/cases/edition/case.toml
@@ -1,3 +1,3 @@
 generated_project = "harness_edition"
-proto_files = ["edition.proto", "inherited_file.proto", "open_enum.proto", "delimited.proto"]
+proto_files = ["edition.proto", "inherited_file.proto", "open_enum.proto", "delimited.proto", "file_delimited.proto"]
 test_args = ["test", "src", "--target", "native", "--deny-warn"]

--- a/test/harness/cases/edition/case.toml
+++ b/test/harness/cases/edition/case.toml
@@ -1,3 +1,3 @@
 generated_project = "harness_edition"
-proto_files = ["edition.proto", "inherited_file.proto", "open_enum.proto"]
+proto_files = ["edition.proto", "inherited_file.proto", "open_enum.proto", "delimited.proto"]
 test_args = ["test", "src", "--target", "native", "--deny-warn"]

--- a/test/harness/cases/edition/proto/delimited.proto
+++ b/test/harness/cases/edition/proto/delimited.proto
@@ -1,0 +1,13 @@
+edition = "2024";
+
+package harness.delimited;
+
+message Payload {
+  message Child {
+    int32 value = 1;
+  }
+
+  Child delimited_child = 1 [features.message_encoding = DELIMITED];
+  Child length_prefixed_child = 2;
+  repeated Child delimited_children = 3 [features.message_encoding = DELIMITED];
+}

--- a/test/harness/cases/edition/proto/delimited.proto
+++ b/test/harness/cases/edition/proto/delimited.proto
@@ -3,6 +3,8 @@ edition = "2024";
 package harness.delimited;
 
 message Payload {
+  message Empty {}
+
   message Child {
     int32 value = 1;
   }
@@ -10,4 +12,6 @@ message Payload {
   Child delimited_child = 1 [features.message_encoding = DELIMITED];
   Child length_prefixed_child = 2;
   repeated Child delimited_children = 3 [features.message_encoding = DELIMITED];
+  Empty empty_delimited = 4 [features.message_encoding = DELIMITED];
+  int32 after_empty = 5;
 }

--- a/test/harness/cases/edition/proto/file_delimited.proto
+++ b/test/harness/cases/edition/proto/file_delimited.proto
@@ -1,0 +1,14 @@
+edition = "2024";
+
+package harness.file_delimited;
+
+option features.message_encoding = DELIMITED;
+
+message Child {
+  int32 value = 1;
+}
+
+message Payload {
+  Child default_child = 1;
+  map<string, Child> children_by_name = 6;
+}

--- a/test/harness/cases/edition/runner/moon.mod
+++ b/test/harness/cases/edition/runner/moon.mod
@@ -3,6 +3,7 @@ name = "username/harness_edition_runner"
 version = "0.1.0"
 
 import {
+  "moonbitlang/async@0.18.0",
   "moonbitlang/protobuf@0.1.3",
   "username/harness_edition@0.1.0",
 }
@@ -13,6 +14,6 @@ repository = ""
 
 license = ""
 
-keywords = []
+keywords = [ ]
 
 description = ""

--- a/test/harness/cases/edition/runner/src/edition_test.mbt
+++ b/test/harness/cases/edition/runner/src/edition_test.mbt
@@ -199,6 +199,26 @@ test "edition ordinary message encoding stays length prefixed" {
 }
 
 ///|
+/// File-level DELIMITED defaults should not change map-entry wire encoding.
+test "edition file delimited maps stay length prefixed" {
+  let child = @file_delimited.Child::new(value=150)
+  let message = @file_delimited.Payload::default()
+  message.default_child = Some(child)
+  message.children_by_name["a"] = child
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(
+    writer.to_bytes(),
+    b"\x0b\x08\x96\x01\x0c\x32\x08\x0a\x01a\x12\x03\x08\x96\x01",
+  )
+  let reader = @protobuf.BytesReader::from_bytes(
+    b"\x32\x08\x0a\x01a\x12\x03\x08\x96\x01",
+  )
+  let parsed : @file_delimited.Payload = @protobuf.Read::read(reader)
+  @debug.assert_eq(parsed.children_by_name.get("a"), Some(child))
+}
+
+///|
 /// Async generated codecs should use the same DELIMITED message wire format.
 async test "edition delimited message encoding async codecs" {
   let child = @delimited.Payload_Child::new(value=150)

--- a/test/harness/cases/edition/runner/src/edition_test.mbt
+++ b/test/harness/cases/edition/runner/src/edition_test.mbt
@@ -165,6 +165,29 @@ test "edition repeated delimited messages use repeated groups" {
 }
 
 ///|
+/// Empty DELIMITED message fields should consume their end-group tag.
+test "edition empty delimited message consumes end group" {
+  let reader = @protobuf.BytesReader::from_bytes(b"\x23\x24\x28\x07")
+  let message : @delimited.Payload = @protobuf.Read::read(reader)
+  @debug.assert_eq(
+    message.empty_delimited,
+    Some(@delimited.Payload_Empty::default()),
+  )
+  @debug.assert_eq(message.after_empty, Some(7))
+}
+
+///|
+/// Empty DELIMITED message fields should skip unknown payload fields.
+test "edition empty delimited message skips unknown payload fields" {
+  let reader = @protobuf.BytesReader::from_bytes(b"\x23\x08\x96\x01\x24")
+  let message : @delimited.Payload = @protobuf.Read::read(reader)
+  @debug.assert_eq(
+    message.empty_delimited,
+    Some(@delimited.Payload_Empty::default()),
+  )
+}
+
+///|
 /// Ordinary edition message fields should stay length-prefixed.
 test "edition ordinary message encoding stays length prefixed" {
   let child = @delimited.Payload_Child::new(value=150)
@@ -187,4 +210,16 @@ async test "edition delimited message encoding async codecs" {
   let reader = @protobuf.BytesReader::from_bytes(writer.to_bytes())
   let parsed : @delimited.Payload = @protobuf.AsyncRead::read(reader)
   @debug.assert_eq(parsed.delimited_child, Some(child))
+}
+
+///|
+/// Async empty DELIMITED message fields should consume their end-group tag.
+async test "edition empty delimited message async consumes end group" {
+  let reader = @protobuf.BytesReader::from_bytes(b"\x23\x24\x28\x07")
+  let message : @delimited.Payload = @protobuf.AsyncRead::read(reader)
+  @debug.assert_eq(
+    message.empty_delimited,
+    Some(@delimited.Payload_Empty::default()),
+  )
+  @debug.assert_eq(message.after_empty, Some(7))
 }

--- a/test/harness/cases/edition/runner/src/edition_test.mbt
+++ b/test/harness/cases/edition/runner/src/edition_test.mbt
@@ -123,3 +123,68 @@ test "edition open enum unknown carrier avoids generated value name collision" {
   )
   @debug.assert_eq(unknown.to_json(), Json::number(7.0))
 }
+
+///|
+/// DELIMITED message encoding should emit start/end group tags around the payload.
+test "edition delimited message encoding writes group wire format" {
+  let child = @delimited.Payload_Child::new(value=150)
+  let message = @delimited.Payload::default()
+  message.delimited_child = Some(child)
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x0b\x08\x96\x01\x0c")
+  @debug.assert_eq(
+    @protobuf.size_of(message),
+    writer.to_bytes().length().reinterpret_as_uint(),
+  )
+}
+
+///|
+/// Readers should accept DELIMITED message fields written as groups.
+test "edition delimited message encoding reads group wire format" {
+  let reader = @protobuf.BytesReader::from_bytes(b"\x0b\x08\x96\x01\x0c")
+  let message : @delimited.Payload = @protobuf.Read::read(reader)
+  @debug.assert_eq(
+    message.delimited_child,
+    Some(@delimited.Payload_Child::new(value=150)),
+  )
+}
+
+///|
+/// Repeated DELIMITED message fields should parse each group as one element.
+test "edition repeated delimited messages use repeated groups" {
+  let child = @delimited.Payload_Child::new(value=150)
+  let message = @delimited.Payload::default()
+  message.delimited_children.push(child)
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x1b\x08\x96\x01\x1c")
+  let reader = @protobuf.BytesReader::from_bytes(writer.to_bytes())
+  let parsed : @delimited.Payload = @protobuf.Read::read(reader)
+  @debug.assert_eq(parsed.delimited_children, [child])
+}
+
+///|
+/// Ordinary edition message fields should stay length-prefixed.
+test "edition ordinary message encoding stays length prefixed" {
+  let child = @delimited.Payload_Child::new(value=150)
+  let message = @delimited.Payload::default()
+  message.length_prefixed_child = Some(child)
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x12\x03\x08\x96\x01")
+}
+
+///|
+/// Async generated codecs should use the same DELIMITED message wire format.
+async test "edition delimited message encoding async codecs" {
+  let child = @delimited.Payload_Child::new(value=150)
+  let message = @delimited.Payload::default()
+  message.delimited_child = Some(child)
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.AsyncWrite::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x0b\x08\x96\x01\x0c")
+  let reader = @protobuf.BytesReader::from_bytes(writer.to_bytes())
+  let parsed : @delimited.Payload = @protobuf.AsyncRead::read(reader)
+  @debug.assert_eq(parsed.delimited_child, Some(child))
+}

--- a/test/harness/cases/edition/runner/src/moon.pkg
+++ b/test/harness/cases/edition/runner/src/moon.pkg
@@ -4,6 +4,7 @@ import {
 import {
   "username/harness_edition/harness/edition",
   "username/harness_edition/harness/delimited",
+  "username/harness_edition/harness/file_delimited",
   "username/harness_edition/harness/inherited/file" @file_inherited,
   "username/harness_edition/harness/open_enum",
   "moonbitlang/protobuf",

--- a/test/harness/cases/edition/runner/src/moon.pkg
+++ b/test/harness/cases/edition/runner/src/moon.pkg
@@ -3,9 +3,11 @@ import {
 
 import {
   "username/harness_edition/harness/edition",
+  "username/harness_edition/harness/delimited",
   "username/harness_edition/harness/inherited/file" @file_inherited,
   "username/harness_edition/harness/open_enum",
   "moonbitlang/protobuf",
+  "moonbitlang/async",
   "moonbitlang/core/buffer",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",

--- a/test/harness/cases/syntax-defaults/proto/proto2_defaults.proto
+++ b/test/harness/cases/syntax-defaults/proto/proto2_defaults.proto
@@ -13,3 +13,15 @@ message Proto2Presence {
   repeated int32 values = 3;
   optional Proto2State state = 4;
 }
+
+message Proto2Groups {
+  optional group OptionalGroup = 1 {
+    optional int32 value = 2;
+  }
+
+  repeated group RepeatedGroup = 3 {
+    optional int32 value = 4;
+  }
+
+  optional int32 after = 5;
+}

--- a/test/harness/cases/syntax-defaults/runner/moon.mod
+++ b/test/harness/cases/syntax-defaults/runner/moon.mod
@@ -3,6 +3,7 @@ name = "username/harness_syntax_defaults_runner"
 version = "0.1.0"
 
 import {
+  "moonbitlang/async@0.18.0",
   "moonbitlang/protobuf@0.1.3",
   "username/harness_syntax_defaults@0.1.0",
 }
@@ -13,6 +14,6 @@ repository = ""
 
 license = ""
 
-keywords = []
+keywords = [ ]
 
 description = ""

--- a/test/harness/cases/syntax-defaults/runner/src/moon.pkg
+++ b/test/harness/cases/syntax-defaults/runner/src/moon.pkg
@@ -5,6 +5,7 @@ import {
   "username/harness_syntax_defaults/harness/syntax/proto2" @proto2,
   "username/harness_syntax_defaults/harness/syntax/proto3" @proto3,
   "moonbitlang/protobuf",
+  "moonbitlang/async",
   "moonbitlang/core/buffer",
   "moonbitlang/core/debug",
 } for "test"

--- a/test/harness/cases/syntax-defaults/runner/src/syntax_defaults_test.mbt
+++ b/test/harness/cases/syntax-defaults/runner/src/syntax_defaults_test.mbt
@@ -41,6 +41,65 @@ test "proto2 enum is closed by default" {
 }
 
 ///|
+/// Proto2 groups should lower to nested message values with group wire encoding.
+test "proto2 group writes group wire format" {
+  let child = @proto2.Proto2Groups_OptionalGroup::new(value=150)
+  let message = @proto2.Proto2Groups::new([], optionalgroup=child)
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x0b\x10\x96\x01\x0c")
+  @debug.assert_eq(
+    @protobuf.size_of(message),
+    writer.to_bytes().length().reinterpret_as_uint(),
+  )
+}
+
+///|
+/// Proto2 group readers should accept start/end group tags as one nested message.
+test "proto2 group reads group wire format" {
+  let reader = @protobuf.BytesReader::from_bytes(b"\x0b\x10\x96\x01\x0c")
+  let message : @proto2.Proto2Groups = @protobuf.Read::read(reader)
+  @debug.assert_eq(
+    message.optionalgroup,
+    Some(@proto2.Proto2Groups_OptionalGroup::new(value=150)),
+  )
+}
+
+///|
+/// Repeated proto2 groups should parse each group envelope as one array item.
+test "proto2 repeated groups use repeated group envelopes" {
+  let child = @proto2.Proto2Groups_RepeatedGroup::new(value=150)
+  let message = @proto2.Proto2Groups::new([child])
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.Write::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x1b\x20\x96\x01\x1c")
+  let reader = @protobuf.BytesReader::from_bytes(writer.to_bytes())
+  let parsed : @proto2.Proto2Groups = @protobuf.Read::read(reader)
+  @debug.assert_eq(parsed.repeatedgroup, [child])
+}
+
+///|
+/// Unknown group fields need field-number-aware skipping to find the matching end tag.
+test "proto2 unknown group fields are skipped" {
+  let reader = @protobuf.BytesReader::from_bytes(b"\x33\x08\x63\x34\x28\x07")
+  let message : @proto2.Proto2Groups = @protobuf.Read::read(reader)
+  @debug.assert_eq(message.after, Some(7))
+}
+
+///|
+/// Async generated codecs should use the same proto2 group wire format.
+async test "proto2 group async codecs" {
+  let child = @proto2.Proto2Groups_OptionalGroup::new(value=150)
+  let message = @proto2.Proto2Groups::new([], optionalgroup=child)
+  let writer = @buffer.Buffer::Buffer()
+  @protobuf.AsyncWrite::write(message, writer)
+  @debug.assert_eq(writer.to_bytes(), b"\x0b\x10\x96\x01\x0c")
+  let reader = @protobuf.BytesReader::from_bytes(writer.to_bytes())
+  let parsed : @proto2.Proto2Groups = @protobuf.AsyncRead::read(reader)
+  @debug.assert_eq(parsed.optionalgroup, Some(child))
+}
+
+///|
 /// Proto3 optional and implicit fields should keep distinct generated shapes.
 test "proto3 optional field controls generated presence" {
   let message = @proto3.Proto3Defaults::new(

--- a/test/reader/gen_proto2/src/top.mbt
+++ b/test/reader/gen_proto2/src/top.mbt
@@ -465,27 +465,30 @@ pub impl @lib.Read for FooMessageP2 with fn read_with_limit(
       (14, _) => msg.f_float = reader |> @lib.read_float() |> Some
       (15, _) => msg.f_bytes = reader |> @lib.read_bytes() |> Some
       (16, _) => msg.f_string = reader |> @lib.read_string() |> Some
-      (18, 2) =>
+      (18, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_bar_message = (reader |> @lib.read_message() : BarMessageP2)
           |> Some
-      (19, 2) =>
+      (19, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_int32.push_iter(
           (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
         )
-      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
-      (20, 2) =>
+      (19, @lib.WIRE_TYPE_VARINT) =>
+        msg.f_repeated_int32.push(reader |> @lib.read_int32())
+      (20, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_packed_int32.push_iter(
           (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
         )
-      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
-      (21, 2) =>
+      (20, @lib.WIRE_TYPE_VARINT) =>
+        msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+      (21, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_packed_float.push_iter(
           (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
         )
-      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-      (23, 2) =>
+      (21, @lib.WIRE_TYPE_FIXED32) =>
+        msg.f_repeated_packed_float.push(reader |> @lib.read_float())
+      (23, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_baz = (reader |> @lib.read_message() : BazMessageP2) |> Some
-      (24, 2) =>
+      (24, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
           |> Some
       (25, _) =>
@@ -493,12 +496,13 @@ pub impl @lib.Read for FooMessageP2 with fn read_with_limit(
           |> @lib.read_enum()
           |> BazMessageP2_Nested_NestedEnum::from_enum
           |> Some
-      (27, 2) => msg.f_map.push((reader |> @lib.read_message() : MapEntryP2))
+      (27, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
+        msg.f_map.push((reader |> @lib.read_message() : MapEntryP2))
       (28, _) => msg.f1 = reader |> @lib.read_int32() |> Some
       (29, _) => msg.f2 = reader |> @lib.read_bool() |> Some
       (30, _) => msg.f3 = reader |> @lib.read_string() |> Some
       (31, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-      (32, 2) =>
+      (32, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_baz_message.push(
           (reader |> @lib.read_message() : BazMessageP2),
         )
@@ -512,13 +516,13 @@ pub impl @lib.Read for FooMessageP2 with fn read_with_limit(
           |> @lib.read_enum()
           |> FooEnumP2::from_enum
           |> Some
-      (39, 2) => {
+      (39, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let packed = reader |> @lib.read_packed(@lib.read_enum, None)
         for item in packed {
           msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
         }
       }
-      (39, 0) =>
+      (39, @lib.WIRE_TYPE_VARINT) =>
         msg.f_repeated_packed_enum.push(
           reader |> @lib.read_enum() |> FooEnumP2::from_enum,
         )
@@ -958,29 +962,30 @@ pub impl @lib.AsyncRead for FooMessageP2 with fn read_with_limit(
       (14, _) => msg.f_float = reader |> @lib.async_read_float() |> Some
       (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes() |> Some
       (16, _) => msg.f_string = reader |> @lib.async_read_string() |> Some
-      (18, 2) =>
+      (18, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessageP2)
           |> Some
-      (19, 2) =>
+      (19, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_int32.push_iter(
           (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
         )
-      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
-      (20, 2) =>
+      (19, @lib.WIRE_TYPE_VARINT) =>
+        msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+      (20, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_packed_int32.push_iter(
           (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
         )
-      (20, 0) =>
+      (20, @lib.WIRE_TYPE_VARINT) =>
         msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
-      (21, 2) =>
+      (21, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_packed_float.push_iter(
           (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
         )
-      (21, 5) =>
+      (21, @lib.WIRE_TYPE_FIXED32) =>
         msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-      (23, 2) =>
+      (23, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_baz = (reader |> @lib.async_read_message() : BazMessageP2) |> Some
-      (24, 2) =>
+      (24, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_nested = (
             reader |> @lib.async_read_message() : BazMessageP2_Nested)
           |> Some
@@ -989,13 +994,13 @@ pub impl @lib.AsyncRead for FooMessageP2 with fn read_with_limit(
           |> @lib.async_read_enum()
           |> BazMessageP2_Nested_NestedEnum::from_enum
           |> Some
-      (27, 2) =>
+      (27, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_map.push((reader |> @lib.async_read_message() : MapEntryP2))
       (28, _) => msg.f1 = reader |> @lib.async_read_int32() |> Some
       (29, _) => msg.f2 = reader |> @lib.async_read_bool() |> Some
       (30, _) => msg.f3 = reader |> @lib.async_read_string() |> Some
       (31, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
-      (32, 2) =>
+      (32, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_baz_message.push(
           (reader |> @lib.async_read_message() : BazMessageP2),
         )
@@ -1012,14 +1017,14 @@ pub impl @lib.AsyncRead for FooMessageP2 with fn read_with_limit(
           |> @lib.async_read_enum()
           |> FooEnumP2::from_enum
           |> Some
-      (39, 2) => {
+      (39, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let packed = reader
           |> @lib.async_read_packed(@lib.async_read_enum, None)
         for item in packed {
           msg.f_repeated_packed_enum.push(FooEnumP2::from_enum(item))
         }
       }
-      (39, 0) =>
+      (39, @lib.WIRE_TYPE_VARINT) =>
         msg.f_repeated_packed_enum.push(
           reader |> @lib.async_read_enum() |> FooEnumP2::from_enum,
         )
@@ -1507,7 +1512,7 @@ pub impl @lib.Read for BazMessageP2_Nested with fn read_with_limit(
   let msg = BazMessageP2_Nested::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_nested = (
             reader |> @lib.read_message() : BazMessageP2_Nested_NestedMessage)
           |> Some
@@ -1567,7 +1572,7 @@ pub impl @lib.AsyncRead for BazMessageP2_Nested with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_nested = (
             reader |> @lib.async_read_message() :
             BazMessageP2_Nested_NestedMessage)
@@ -1632,7 +1637,7 @@ pub impl @lib.Read for BazMessageP2 with fn read_with_limit(
   let msg = BazMessageP2::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
           |> Some
       (2, _) => msg.b_int64 = reader |> @lib.read_int64() |> Some
@@ -1709,7 +1714,7 @@ pub impl @lib.AsyncRead for BazMessageP2 with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.nested = (reader |> @lib.async_read_message() : BazMessageP2_Nested)
           |> Some
       (2, _) => msg.b_int64 = reader |> @lib.async_read_int64() |> Some
@@ -1772,7 +1777,7 @@ pub impl @lib.Read for RepeatedMessageP2 with fn read_with_limit(
   let msg = RepeatedMessageP2::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.bar_message.push((reader |> @lib.read_message() : BarMessageP2))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
@@ -1829,7 +1834,7 @@ pub impl @lib.AsyncRead for RepeatedMessageP2 with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.bar_message.push(
           (reader |> @lib.async_read_message() : BarMessageP2),
         )

--- a/test/reader/gen_proto2/src/top.mbt
+++ b/test/reader/gen_proto2/src/top.mbt
@@ -86,7 +86,7 @@ pub impl @lib.Read for BarMessageP2 with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.b_int32 = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -137,7 +137,7 @@ pub impl @lib.AsyncRead for BarMessageP2 with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -465,7 +465,7 @@ pub impl @lib.Read for FooMessageP2 with fn read_with_limit(
       (14, _) => msg.f_float = reader |> @lib.read_float() |> Some
       (15, _) => msg.f_bytes = reader |> @lib.read_bytes() |> Some
       (16, _) => msg.f_string = reader |> @lib.read_string() |> Some
-      (18, _) =>
+      (18, 2) =>
         msg.f_bar_message = (reader |> @lib.read_message() : BarMessageP2)
           |> Some
       (19, 2) =>
@@ -483,9 +483,9 @@ pub impl @lib.Read for FooMessageP2 with fn read_with_limit(
           (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
         )
       (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-      (23, _) =>
+      (23, 2) =>
         msg.f_baz = (reader |> @lib.read_message() : BazMessageP2) |> Some
-      (24, _) =>
+      (24, 2) =>
         msg.f_nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
           |> Some
       (25, _) =>
@@ -493,12 +493,12 @@ pub impl @lib.Read for FooMessageP2 with fn read_with_limit(
           |> @lib.read_enum()
           |> BazMessageP2_Nested_NestedEnum::from_enum
           |> Some
-      (27, _) => msg.f_map.push((reader |> @lib.read_message() : MapEntryP2))
+      (27, 2) => msg.f_map.push((reader |> @lib.read_message() : MapEntryP2))
       (28, _) => msg.f1 = reader |> @lib.read_int32() |> Some
       (29, _) => msg.f2 = reader |> @lib.read_bool() |> Some
       (30, _) => msg.f3 = reader |> @lib.read_string() |> Some
       (31, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-      (32, _) =>
+      (32, 2) =>
         msg.f_repeated_baz_message.push(
           (reader |> @lib.read_message() : BazMessageP2),
         )
@@ -522,7 +522,7 @@ pub impl @lib.Read for FooMessageP2 with fn read_with_limit(
         msg.f_repeated_packed_enum.push(
           reader |> @lib.read_enum() |> FooEnumP2::from_enum,
         )
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -958,7 +958,7 @@ pub impl @lib.AsyncRead for FooMessageP2 with fn read_with_limit(
       (14, _) => msg.f_float = reader |> @lib.async_read_float() |> Some
       (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes() |> Some
       (16, _) => msg.f_string = reader |> @lib.async_read_string() |> Some
-      (18, _) =>
+      (18, 2) =>
         msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessageP2)
           |> Some
       (19, 2) =>
@@ -978,9 +978,9 @@ pub impl @lib.AsyncRead for FooMessageP2 with fn read_with_limit(
         )
       (21, 5) =>
         msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-      (23, _) =>
+      (23, 2) =>
         msg.f_baz = (reader |> @lib.async_read_message() : BazMessageP2) |> Some
-      (24, _) =>
+      (24, 2) =>
         msg.f_nested = (
             reader |> @lib.async_read_message() : BazMessageP2_Nested)
           |> Some
@@ -989,13 +989,13 @@ pub impl @lib.AsyncRead for FooMessageP2 with fn read_with_limit(
           |> @lib.async_read_enum()
           |> BazMessageP2_Nested_NestedEnum::from_enum
           |> Some
-      (27, _) =>
+      (27, 2) =>
         msg.f_map.push((reader |> @lib.async_read_message() : MapEntryP2))
       (28, _) => msg.f1 = reader |> @lib.async_read_int32() |> Some
       (29, _) => msg.f2 = reader |> @lib.async_read_bool() |> Some
       (30, _) => msg.f3 = reader |> @lib.async_read_string() |> Some
       (31, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
-      (32, _) =>
+      (32, 2) =>
         msg.f_repeated_baz_message.push(
           (reader |> @lib.async_read_message() : BazMessageP2),
         )
@@ -1023,7 +1023,7 @@ pub impl @lib.AsyncRead for FooMessageP2 with fn read_with_limit(
         msg.f_repeated_packed_enum.push(
           reader |> @lib.async_read_enum() |> FooEnumP2::from_enum,
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1227,7 +1227,7 @@ pub impl @lib.Read for MapEntryP2 with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.read_string()
       (2, _) => msg.value = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1285,7 +1285,7 @@ pub impl @lib.AsyncRead for MapEntryP2 with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.async_read_string()
       (2, _) => msg.value = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1406,7 +1406,7 @@ pub impl @lib.Read for BazMessageP2_Nested_NestedMessage with fn read_with_limit
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.f_nested = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1459,7 +1459,7 @@ pub impl @lib.AsyncRead for BazMessageP2_Nested_NestedMessage with fn read_with_
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1507,11 +1507,11 @@ pub impl @lib.Read for BazMessageP2_Nested with fn read_with_limit(
   let msg = BazMessageP2_Nested::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.f_nested = (
             reader |> @lib.read_message() : BazMessageP2_Nested_NestedMessage)
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1567,12 +1567,12 @@ pub impl @lib.AsyncRead for BazMessageP2_Nested with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.f_nested = (
             reader |> @lib.async_read_message() :
             BazMessageP2_Nested_NestedMessage)
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1632,12 +1632,12 @@ pub impl @lib.Read for BazMessageP2 with fn read_with_limit(
   let msg = BazMessageP2::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.nested = (reader |> @lib.read_message() : BazMessageP2_Nested)
           |> Some
       (2, _) => msg.b_int64 = reader |> @lib.read_int64() |> Some
       (3, _) => msg.b_string = reader |> @lib.read_string() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1709,12 +1709,12 @@ pub impl @lib.AsyncRead for BazMessageP2 with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.nested = (reader |> @lib.async_read_message() : BazMessageP2_Nested)
           |> Some
       (2, _) => msg.b_int64 = reader |> @lib.async_read_int64() |> Some
       (3, _) => msg.b_string = reader |> @lib.async_read_string() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1772,9 +1772,9 @@ pub impl @lib.Read for RepeatedMessageP2 with fn read_with_limit(
   let msg = RepeatedMessageP2::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.bar_message.push((reader |> @lib.read_message() : BarMessageP2))
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1829,11 +1829,11 @@ pub impl @lib.AsyncRead for RepeatedMessageP2 with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.bar_message.push(
           (reader |> @lib.async_read_message() : BarMessageP2),
         )
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -99,7 +99,7 @@ pub impl @lib.Read for BarMessage with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.b_int32 = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -152,7 +152,7 @@ pub impl @lib.AsyncRead for BarMessage with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -209,7 +209,7 @@ pub impl @lib.Read for FooMessage_FMapEntry with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.read_string()
       (2, _) => msg.value = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -273,7 +273,7 @@ pub impl @lib.AsyncRead for FooMessage_FMapEntry with fn read_with_limit(
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.async_read_string()
       (2, _) => msg.value = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -649,7 +649,7 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(
       (14, _) => msg.f_float = reader |> @lib.read_float()
       (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
       (16, _) => msg.f_string = reader |> @lib.read_string()
-      (18, _) =>
+      (18, 2) =>
         msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
       (19, 2) =>
         msg.f_repeated_int32.push_iter(
@@ -666,22 +666,22 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(
           (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
         )
       (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-      (23, _) =>
+      (23, 2) =>
         msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
-      (24, _) =>
+      (24, 2) =>
         msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested)
           |> Some
       (25, _) =>
         msg.f_nested_enum = reader
           |> @lib.read_enum()
           |> BazMessage_Nested_NestedEnum::from_enum
-      (26, _) => {
+      (26, 2) => {
         let { key, value } = (
           reader |> @lib.read_message() : FooMessage_FMapEntry)
         msg.f_map[key] = value
       }
       (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-      (31, _) =>
+      (31, 2) =>
         msg.f_repeated_baz_message.push(
           (reader |> @lib.read_message() : BazMessage),
         )
@@ -707,10 +707,10 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(
         msg.f_repeated_unpacked_enum.push(
           reader |> @lib.read_enum() |> FooEnum::from_enum,
         )
-      (36, _) =>
+      (36, 2) =>
         msg.f_timestamp = (reader |> @lib.read_message() : @protobuf.Timestamp)
           |> Some
-      (37, _) =>
+      (37, 2) =>
         msg.f_duration = (reader |> @lib.read_message() : @protobuf.Duration)
           |> Some
       (27, _) =>
@@ -721,7 +721,7 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(
         msg.test_oneof = reader
           |> @lib.read_string()
           |> FooMessage_TestOneof::F3
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -852,7 +852,6 @@ pub impl @lib.Write for FooMessage with fn write(
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
-
     writer |> @lib.write_varint(16UL)
     writer |> @lib.write_int32(v)
   }
@@ -1130,7 +1129,7 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(
       (14, _) => msg.f_float = reader |> @lib.async_read_float()
       (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
       (16, _) => msg.f_string = reader |> @lib.async_read_string()
-      (18, _) =>
+      (18, 2) =>
         msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage)
           |> Some
       (19, 2) =>
@@ -1150,22 +1149,22 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(
         )
       (21, 5) =>
         msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-      (23, _) =>
+      (23, 2) =>
         msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
-      (24, _) =>
+      (24, 2) =>
         msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested)
           |> Some
       (25, _) =>
         msg.f_nested_enum = reader
           |> @lib.async_read_enum()
           |> BazMessage_Nested_NestedEnum::from_enum
-      (26, _) => {
+      (26, 2) => {
         let { key, value } = (
           reader |> @lib.async_read_message() : FooMessage_FMapEntry)
         msg.f_map[key] = value
       }
       (30, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
-      (31, _) =>
+      (31, 2) =>
         msg.f_repeated_baz_message.push(
           (reader |> @lib.async_read_message() : BazMessage),
         )
@@ -1194,11 +1193,11 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(
         msg.f_repeated_unpacked_enum.push(
           reader |> @lib.async_read_enum() |> FooEnum::from_enum,
         )
-      (36, _) =>
+      (36, 2) =>
         msg.f_timestamp = (
             reader |> @lib.async_read_message() : @protobuf.Timestamp)
           |> Some
-      (37, _) =>
+      (37, 2) =>
         msg.f_duration = (
             reader |> @lib.async_read_message() : @protobuf.Duration)
           |> Some
@@ -1214,7 +1213,7 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(
         msg.test_oneof = reader
           |> @lib.async_read_string()
           |> FooMessage_TestOneof::F3
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1345,7 +1344,6 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)
-
     writer |> @lib.async_write_varint(16UL)
     writer |> @lib.async_write_int32(v)
   }
@@ -1522,7 +1520,7 @@ pub impl @lib.Read for BazMessage_Nested_NestedMessage with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.f_nested = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1577,7 +1575,7 @@ pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with fn read_with_li
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1627,11 +1625,11 @@ pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(
   let msg = BazMessage_Nested::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.f_nested = (
             reader |> @lib.read_message() : BazMessage_Nested_NestedMessage)
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1687,12 +1685,12 @@ pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.f_nested = (
             reader |> @lib.async_read_message() :
             BazMessage_Nested_NestedMessage)
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1756,11 +1754,11 @@ pub impl @lib.Read for BazMessage with fn read_with_limit(
   let msg = BazMessage::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
       (2, _) => msg.b_int64 = reader |> @lib.read_int64()
       (3, _) => msg.b_string = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1829,12 +1827,12 @@ pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested)
           |> Some
       (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
       (3, _) => msg.b_string = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1890,9 +1888,9 @@ pub impl @lib.Read for RepeatedMessage with fn read_with_limit(
   let msg = RepeatedMessage::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1947,9 +1945,9 @@ pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1998,7 +1996,7 @@ pub impl @lib.Read for EmptyMessage with fn read_with_limit(
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.field = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2051,7 +2049,7 @@ pub impl @lib.AsyncRead for EmptyMessage with fn read_with_limit(
         is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.field = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2101,10 +2099,10 @@ pub impl @lib.Read for EmptyMessageWithField with fn read_with_limit(
   let msg = EmptyMessageWithField::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.empty_message = (reader |> @lib.read_message() : EmptyMessage)
           |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2160,10 +2158,10 @@ pub impl @lib.AsyncRead for EmptyMessageWithField with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) =>
+      (1, 2) =>
         msg.empty_message = (reader |> @lib.async_read_message() : EmptyMessage)
           |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2276,7 +2274,7 @@ pub impl @lib.Read for OnlyOneOfField with fn read_with_limit(
         msg.test_oneof = reader
           |> @lib.read_string()
           |> OnlyOneOfField_TestOneof::F3
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2356,7 +2354,7 @@ pub impl @lib.AsyncRead for OnlyOneOfField with fn read_with_limit(
         msg.test_oneof = reader
           |> @lib.async_read_string()
           |> OnlyOneOfField_TestOneof::F3
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/test/reader/gen_proto3/src/top.mbt
+++ b/test/reader/gen_proto3/src/top.mbt
@@ -649,68 +649,71 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(
       (14, _) => msg.f_float = reader |> @lib.read_float()
       (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
       (16, _) => msg.f_string = reader |> @lib.read_string()
-      (18, 2) =>
+      (18, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
-      (19, 2) =>
+      (19, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_int32.push_iter(
           (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
         )
-      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
-      (20, 2) =>
+      (19, @lib.WIRE_TYPE_VARINT) =>
+        msg.f_repeated_int32.push(reader |> @lib.read_int32())
+      (20, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_packed_int32.push_iter(
           (reader |> @lib.read_packed(@lib.read_int32, None)).iter(),
         )
-      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
-      (21, 2) =>
+      (20, @lib.WIRE_TYPE_VARINT) =>
+        msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+      (21, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_packed_float.push_iter(
           (reader |> @lib.read_packed(@lib.read_float, Some(4))).iter(),
         )
-      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-      (23, 2) =>
+      (21, @lib.WIRE_TYPE_FIXED32) =>
+        msg.f_repeated_packed_float.push(reader |> @lib.read_float())
+      (23, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
-      (24, 2) =>
+      (24, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested)
           |> Some
       (25, _) =>
         msg.f_nested_enum = reader
           |> @lib.read_enum()
           |> BazMessage_Nested_NestedEnum::from_enum
-      (26, 2) => {
+      (26, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let { key, value } = (
           reader |> @lib.read_message() : FooMessage_FMapEntry)
         msg.f_map[key] = value
       }
       (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-      (31, 2) =>
+      (31, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_baz_message.push(
           (reader |> @lib.read_message() : BazMessage),
         )
       (32, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
       (33, _) => msg.with_json_name = reader |> @lib.read_string()
-      (34, 2) => {
+      (34, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let packed = reader |> @lib.read_packed(@lib.read_enum, None)
         for item in packed {
           msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
         }
       }
-      (34, 0) =>
+      (34, @lib.WIRE_TYPE_VARINT) =>
         msg.f_repeated_packed_enum.push(
           reader |> @lib.read_enum() |> FooEnum::from_enum,
         )
-      (35, 2) => {
+      (35, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let packed = reader |> @lib.read_packed(@lib.read_enum, None)
         for item in packed {
           msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
         }
       }
-      (35, 0) =>
+      (35, @lib.WIRE_TYPE_VARINT) =>
         msg.f_repeated_unpacked_enum.push(
           reader |> @lib.read_enum() |> FooEnum::from_enum,
         )
-      (36, 2) =>
+      (36, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_timestamp = (reader |> @lib.read_message() : @protobuf.Timestamp)
           |> Some
-      (37, 2) =>
+      (37, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_duration = (reader |> @lib.read_message() : @protobuf.Duration)
           |> Some
       (27, _) =>
@@ -1129,75 +1132,76 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(
       (14, _) => msg.f_float = reader |> @lib.async_read_float()
       (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
       (16, _) => msg.f_string = reader |> @lib.async_read_string()
-      (18, 2) =>
+      (18, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage)
           |> Some
-      (19, 2) =>
+      (19, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_int32.push_iter(
           (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
         )
-      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
-      (20, 2) =>
+      (19, @lib.WIRE_TYPE_VARINT) =>
+        msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+      (20, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_packed_int32.push_iter(
           (reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter(),
         )
-      (20, 0) =>
+      (20, @lib.WIRE_TYPE_VARINT) =>
         msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
-      (21, 2) =>
+      (21, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_packed_float.push_iter(
           (reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter(),
         )
-      (21, 5) =>
+      (21, @lib.WIRE_TYPE_FIXED32) =>
         msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-      (23, 2) =>
+      (23, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
-      (24, 2) =>
+      (24, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested)
           |> Some
       (25, _) =>
         msg.f_nested_enum = reader
           |> @lib.async_read_enum()
           |> BazMessage_Nested_NestedEnum::from_enum
-      (26, 2) => {
+      (26, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let { key, value } = (
           reader |> @lib.async_read_message() : FooMessage_FMapEntry)
         msg.f_map[key] = value
       }
       (30, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
-      (31, 2) =>
+      (31, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_repeated_baz_message.push(
           (reader |> @lib.async_read_message() : BazMessage),
         )
       (32, _) =>
         msg.f_optional_string = reader |> @lib.async_read_string() |> Some
       (33, _) => msg.with_json_name = reader |> @lib.async_read_string()
-      (34, 2) => {
+      (34, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let packed = reader
           |> @lib.async_read_packed(@lib.async_read_enum, None)
         for item in packed {
           msg.f_repeated_packed_enum.push(FooEnum::from_enum(item))
         }
       }
-      (34, 0) =>
+      (34, @lib.WIRE_TYPE_VARINT) =>
         msg.f_repeated_packed_enum.push(
           reader |> @lib.async_read_enum() |> FooEnum::from_enum,
         )
-      (35, 2) => {
+      (35, @lib.WIRE_TYPE_LENGTH_DELIMITED) => {
         let packed = reader
           |> @lib.async_read_packed(@lib.async_read_enum, None)
         for item in packed {
           msg.f_repeated_unpacked_enum.push(FooEnum::from_enum(item))
         }
       }
-      (35, 0) =>
+      (35, @lib.WIRE_TYPE_VARINT) =>
         msg.f_repeated_unpacked_enum.push(
           reader |> @lib.async_read_enum() |> FooEnum::from_enum,
         )
-      (36, 2) =>
+      (36, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_timestamp = (
             reader |> @lib.async_read_message() : @protobuf.Timestamp)
           |> Some
-      (37, 2) =>
+      (37, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_duration = (
             reader |> @lib.async_read_message() : @protobuf.Duration)
           |> Some
@@ -1625,7 +1629,7 @@ pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(
   let msg = BazMessage_Nested::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_nested = (
             reader |> @lib.read_message() : BazMessage_Nested_NestedMessage)
           |> Some
@@ -1685,7 +1689,7 @@ pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.f_nested = (
             reader |> @lib.async_read_message() :
             BazMessage_Nested_NestedMessage)
@@ -1754,7 +1758,7 @@ pub impl @lib.Read for BazMessage with fn read_with_limit(
   let msg = BazMessage::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
       (2, _) => msg.b_int64 = reader |> @lib.read_int64()
       (3, _) => msg.b_string = reader |> @lib.read_string()
@@ -1827,7 +1831,7 @@ pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested)
           |> Some
       (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
@@ -1888,7 +1892,7 @@ pub impl @lib.Read for RepeatedMessage with fn read_with_limit(
   let msg = RepeatedMessage::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
@@ -1945,7 +1949,7 @@ pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
@@ -2099,7 +2103,7 @@ pub impl @lib.Read for EmptyMessageWithField with fn read_with_limit(
   let msg = EmptyMessageWithField::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.empty_message = (reader |> @lib.read_message() : EmptyMessage)
           |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -2158,7 +2162,7 @@ pub impl @lib.AsyncRead for EmptyMessageWithField with fn read_with_limit(
   while (reader |> @lib.async_read_next_message_field())
         is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) =>
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) =>
         msg.empty_message = (reader |> @lib.async_read_message() : EmptyMessage)
           |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -451,19 +451,19 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(reader : @lib.LimitedR
       (14, _) => msg.f_float = reader |> @lib.read_float()
       (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
       (16, _) => msg.f_string = reader |> @lib.read_string()
-      (18, 2) => msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
-      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
-      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
-      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()) }
-      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-      (23, 2) => msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
-      (24, 2) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
+      (18, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
+      (19, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (19, @lib.WIRE_TYPE_VARINT) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
+      (20, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (20, @lib.WIRE_TYPE_VARINT) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
+      (21, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()) }
+      (21, @lib.WIRE_TYPE_FIXED32) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
+      (23, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
+      (24, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
       (25, _) => msg.f_nested_enum = reader |> @lib.read_enum() |> BazMessage_Nested_NestedEnum::from_enum
-      (26, 2) => { let {key, value} = (reader |> @lib.read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
+      (26, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { let {key, value} = (reader |> @lib.read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
       (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-      (31, 2) => msg.f_repeated_baz_message.push((reader |> @lib.read_message() : BazMessage))
+      (31, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.f_repeated_baz_message.push((reader |> @lib.read_message() : BazMessage))
       (32, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
       (27, _) => msg.test_oneof = reader |> @lib.read_int32() |> FooMessage_TestOneof::F1
       (28, _) => msg.test_oneof = reader |> @lib.read_bool() |> FooMessage_TestOneof::F2
@@ -781,19 +781,19 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(reader : @lib.Lim
       (14, _) => msg.f_float = reader |> @lib.async_read_float()
       (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
       (16, _) => msg.f_string = reader |> @lib.async_read_string()
-      (18, 2) => msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage) |> Some
-      (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
-      (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
-      (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()) }
-      (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-      (23, 2) => msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
-      (24, 2) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
+      (18, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage) |> Some
+      (19, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (19, @lib.WIRE_TYPE_VARINT) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
+      (20, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (20, @lib.WIRE_TYPE_VARINT) => msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
+      (21, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()) }
+      (21, @lib.WIRE_TYPE_FIXED32) => msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
+      (23, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
+      (24, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
       (25, _) => msg.f_nested_enum = reader |> @lib.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum
-      (26, 2) => { let {key, value} = (reader |> @lib.async_read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
+      (26, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { let {key, value} = (reader |> @lib.async_read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
       (30, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
-      (31, 2) => msg.f_repeated_baz_message.push((reader |> @lib.async_read_message() : BazMessage))
+      (31, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.f_repeated_baz_message.push((reader |> @lib.async_read_message() : BazMessage))
       (32, _) => msg.f_optional_string = reader |> @lib.async_read_string() |> Some
       (27, _) => msg.test_oneof = reader |> @lib.async_read_int32() |> FooMessage_TestOneof::F1
       (28, _) => msg.test_oneof = reader |> @lib.async_read_bool() |> FooMessage_TestOneof::F2
@@ -1098,7 +1098,7 @@ pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(reader : @lib.L
   let msg = BazMessage_Nested::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage) |> Some
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1135,7 +1135,7 @@ pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(reader : @
   let msg = BazMessage_Nested::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage) |> Some
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1183,7 +1183,7 @@ pub impl @lib.Read for BazMessage with fn read_with_limit(reader : @lib.LimitedR
   let msg = BazMessage::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
       (2, _) => msg.b_int64 = reader |> @lib.read_int64()
       (3, _) => msg.b_string = reader |> @lib.read_string()
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -1238,7 +1238,7 @@ pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(reader : @lib.Lim
   let msg = BazMessage::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
       (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
       (3, _) => msg.b_string = reader |> @lib.async_read_string()
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -1284,7 +1284,7 @@ pub impl @lib.Read for RepeatedMessage with fn read_with_limit(reader : @lib.Lim
   let msg = RepeatedMessage::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1321,7 +1321,7 @@ pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(reader : @li
   let msg = RepeatedMessage::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -70,7 +70,7 @@ pub impl @lib.Read for BarMessage with fn read_with_limit(reader : @lib.LimitedR
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.b_int32 = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -106,7 +106,7 @@ pub impl @lib.AsyncRead for BarMessage with fn read_with_limit(reader : @lib.Lim
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.b_int32 = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -149,7 +149,7 @@ pub impl @lib.Read for FooMessage_FMapEntry with fn read_with_limit(reader : @li
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.read_string()
       (2, _) => msg.value = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -194,7 +194,7 @@ pub impl @lib.AsyncRead for FooMessage_FMapEntry with fn read_with_limit(reader 
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.async_read_string()
       (2, _) => msg.value = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -451,24 +451,24 @@ pub impl @lib.Read for FooMessage with fn read_with_limit(reader : @lib.LimitedR
       (14, _) => msg.f_float = reader |> @lib.read_float()
       (15, _) => msg.f_bytes = reader |> @lib.read_bytes()
       (16, _) => msg.f_string = reader |> @lib.read_string()
-      (18, _) => msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
+      (18, 2) => msg.f_bar_message = (reader |> @lib.read_message() : BarMessage) |> Some
       (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
       (19, 0) => msg.f_repeated_int32.push(reader |> @lib.read_int32())
       (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
       (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.read_int32())
       (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.read_packed(@lib.read_float, Some(4))).iter()) }
       (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.read_float())
-      (23, _) => msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
-      (24, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
+      (23, 2) => msg.f_baz = (reader |> @lib.read_message() : BazMessage) |> Some
+      (24, 2) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
       (25, _) => msg.f_nested_enum = reader |> @lib.read_enum() |> BazMessage_Nested_NestedEnum::from_enum
-      (26, _) => { let {key, value} = (reader |> @lib.read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
+      (26, 2) => { let {key, value} = (reader |> @lib.read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
       (30, _) => msg.f_repeated_string.push(reader |> @lib.read_string())
-      (31, _) => msg.f_repeated_baz_message.push((reader |> @lib.read_message() : BazMessage))
+      (31, 2) => msg.f_repeated_baz_message.push((reader |> @lib.read_message() : BazMessage))
       (32, _) => msg.f_optional_string = reader |> @lib.read_string() |> Some
       (27, _) => msg.test_oneof = reader |> @lib.read_int32() |> FooMessage_TestOneof::F1
       (28, _) => msg.test_oneof = reader |> @lib.read_bool() |> FooMessage_TestOneof::F2
       (29, _) => msg.test_oneof = reader |> @lib.read_string() |> FooMessage_TestOneof::F3
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -540,6 +540,7 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
   }
   if self.f_bar_message is Some(v) {
     writer |> @lib.write_varint(146UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -572,11 +573,13 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
   }
   if self.f_baz is Some(v) {
     writer |> @lib.write_varint(186UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.f_nested is Some(v) {
     writer |> @lib.write_varint(194UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -599,34 +602,40 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
     writer |> @lib.write_int32(v)
 
   }
-   for item in self.f_repeated_string {
+  for item in self.f_repeated_string {
     writer |> @lib.write_varint(242UL)
+
     writer |> @lib.write_string(item)
 
   }
   for item in self.f_repeated_baz_message {
     writer |> @lib.write_varint(250UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.f_optional_string is Some(v) {
     writer |> @lib.write_varint(258UL);
+
     writer |> @lib.write_string(v)
 
   }
   match self.test_oneof {
     FooMessage_TestOneof::F1(v) => {
       writer |> @lib.write_varint(216UL)
+
       writer |> @lib.write_int32(v)
 
      }
     FooMessage_TestOneof::F2(v) => {
       writer |> @lib.write_varint(224UL)
+
       writer |> @lib.write_bool(v)
 
      }
     FooMessage_TestOneof::F3(v) => {
       writer |> @lib.write_varint(234UL)
+
       writer |> @lib.write_string(v)
 
      }
@@ -795,24 +804,24 @@ pub impl @lib.AsyncRead for FooMessage with fn read_with_limit(reader : @lib.Lim
       (14, _) => msg.f_float = reader |> @lib.async_read_float()
       (15, _) => msg.f_bytes = reader |> @lib.async_read_bytes()
       (16, _) => msg.f_string = reader |> @lib.async_read_string()
-      (18, _) => msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage) |> Some
+      (18, 2) => msg.f_bar_message = (reader |> @lib.async_read_message() : BarMessage) |> Some
       (19, 2) => { msg.f_repeated_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
       (19, 0) => msg.f_repeated_int32.push(reader |> @lib.async_read_int32())
       (20, 2) => { msg.f_repeated_packed_int32.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
       (20, 0) => msg.f_repeated_packed_int32.push(reader |> @lib.async_read_int32())
       (21, 2) => { msg.f_repeated_packed_float.push_iter((reader |> @lib.async_read_packed(@lib.async_read_float, Some(4))).iter()) }
       (21, 5) => msg.f_repeated_packed_float.push(reader |> @lib.async_read_float())
-      (23, _) => msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
-      (24, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
+      (23, 2) => msg.f_baz = (reader |> @lib.async_read_message() : BazMessage) |> Some
+      (24, 2) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
       (25, _) => msg.f_nested_enum = reader |> @lib.async_read_enum() |> BazMessage_Nested_NestedEnum::from_enum
-      (26, _) => { let {key, value} = (reader |> @lib.async_read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
+      (26, 2) => { let {key, value} = (reader |> @lib.async_read_message() : FooMessage_FMapEntry); msg.f_map[key] = value }
       (30, _) => msg.f_repeated_string.push(reader |> @lib.async_read_string())
-      (31, _) => msg.f_repeated_baz_message.push((reader |> @lib.async_read_message() : BazMessage))
+      (31, 2) => msg.f_repeated_baz_message.push((reader |> @lib.async_read_message() : BazMessage))
       (32, _) => msg.f_optional_string = reader |> @lib.async_read_string() |> Some
       (27, _) => msg.test_oneof = reader |> @lib.async_read_int32() |> FooMessage_TestOneof::F1
       (28, _) => msg.test_oneof = reader |> @lib.async_read_bool() |> FooMessage_TestOneof::F2
       (29, _) => msg.test_oneof = reader |> @lib.async_read_string() |> FooMessage_TestOneof::F3
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -884,6 +893,7 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
   }
   if self.f_bar_message is Some(v) {
     writer |> @lib.async_write_varint(146UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -916,11 +926,13 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
   }
   if self.f_baz is Some(v) {
     writer |> @lib.async_write_varint(186UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.f_nested is Some(v) {
     writer |> @lib.async_write_varint(194UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -943,34 +955,40 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
     writer |> @lib.async_write_int32(v)
 
   }
-   for item in self.f_repeated_string {
+  for item in self.f_repeated_string {
     writer |> @lib.async_write_varint(242UL)
+
     writer |> @lib.async_write_string(item)
 
   }
   for item in self.f_repeated_baz_message {
     writer |> @lib.async_write_varint(250UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.f_optional_string is Some(v) {
     writer |> @lib.async_write_varint(258UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   match self.test_oneof {
     FooMessage_TestOneof::F1(v) => {
       writer |> @lib.async_write_varint(216UL)
+
       writer |> @lib.async_write_int32(v)
 
      }
     FooMessage_TestOneof::F2(v) => {
       writer |> @lib.async_write_varint(224UL)
+
       writer |> @lib.async_write_bool(v)
 
      }
     FooMessage_TestOneof::F3(v) => {
       writer |> @lib.async_write_varint(234UL)
+
       writer |> @lib.async_write_string(v)
 
      }
@@ -1055,7 +1073,7 @@ pub impl @lib.Read for BazMessage_Nested_NestedMessage with fn read_with_limit(r
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.f_nested = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1091,7 +1109,7 @@ pub impl @lib.AsyncRead for BazMessage_Nested_NestedMessage with fn read_with_li
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.f_nested = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1126,8 +1144,8 @@ pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(reader : @lib.L
   let msg = BazMessage_Nested::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (1, 2) => msg.f_nested = (reader |> @lib.read_message() : BazMessage_Nested_NestedMessage) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1135,6 +1153,7 @@ pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(reader : @lib.L
 pub impl @lib.Write for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.Writer) -> Unit raise {
   if self.f_nested is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -1164,8 +1183,8 @@ pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(reader : @
   let msg = BazMessage_Nested::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (1, 2) => msg.f_nested = (reader |> @lib.async_read_message() : BazMessage_Nested_NestedMessage) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1173,6 +1192,7 @@ pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(reader : @
 pub impl @lib.AsyncWrite for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.f_nested is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -1213,10 +1233,10 @@ pub impl @lib.Read for BazMessage with fn read_with_limit(reader : @lib.LimitedR
   let msg = BazMessage::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
+      (1, 2) => msg.nested = (reader |> @lib.read_message() : BazMessage_Nested) |> Some
       (2, _) => msg.b_int64 = reader |> @lib.read_int64()
       (3, _) => msg.b_string = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1224,6 +1244,7 @@ pub impl @lib.Read for BazMessage with fn read_with_limit(reader : @lib.LimitedR
 pub impl @lib.Write for BazMessage with fn write(self: BazMessage, writer : &@lib.Writer) -> Unit raise {
   if self.nested is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -1269,10 +1290,10 @@ pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(reader : @lib.Lim
   let msg = BazMessage::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
+      (1, 2) => msg.nested = (reader |> @lib.async_read_message() : BazMessage_Nested) |> Some
       (2, _) => msg.b_int64 = reader |> @lib.async_read_int64()
       (3, _) => msg.b_string = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1280,6 +1301,7 @@ pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(reader : @lib.Lim
 pub impl @lib.AsyncWrite for BazMessage with fn write(self: BazMessage, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.nested is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -1316,8 +1338,8 @@ pub impl @lib.Read for RepeatedMessage with fn read_with_limit(reader : @lib.Lim
   let msg = RepeatedMessage::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
-      _ => reader |> @lib.skip_message_field(wire)
+      (1, 2) => msg.bar_message.push((reader |> @lib.read_message() : BarMessage))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1325,6 +1347,7 @@ pub impl @lib.Read for RepeatedMessage with fn read_with_limit(reader : @lib.Lim
 pub impl @lib.Write for RepeatedMessage with fn write(self: RepeatedMessage, writer : &@lib.Writer) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.write_varint(10UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -1354,8 +1377,8 @@ pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(reader : @li
   let msg = RepeatedMessage::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (1, 2) => msg.bar_message.push((reader |> @lib.async_read_message() : BarMessage))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1363,6 +1386,7 @@ pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(reader : @li
 pub impl @lib.AsyncWrite for RepeatedMessage with fn write(self: RepeatedMessage, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.async_write_varint(10UL)
+
     writer |> @lib.async_write_message(item)
 
   }

--- a/test/snapshots/test_case1/__snapshot/src/top.mbt
+++ b/test/snapshots/test_case1/__snapshot/src/top.mbt
@@ -540,9 +540,7 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
   }
   if self.f_bar_message is Some(v) {
     writer |> @lib.write_varint(146UL);
-
     writer |> @lib.write_message(v)
-
   }
   if !self.f_repeated_int32.is_empty() {
     writer |> @lib.write_varint(154UL)
@@ -550,7 +548,6 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
     writer |> @lib.write_uint32(size)
     for item in self.f_repeated_int32 {
         writer |> @lib.write_int32(item)
-
     }
   }
   if !self.f_repeated_packed_int32.is_empty() {
@@ -559,7 +556,6 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
     writer |> @lib.write_uint32(size)
     for item in self.f_repeated_packed_int32 {
         writer |> @lib.write_int32(item)
-
     }
   }
   if !self.f_repeated_packed_float.is_empty() {
@@ -568,20 +564,15 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
     writer |> @lib.write_uint32(size)
     for item in self.f_repeated_packed_float {
         writer |> @lib.write_float(item)
-
     }
   }
   if self.f_baz is Some(v) {
     writer |> @lib.write_varint(186UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.f_nested is Some(v) {
     writer |> @lib.write_varint(194UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.f_nested_enum != Default::default() {
   writer |> @lib.write_varint(200UL);
@@ -597,47 +588,33 @@ pub impl @lib.Write for FooMessage with fn write(self: FooMessage, writer : &@li
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
-
     writer |> @lib.write_varint(16UL);
     writer |> @lib.write_int32(v)
-
   }
   for item in self.f_repeated_string {
     writer |> @lib.write_varint(242UL)
-
     writer |> @lib.write_string(item)
-
   }
   for item in self.f_repeated_baz_message {
     writer |> @lib.write_varint(250UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.f_optional_string is Some(v) {
     writer |> @lib.write_varint(258UL);
-
     writer |> @lib.write_string(v)
-
   }
   match self.test_oneof {
     FooMessage_TestOneof::F1(v) => {
       writer |> @lib.write_varint(216UL)
-
       writer |> @lib.write_int32(v)
-
      }
     FooMessage_TestOneof::F2(v) => {
       writer |> @lib.write_varint(224UL)
-
       writer |> @lib.write_bool(v)
-
      }
     FooMessage_TestOneof::F3(v) => {
       writer |> @lib.write_varint(234UL)
-
       writer |> @lib.write_string(v)
-
      }
     FooMessage_TestOneof::NotSet => ()
   }
@@ -893,9 +870,7 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
   }
   if self.f_bar_message is Some(v) {
     writer |> @lib.async_write_varint(146UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if !self.f_repeated_int32.is_empty() {
     writer |> @lib.async_write_varint(154UL)
@@ -903,7 +878,6 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
     writer |> @lib.async_write_uint32(size)
     for item in self.f_repeated_int32 {
         writer |> @lib.async_write_int32(item)
-
     }
   }
   if !self.f_repeated_packed_int32.is_empty() {
@@ -912,7 +886,6 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
     writer |> @lib.async_write_uint32(size)
     for item in self.f_repeated_packed_int32 {
         writer |> @lib.async_write_int32(item)
-
     }
   }
   if !self.f_repeated_packed_float.is_empty() {
@@ -921,20 +894,15 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
     writer |> @lib.async_write_uint32(size)
     for item in self.f_repeated_packed_float {
         writer |> @lib.async_write_float(item)
-
     }
   }
   if self.f_baz is Some(v) {
     writer |> @lib.async_write_varint(186UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.f_nested is Some(v) {
     writer |> @lib.async_write_varint(194UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.f_nested_enum != Default::default() {
   writer |> @lib.async_write_varint(200UL);
@@ -950,47 +918,33 @@ pub impl @lib.AsyncWrite for FooMessage with fn write(self: FooMessage, writer :
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)
-
     writer |> @lib.async_write_varint(16UL);
     writer |> @lib.async_write_int32(v)
-
   }
   for item in self.f_repeated_string {
     writer |> @lib.async_write_varint(242UL)
-
     writer |> @lib.async_write_string(item)
-
   }
   for item in self.f_repeated_baz_message {
     writer |> @lib.async_write_varint(250UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.f_optional_string is Some(v) {
     writer |> @lib.async_write_varint(258UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   match self.test_oneof {
     FooMessage_TestOneof::F1(v) => {
       writer |> @lib.async_write_varint(216UL)
-
       writer |> @lib.async_write_int32(v)
-
      }
     FooMessage_TestOneof::F2(v) => {
       writer |> @lib.async_write_varint(224UL)
-
       writer |> @lib.async_write_bool(v)
-
      }
     FooMessage_TestOneof::F3(v) => {
       writer |> @lib.async_write_varint(234UL)
-
       writer |> @lib.async_write_string(v)
-
      }
     FooMessage_TestOneof::NotSet => ()
   }
@@ -1153,9 +1107,7 @@ pub impl @lib.Read for BazMessage_Nested with fn read_with_limit(reader : @lib.L
 pub impl @lib.Write for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.Writer) -> Unit raise {
   if self.f_nested is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for BazMessage_Nested with fn to_json(self) {
@@ -1192,9 +1144,7 @@ pub impl @lib.AsyncRead for BazMessage_Nested with fn read_with_limit(reader : @
 pub impl @lib.AsyncWrite for BazMessage_Nested with fn write(self: BazMessage_Nested, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.f_nested is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct BazMessage {
@@ -1244,9 +1194,7 @@ pub impl @lib.Read for BazMessage with fn read_with_limit(reader : @lib.LimitedR
 pub impl @lib.Write for BazMessage with fn write(self: BazMessage, writer : &@lib.Writer) -> Unit raise {
   if self.nested is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.b_int64 != Default::default() {
   writer |> @lib.write_varint(16UL);
@@ -1301,9 +1249,7 @@ pub impl @lib.AsyncRead for BazMessage with fn read_with_limit(reader : @lib.Lim
 pub impl @lib.AsyncWrite for BazMessage with fn write(self: BazMessage, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.nested is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.b_int64 != Default::default() {
   writer |> @lib.async_write_varint(16UL);
@@ -1347,9 +1293,7 @@ pub impl @lib.Read for RepeatedMessage with fn read_with_limit(reader : @lib.Lim
 pub impl @lib.Write for RepeatedMessage with fn write(self: RepeatedMessage, writer : &@lib.Writer) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.write_varint(10UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for RepeatedMessage with fn to_json(self) {
@@ -1386,8 +1330,6 @@ pub impl @lib.AsyncRead for RepeatedMessage with fn read_with_limit(reader : @li
 pub impl @lib.AsyncWrite for RepeatedMessage with fn write(self: RepeatedMessage, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.bar_message {
     writer |> @lib.async_write_varint(10UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -30,7 +30,7 @@ pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.read_string()
       (2, _) => msg.value = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -75,7 +75,7 @@ pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader :
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.async_read_string()
       (2, _) => msg.value = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -143,9 +143,9 @@ pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.age = reader |> @lib.read_int32()
       (3, _) => msg.hobbies.push(reader |> @lib.read_string())
-      (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, _) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (4, 2) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, 2) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -161,6 +161,7 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
   }
   for item in self.hobbies {
     writer |> @lib.write_varint(26UL)
+
     writer |> @lib.write_string(item)
 
   }
@@ -179,8 +180,9 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
     writer |> @lib.write_string(v)
 
   }
-   if self.friend is Some(v) {
+  if self.friend is Some(v) {
     writer |> @lib.write_varint(42UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -230,9 +232,9 @@ pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedR
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.age = reader |> @lib.async_read_int32()
       (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
-      (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, _) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (4, 2) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, 2) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -248,6 +250,7 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
   }
   for item in self.hobbies {
     writer |> @lib.async_write_varint(26UL)
+
     writer |> @lib.async_write_string(item)
 
   }
@@ -266,8 +269,9 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
     writer |> @lib.async_write_string(v)
 
   }
-   if self.friend is Some(v) {
+  if self.friend is Some(v) {
     writer |> @lib.async_write_varint(42UL);
+
     writer |> @lib.async_write_message(v)
 
   }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -143,8 +143,8 @@ pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.age = reader |> @lib.read_int32()
       (3, _) => msg.hobbies.push(reader |> @lib.read_string())
-      (4, 2) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, 2) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -226,8 +226,8 @@ pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedR
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.age = reader |> @lib.async_read_int32()
       (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
-      (4, 2) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, 2) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/lib/top.mbt
@@ -161,9 +161,7 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
   }
   for item in self.hobbies {
     writer |> @lib.write_varint(26UL)
-
     writer |> @lib.write_string(item)
-
   }
   let keys = self.metadata.keys().collect()
   for i in 0..<keys.length() {
@@ -175,16 +173,12 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
-
     writer |> @lib.write_varint(18UL);
     writer |> @lib.write_string(v)
-
   }
   if self.friend is Some(v) {
     writer |> @lib.write_varint(42UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for Hello with fn to_json(self) {
@@ -250,9 +244,7 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
   }
   for item in self.hobbies {
     writer |> @lib.async_write_varint(26UL)
-
     writer |> @lib.async_write_string(item)
-
   }
   let keys = self.metadata.keys().collect()
   for i in 0..<keys.length() {
@@ -264,15 +256,11 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)
-
     writer |> @lib.async_write_varint(18UL);
     writer |> @lib.async_write_string(v)
-
   }
   if self.friend is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
@@ -22,7 +22,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   let msg = Test::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello) |> Some
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -59,7 +59,7 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   let msg = Test::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello) |> Some
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
@@ -31,9 +31,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   if self.test_hello is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for Test with fn to_json(self) {
@@ -70,8 +68,6 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.test_hello is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }

--- a/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
+++ b/test/snapshots/test_case10/__snapshot/src/test_case10/top.mbt
@@ -22,8 +22,8 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   let msg = Test::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (1, 2) => msg.test_hello = (reader |> @lib.read_message() : @lib1.Hello) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -31,6 +31,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   if self.test_hello is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -60,8 +61,8 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   let msg = Test::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (1, 2) => msg.test_hello = (reader |> @lib.async_read_message() : @lib1.Hello) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -69,6 +70,7 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.test_hello is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_message(v)
 
   }

--- a/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
@@ -22,7 +22,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   let msg = Test::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp) |> Some
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -59,7 +59,7 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   let msg = Test::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp) |> Some
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
@@ -22,8 +22,8 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   let msg = Test::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (1, 2) => msg.created_at = (reader |> @lib.read_message() : @protobuf.Timestamp) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -31,6 +31,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -60,8 +61,8 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   let msg = Test::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (1, 2) => msg.created_at = (reader |> @lib.async_read_message() : @protobuf.Timestamp) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -69,6 +70,7 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_message(v)
 
   }

--- a/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case2/__snapshot/src/test3/top.mbt
@@ -31,9 +31,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for Test with fn to_json(self) {
@@ -70,8 +68,6 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -30,7 +30,7 @@ pub impl @lib.Read for Hello_MetadataEntry with fn read_with_limit(reader : @lib
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.read_string()
       (2, _) => msg.value = reader |> @lib.read_string()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -75,7 +75,7 @@ pub impl @lib.AsyncRead for Hello_MetadataEntry with fn read_with_limit(reader :
     match (field_number, wire) {
       (1, _) => msg.key = reader |> @lib.async_read_string()
       (2, _) => msg.value = reader |> @lib.async_read_string()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -143,9 +143,9 @@ pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.age = reader |> @lib.read_int32()
       (3, _) => msg.hobbies.push(reader |> @lib.read_string())
-      (4, _) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, _) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (4, 2) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, 2) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -161,6 +161,7 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
   }
   for item in self.hobbies {
     writer |> @lib.write_varint(26UL)
+
     writer |> @lib.write_string(item)
 
   }
@@ -179,8 +180,9 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
     writer |> @lib.write_string(v)
 
   }
-   if self.friend is Some(v) {
+  if self.friend is Some(v) {
     writer |> @lib.write_varint(42UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -230,9 +232,9 @@ pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedR
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.age = reader |> @lib.async_read_int32()
       (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
-      (4, _) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, _) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (4, 2) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, 2) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -248,6 +250,7 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
   }
   for item in self.hobbies {
     writer |> @lib.async_write_varint(26UL)
+
     writer |> @lib.async_write_string(item)
 
   }
@@ -266,8 +269,9 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
     writer |> @lib.async_write_string(v)
 
   }
-   if self.friend is Some(v) {
+  if self.friend is Some(v) {
     writer |> @lib.async_write_varint(42UL);
+
     writer |> @lib.async_write_message(v)
 
   }

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -143,8 +143,8 @@ pub impl @lib.Read for Hello with fn read_with_limit(reader : @lib.LimitedReader
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.age = reader |> @lib.read_int32()
       (3, _) => msg.hobbies.push(reader |> @lib.read_string())
-      (4, 2) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, 2) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { let {key, value} = (reader |> @lib.read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.friend = (reader |> @lib.read_message() : Hello) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -226,8 +226,8 @@ pub impl @lib.AsyncRead for Hello with fn read_with_limit(reader : @lib.LimitedR
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.age = reader |> @lib.async_read_int32()
       (3, _) => msg.hobbies.push(reader |> @lib.async_read_string())
-      (4, 2) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
-      (5, 2) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { let {key, value} = (reader |> @lib.async_read_message() : Hello_MetadataEntry); msg.metadata[key] = value }
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.friend = (reader |> @lib.async_read_message() : Hello) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test2/top.mbt
@@ -161,9 +161,7 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
   }
   for item in self.hobbies {
     writer |> @lib.write_varint(26UL)
-
     writer |> @lib.write_string(item)
-
   }
   let keys = self.metadata.keys().collect()
   for i in 0..<keys.length() {
@@ -175,16 +173,12 @@ pub impl @lib.Write for Hello with fn write(self: Hello, writer : &@lib.Writer) 
     writer |> @lib.write_uint32(key_size + value_size)
     writer |> @lib.write_varint(10UL)
     writer |> @lib.write_string(k)
-
     writer |> @lib.write_varint(18UL);
     writer |> @lib.write_string(v)
-
   }
   if self.friend is Some(v) {
     writer |> @lib.write_varint(42UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for Hello with fn to_json(self) {
@@ -250,9 +244,7 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
   }
   for item in self.hobbies {
     writer |> @lib.async_write_varint(26UL)
-
     writer |> @lib.async_write_string(item)
-
   }
   let keys = self.metadata.keys().collect()
   for i in 0..<keys.length() {
@@ -264,15 +256,11 @@ pub impl @lib.AsyncWrite for Hello with fn write(self: Hello, writer : &@lib.Asy
     writer |> @lib.async_write_uint32(key_size + value_size)
     writer |> @lib.async_write_varint(10UL)
     writer |> @lib.async_write_string(k)
-
     writer |> @lib.async_write_varint(18UL);
     writer |> @lib.async_write_string(v)
-
   }
   if self.friend is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }

--- a/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
@@ -22,8 +22,8 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   let msg = Test::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.created_at = (reader |> @lib.read_message() : @test2.Hello) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (1, 2) => msg.created_at = (reader |> @lib.read_message() : @test2.Hello) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -31,6 +31,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -60,8 +61,8 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   let msg = Test::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (1, 2) => msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -69,6 +70,7 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_message(v)
 
   }

--- a/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
@@ -22,7 +22,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
   let msg = Test::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.created_at = (reader |> @lib.read_message() : @test2.Hello) |> Some
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.created_at = (reader |> @lib.read_message() : @test2.Hello) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -59,7 +59,7 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
   let msg = Test::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello) |> Some
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.created_at = (reader |> @lib.async_read_message() : @test2.Hello) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
+++ b/test/snapshots/test_case3/__snapshot/src/test3/top.mbt
@@ -31,9 +31,7 @@ pub impl @lib.Read for Test with fn read_with_limit(reader : @lib.LimitedReader[
 pub impl @lib.Write for Test with fn write(self: Test, writer : &@lib.Writer) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for Test with fn to_json(self) {
@@ -70,8 +68,6 @@ pub impl @lib.AsyncRead for Test with fn read_with_limit(reader : @lib.LimitedRe
 pub impl @lib.AsyncWrite for Test with fn write(self: Test, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.created_at is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }

--- a/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
+++ b/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
@@ -44,7 +44,7 @@ pub impl @lib.Read for Version with fn read_with_limit(reader : @lib.LimitedRead
       (2, _) => msg.minor = reader |> @lib.read_int32() |> Some
       (3, _) => msg.patch = reader |> @lib.read_int32() |> Some
       (4, _) => msg.suffix = reader |> @lib.read_string() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -52,21 +52,25 @@ pub impl @lib.Read for Version with fn read_with_limit(reader : @lib.LimitedRead
 pub impl @lib.Write for Version with fn write(self: Version, writer : &@lib.Writer) -> Unit raise {
   if self.major is Some(v) {
     writer |> @lib.write_varint(8UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.minor is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.patch is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.suffix is Some(v) {
     writer |> @lib.write_varint(34UL);
+
     writer |> @lib.write_string(v)
 
   }
@@ -115,7 +119,7 @@ pub impl @lib.AsyncRead for Version with fn read_with_limit(reader : @lib.Limite
       (2, _) => msg.minor = reader |> @lib.async_read_int32() |> Some
       (3, _) => msg.patch = reader |> @lib.async_read_int32() |> Some
       (4, _) => msg.suffix = reader |> @lib.async_read_string() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -123,21 +127,25 @@ pub impl @lib.AsyncRead for Version with fn read_with_limit(reader : @lib.Limite
 pub impl @lib.AsyncWrite for Version with fn write(self: Version, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.major is Some(v) {
     writer |> @lib.async_write_varint(8UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.minor is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.patch is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.suffix is Some(v) {
     writer |> @lib.async_write_varint(34UL);
+
     writer |> @lib.async_write_string(v)
 
   }
@@ -192,10 +200,10 @@ pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(reader : @li
     match (field_number, wire) {
       (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
       (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
-      (15, _) => msg.proto_file.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
-      (17, _) => msg.source_file_descriptors.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
-      (3, _) => msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (15, 2) => msg.proto_file.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
+      (17, 2) => msg.source_file_descriptors.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
+      (3, 2) => msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -203,26 +211,31 @@ pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(reader : @li
 pub impl @lib.Write for CodeGeneratorRequest with fn write(self: CodeGeneratorRequest, writer : &@lib.Writer) -> Unit raise {
   for item in self.file_to_generate {
     writer |> @lib.write_varint(10UL)
+
     writer |> @lib.write_string(item)
 
   }
   if self.parameter is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   for item in self.proto_file {
     writer |> @lib.write_varint(122UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.source_file_descriptors {
     writer |> @lib.write_varint(138UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.compiler_version is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -274,10 +287,10 @@ pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(reader 
     match (field_number, wire) {
       (1, _) => msg.file_to_generate.push(reader |> @lib.async_read_string())
       (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
-      (15, _) => msg.proto_file.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
-      (17, _) => msg.source_file_descriptors.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
-      (3, _) => msg.compiler_version = (reader |> @lib.async_read_message() : Version) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (15, 2) => msg.proto_file.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
+      (17, 2) => msg.source_file_descriptors.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
+      (3, 2) => msg.compiler_version = (reader |> @lib.async_read_message() : Version) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -285,26 +298,31 @@ pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(reader 
 pub impl @lib.AsyncWrite for CodeGeneratorRequest with fn write(self: CodeGeneratorRequest, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.file_to_generate {
     writer |> @lib.async_write_varint(10UL)
+
     writer |> @lib.async_write_string(item)
 
   }
   if self.parameter is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   for item in self.proto_file {
     writer |> @lib.async_write_varint(122UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.source_file_descriptors {
     writer |> @lib.async_write_varint(138UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.compiler_version is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -398,8 +416,8 @@ pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(reader
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
       (15, _) => msg.content = reader |> @lib.read_string() |> Some
-      (16, _) => msg.generated_code_info = (reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (16, 2) => msg.generated_code_info = (reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -407,21 +425,25 @@ pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(reader
 pub impl @lib.Write for CodeGeneratorResponse_File with fn write(self: CodeGeneratorResponse_File, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.insertion_point is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.content is Some(v) {
     writer |> @lib.write_varint(122UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.generated_code_info is Some(v) {
     writer |> @lib.write_varint(130UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -469,8 +491,8 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(r
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.insertion_point = reader |> @lib.async_read_string() |> Some
       (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
-      (16, _) => msg.generated_code_info = (reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (16, 2) => msg.generated_code_info = (reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -478,21 +500,25 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(r
 pub impl @lib.AsyncWrite for CodeGeneratorResponse_File with fn write(self: CodeGeneratorResponse_File, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.insertion_point is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.content is Some(v) {
     writer |> @lib.async_write_varint(122UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.generated_code_info is Some(v) {
     writer |> @lib.async_write_varint(130UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -549,8 +575,8 @@ pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(reader : @l
       (2, _) => msg.supported_features = reader |> @lib.read_uint64() |> Some
       (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
       (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
-      (15, _) => msg.file.push((reader |> @lib.read_message() : CodeGeneratorResponse_File))
-      _ => reader |> @lib.skip_message_field(wire)
+      (15, 2) => msg.file.push((reader |> @lib.read_message() : CodeGeneratorResponse_File))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -558,26 +584,31 @@ pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(reader : @l
 pub impl @lib.Write for CodeGeneratorResponse with fn write(self: CodeGeneratorResponse, writer : &@lib.Writer) -> Unit raise {
   if self.error is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.supported_features is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_uint64(v)
 
   }
   if self.minimum_edition is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.maximum_edition is Some(v) {
     writer |> @lib.write_varint(32UL);
+
     writer |> @lib.write_int32(v)
 
   }
   for item in self.file {
     writer |> @lib.write_varint(122UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -631,8 +662,8 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(reader
       (2, _) => msg.supported_features = reader |> @lib.async_read_uint64() |> Some
       (3, _) => msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
       (4, _) => msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
-      (15, _) => msg.file.push((reader |> @lib.async_read_message() : CodeGeneratorResponse_File))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (15, 2) => msg.file.push((reader |> @lib.async_read_message() : CodeGeneratorResponse_File))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -640,26 +671,31 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(reader
 pub impl @lib.AsyncWrite for CodeGeneratorResponse with fn write(self: CodeGeneratorResponse, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.error is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.supported_features is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_uint64(v)
 
   }
   if self.minimum_edition is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.maximum_edition is Some(v) {
     writer |> @lib.async_write_varint(32UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   for item in self.file {
     writer |> @lib.async_write_varint(122UL)
+
     writer |> @lib.async_write_message(item)
 
   }

--- a/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
+++ b/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
@@ -184,9 +184,9 @@ pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(reader : @li
     match (field_number, wire) {
       (1, _) => msg.file_to_generate.push(reader |> @lib.read_string())
       (2, _) => msg.parameter = reader |> @lib.read_string() |> Some
-      (15, 2) => msg.proto_file.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
-      (17, 2) => msg.source_file_descriptors.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
-      (3, 2) => msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some
+      (15, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.proto_file.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
+      (17, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.source_file_descriptors.push((reader |> @lib.read_message() : @protobuf.FileDescriptorProto))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.compiler_version = (reader |> @lib.read_message() : Version) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -261,9 +261,9 @@ pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(reader 
     match (field_number, wire) {
       (1, _) => msg.file_to_generate.push(reader |> @lib.async_read_string())
       (2, _) => msg.parameter = reader |> @lib.async_read_string() |> Some
-      (15, 2) => msg.proto_file.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
-      (17, 2) => msg.source_file_descriptors.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
-      (3, 2) => msg.compiler_version = (reader |> @lib.async_read_message() : Version) |> Some
+      (15, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.proto_file.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
+      (17, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.source_file_descriptors.push((reader |> @lib.async_read_message() : @protobuf.FileDescriptorProto))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.compiler_version = (reader |> @lib.async_read_message() : Version) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -380,7 +380,7 @@ pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(reader
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.insertion_point = reader |> @lib.read_string() |> Some
       (15, _) => msg.content = reader |> @lib.read_string() |> Some
-      (16, 2) => msg.generated_code_info = (reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo) |> Some
+      (16, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.generated_code_info = (reader |> @lib.read_message() : @protobuf.GeneratedCodeInfo) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -447,7 +447,7 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(r
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.insertion_point = reader |> @lib.async_read_string() |> Some
       (15, _) => msg.content = reader |> @lib.async_read_string() |> Some
-      (16, 2) => msg.generated_code_info = (reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo) |> Some
+      (16, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.generated_code_info = (reader |> @lib.async_read_message() : @protobuf.GeneratedCodeInfo) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -523,7 +523,7 @@ pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(reader : @l
       (2, _) => msg.supported_features = reader |> @lib.read_uint64() |> Some
       (3, _) => msg.minimum_edition = reader |> @lib.read_int32() |> Some
       (4, _) => msg.maximum_edition = reader |> @lib.read_int32() |> Some
-      (15, 2) => msg.file.push((reader |> @lib.read_message() : CodeGeneratorResponse_File))
+      (15, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.file.push((reader |> @lib.read_message() : CodeGeneratorResponse_File))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -600,7 +600,7 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(reader
       (2, _) => msg.supported_features = reader |> @lib.async_read_uint64() |> Some
       (3, _) => msg.minimum_edition = reader |> @lib.async_read_int32() |> Some
       (4, _) => msg.maximum_edition = reader |> @lib.async_read_int32() |> Some
-      (15, 2) => msg.file.push((reader |> @lib.async_read_message() : CodeGeneratorResponse_File))
+      (15, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.file.push((reader |> @lib.async_read_message() : CodeGeneratorResponse_File))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
+++ b/test/snapshots/test_case4/__snapshot/src/google/protobuf/compiler/top.mbt
@@ -52,27 +52,19 @@ pub impl @lib.Read for Version with fn read_with_limit(reader : @lib.LimitedRead
 pub impl @lib.Write for Version with fn write(self: Version, writer : &@lib.Writer) -> Unit raise {
   if self.major is Some(v) {
     writer |> @lib.write_varint(8UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.minor is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.patch is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.suffix is Some(v) {
     writer |> @lib.write_varint(34UL);
-
     writer |> @lib.write_string(v)
-
   }
 }
 pub impl ToJson for Version with fn to_json(self) {
@@ -127,27 +119,19 @@ pub impl @lib.AsyncRead for Version with fn read_with_limit(reader : @lib.Limite
 pub impl @lib.AsyncWrite for Version with fn write(self: Version, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.major is Some(v) {
     writer |> @lib.async_write_varint(8UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.minor is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.patch is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.suffix is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-
     writer |> @lib.async_write_string(v)
-
   }
 }
 pub(all) struct CodeGeneratorRequest {
@@ -211,33 +195,23 @@ pub impl @lib.Read for CodeGeneratorRequest with fn read_with_limit(reader : @li
 pub impl @lib.Write for CodeGeneratorRequest with fn write(self: CodeGeneratorRequest, writer : &@lib.Writer) -> Unit raise {
   for item in self.file_to_generate {
     writer |> @lib.write_varint(10UL)
-
     writer |> @lib.write_string(item)
-
   }
   if self.parameter is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   for item in self.proto_file {
     writer |> @lib.write_varint(122UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.source_file_descriptors {
     writer |> @lib.write_varint(138UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.compiler_version is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for CodeGeneratorRequest with fn to_json(self) {
@@ -298,33 +272,23 @@ pub impl @lib.AsyncRead for CodeGeneratorRequest with fn read_with_limit(reader 
 pub impl @lib.AsyncWrite for CodeGeneratorRequest with fn write(self: CodeGeneratorRequest, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.file_to_generate {
     writer |> @lib.async_write_varint(10UL)
-
     writer |> @lib.async_write_string(item)
-
   }
   if self.parameter is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   for item in self.proto_file {
     writer |> @lib.async_write_varint(122UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.source_file_descriptors {
     writer |> @lib.async_write_varint(138UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.compiler_version is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) enum CodeGeneratorResponse_Feature {
@@ -425,27 +389,19 @@ pub impl @lib.Read for CodeGeneratorResponse_File with fn read_with_limit(reader
 pub impl @lib.Write for CodeGeneratorResponse_File with fn write(self: CodeGeneratorResponse_File, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.insertion_point is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.content is Some(v) {
     writer |> @lib.write_varint(122UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.generated_code_info is Some(v) {
     writer |> @lib.write_varint(130UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for CodeGeneratorResponse_File with fn to_json(self) {
@@ -500,27 +456,19 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse_File with fn read_with_limit(r
 pub impl @lib.AsyncWrite for CodeGeneratorResponse_File with fn write(self: CodeGeneratorResponse_File, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.insertion_point is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.content is Some(v) {
     writer |> @lib.async_write_varint(122UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.generated_code_info is Some(v) {
     writer |> @lib.async_write_varint(130UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct CodeGeneratorResponse {
@@ -584,33 +532,23 @@ pub impl @lib.Read for CodeGeneratorResponse with fn read_with_limit(reader : @l
 pub impl @lib.Write for CodeGeneratorResponse with fn write(self: CodeGeneratorResponse, writer : &@lib.Writer) -> Unit raise {
   if self.error is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.supported_features is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_uint64(v)
-
   }
   if self.minimum_edition is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.maximum_edition is Some(v) {
     writer |> @lib.write_varint(32UL);
-
     writer |> @lib.write_int32(v)
-
   }
   for item in self.file {
     writer |> @lib.write_varint(122UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for CodeGeneratorResponse with fn to_json(self) {
@@ -671,32 +609,22 @@ pub impl @lib.AsyncRead for CodeGeneratorResponse with fn read_with_limit(reader
 pub impl @lib.AsyncWrite for CodeGeneratorResponse with fn write(self: CodeGeneratorResponse, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.error is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.supported_features is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_uint64(v)
-
   }
   if self.minimum_edition is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.maximum_edition is Some(v) {
     writer |> @lib.async_write_varint(32UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   for item in self.file {
     writer |> @lib.async_write_varint(122UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }

--- a/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case6/__snapshot/src/google/protobuf/top.mbt
@@ -30,7 +30,7 @@ pub impl @lib.Read for Timestamp with fn read_with_limit(reader : @lib.LimitedRe
     match (field_number, wire) {
       (1, _) => msg.seconds = reader |> @lib.read_int64()
       (2, _) => msg.nanos = reader |> @lib.read_int32()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -51,7 +51,7 @@ pub impl @lib.AsyncRead for Timestamp with fn read_with_limit(reader : @lib.Limi
     match (field_number, wire) {
       (1, _) => msg.seconds = reader |> @lib.async_read_int64()
       (2, _) => msg.nanos = reader |> @lib.async_read_int32()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg

--- a/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
+++ b/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
@@ -46,9 +46,9 @@ pub impl @lib.Read for TreeNode with fn read_with_limit(reader : @lib.LimitedRea
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.value = reader |> @lib.read_int32() |> Some
-      (3, 2) => msg.parent = (reader |> @lib.read_message() : TreeNode) |> Some
-      (4, 2) => msg.children.push((reader |> @lib.read_message() : TreeNode))
-      (5, 2) => msg.sibling = (reader |> @lib.read_message() : TreeNode) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.parent = (reader |> @lib.read_message() : TreeNode) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.children.push((reader |> @lib.read_message() : TreeNode))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.sibling = (reader |> @lib.read_message() : TreeNode) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -120,9 +120,9 @@ pub impl @lib.AsyncRead for TreeNode with fn read_with_limit(reader : @lib.Limit
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.value = reader |> @lib.async_read_int32() |> Some
-      (3, 2) => msg.parent = (reader |> @lib.async_read_message() : TreeNode) |> Some
-      (4, 2) => msg.children.push((reader |> @lib.async_read_message() : TreeNode))
-      (5, 2) => msg.sibling = (reader |> @lib.async_read_message() : TreeNode) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.parent = (reader |> @lib.async_read_message() : TreeNode) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.children.push((reader |> @lib.async_read_message() : TreeNode))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.sibling = (reader |> @lib.async_read_message() : TreeNode) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -183,8 +183,8 @@ pub impl @lib.Read for ListNode with fn read_with_limit(reader : @lib.LimitedRea
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.data = reader |> @lib.read_string()
-      (2, 2) => msg.next = (reader |> @lib.read_message() : ListNode) |> Some
-      (3, 2) => msg.prev = (reader |> @lib.read_message() : ListNode) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.next = (reader |> @lib.read_message() : ListNode) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.prev = (reader |> @lib.read_message() : ListNode) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -237,8 +237,8 @@ pub impl @lib.AsyncRead for ListNode with fn read_with_limit(reader : @lib.Limit
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.data = reader |> @lib.async_read_string()
-      (2, 2) => msg.next = (reader |> @lib.async_read_message() : ListNode) |> Some
-      (3, 2) => msg.prev = (reader |> @lib.async_read_message() : ListNode) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.next = (reader |> @lib.async_read_message() : ListNode) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.prev = (reader |> @lib.async_read_message() : ListNode) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -298,7 +298,7 @@ pub impl @lib.Read for GraphNode with fn read_with_limit(reader : @lib.LimitedRe
     match (field_number, wire) {
       (1, _) => msg.id = reader |> @lib.read_string()
       (2, _) => msg.label = reader |> @lib.read_string() |> Some
-      (3, 2) => msg.neighbors.push((reader |> @lib.read_message() : GraphNode))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.neighbors.push((reader |> @lib.read_message() : GraphNode))
       (4, _) => msg.visited = reader |> @lib.read_bool() |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
@@ -362,7 +362,7 @@ pub impl @lib.AsyncRead for GraphNode with fn read_with_limit(reader : @lib.Limi
     match (field_number, wire) {
       (1, _) => msg.id = reader |> @lib.async_read_string()
       (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
-      (3, 2) => msg.neighbors.push((reader |> @lib.async_read_message() : GraphNode))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.neighbors.push((reader |> @lib.async_read_message() : GraphNode))
       (4, _) => msg.visited = reader |> @lib.async_read_bool() |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
@@ -422,8 +422,8 @@ pub impl @lib.Read for NestedSelfRef_Inner with fn read_with_limit(reader : @lib
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.inner_name = reader |> @lib.read_string() |> Some
-      (2, 2) => msg.outer_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
-      (3, 2) => msg.inner_ref = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.outer_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.inner_ref = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -479,8 +479,8 @@ pub impl @lib.AsyncRead for NestedSelfRef_Inner with fn read_with_limit(reader :
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.inner_name = reader |> @lib.async_read_string() |> Some
-      (2, 2) => msg.outer_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
-      (3, 2) => msg.inner_ref = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.outer_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.inner_ref = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -535,8 +535,8 @@ pub impl @lib.Read for NestedSelfRef with fn read_with_limit(reader : @lib.Limit
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
-      (2, 2) => msg.inner = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
-      (3, 2) => msg.self_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.inner = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.self_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -589,8 +589,8 @@ pub impl @lib.AsyncRead for NestedSelfRef with fn read_with_limit(reader : @lib.
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, 2) => msg.inner = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
-      (3, 2) => msg.self_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.inner = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.self_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -656,9 +656,9 @@ pub impl @lib.Read for Organization with fn read_with_limit(reader : @lib.Limite
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.description = reader |> @lib.read_string() |> Some
-      (3, 2) => msg.parent_org = (reader |> @lib.read_message() : Organization) |> Some
-      (4, 2) => msg.sub_orgs.push((reader |> @lib.read_message() : Organization))
-      (5, 2) => msg.employees.push((reader |> @lib.read_message() : Employee))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.parent_org = (reader |> @lib.read_message() : Organization) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.sub_orgs.push((reader |> @lib.read_message() : Organization))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.employees.push((reader |> @lib.read_message() : Employee))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -730,9 +730,9 @@ pub impl @lib.AsyncRead for Organization with fn read_with_limit(reader : @lib.L
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.description = reader |> @lib.async_read_string() |> Some
-      (3, 2) => msg.parent_org = (reader |> @lib.async_read_message() : Organization) |> Some
-      (4, 2) => msg.sub_orgs.push((reader |> @lib.async_read_message() : Organization))
-      (5, 2) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.parent_org = (reader |> @lib.async_read_message() : Organization) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.sub_orgs.push((reader |> @lib.async_read_message() : Organization))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -804,9 +804,9 @@ pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedRea
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.id = reader |> @lib.read_string()
-      (3, 2) => msg.organization = (reader |> @lib.read_message() : Organization) |> Some
-      (4, 2) => msg.manager = (reader |> @lib.read_message() : Employee) |> Some
-      (5, 2) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.organization = (reader |> @lib.read_message() : Organization) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.manager = (reader |> @lib.read_message() : Employee) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -875,9 +875,9 @@ pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.Limit
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.id = reader |> @lib.async_read_string()
-      (3, 2) => msg.organization = (reader |> @lib.async_read_message() : Organization) |> Some
-      (4, 2) => msg.manager = (reader |> @lib.async_read_message() : Employee) |> Some
-      (5, 2) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.organization = (reader |> @lib.async_read_message() : Organization) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.manager = (reader |> @lib.async_read_message() : Employee) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
+++ b/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
@@ -46,10 +46,10 @@ pub impl @lib.Read for TreeNode with fn read_with_limit(reader : @lib.LimitedRea
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.value = reader |> @lib.read_int32() |> Some
-      (3, _) => msg.parent = (reader |> @lib.read_message() : TreeNode) |> Some
-      (4, _) => msg.children.push((reader |> @lib.read_message() : TreeNode))
-      (5, _) => msg.sibling = (reader |> @lib.read_message() : TreeNode) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.parent = (reader |> @lib.read_message() : TreeNode) |> Some
+      (4, 2) => msg.children.push((reader |> @lib.read_message() : TreeNode))
+      (5, 2) => msg.sibling = (reader |> @lib.read_message() : TreeNode) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -59,21 +59,25 @@ pub impl @lib.Write for TreeNode with fn write(self: TreeNode, writer : &@lib.Wr
   writer |> @lib.write_string(self.name)
   if self.value is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.parent is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.children {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.sibling is Some(v) {
     writer |> @lib.write_varint(42UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -124,10 +128,10 @@ pub impl @lib.AsyncRead for TreeNode with fn read_with_limit(reader : @lib.Limit
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.value = reader |> @lib.async_read_int32() |> Some
-      (3, _) => msg.parent = (reader |> @lib.async_read_message() : TreeNode) |> Some
-      (4, _) => msg.children.push((reader |> @lib.async_read_message() : TreeNode))
-      (5, _) => msg.sibling = (reader |> @lib.async_read_message() : TreeNode) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.parent = (reader |> @lib.async_read_message() : TreeNode) |> Some
+      (4, 2) => msg.children.push((reader |> @lib.async_read_message() : TreeNode))
+      (5, 2) => msg.sibling = (reader |> @lib.async_read_message() : TreeNode) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -137,21 +141,25 @@ pub impl @lib.AsyncWrite for TreeNode with fn write(self: TreeNode, writer : &@l
   writer |> @lib.async_write_string(self.name)
   if self.value is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.parent is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.children {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.sibling is Some(v) {
     writer |> @lib.async_write_varint(42UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -191,9 +199,9 @@ pub impl @lib.Read for ListNode with fn read_with_limit(reader : @lib.LimitedRea
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.data = reader |> @lib.read_string()
-      (2, _) => msg.next = (reader |> @lib.read_message() : ListNode) |> Some
-      (3, _) => msg.prev = (reader |> @lib.read_message() : ListNode) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (2, 2) => msg.next = (reader |> @lib.read_message() : ListNode) |> Some
+      (3, 2) => msg.prev = (reader |> @lib.read_message() : ListNode) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -203,11 +211,13 @@ pub impl @lib.Write for ListNode with fn write(self: ListNode, writer : &@lib.Wr
   writer |> @lib.write_string(self.data)
   if self.next is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.prev is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -247,9 +257,9 @@ pub impl @lib.AsyncRead for ListNode with fn read_with_limit(reader : @lib.Limit
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.data = reader |> @lib.async_read_string()
-      (2, _) => msg.next = (reader |> @lib.async_read_message() : ListNode) |> Some
-      (3, _) => msg.prev = (reader |> @lib.async_read_message() : ListNode) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (2, 2) => msg.next = (reader |> @lib.async_read_message() : ListNode) |> Some
+      (3, 2) => msg.prev = (reader |> @lib.async_read_message() : ListNode) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -259,11 +269,13 @@ pub impl @lib.AsyncWrite for ListNode with fn write(self: ListNode, writer : &@l
   writer |> @lib.async_write_string(self.data)
   if self.next is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.prev is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -310,9 +322,9 @@ pub impl @lib.Read for GraphNode with fn read_with_limit(reader : @lib.LimitedRe
     match (field_number, wire) {
       (1, _) => msg.id = reader |> @lib.read_string()
       (2, _) => msg.label = reader |> @lib.read_string() |> Some
-      (3, _) => msg.neighbors.push((reader |> @lib.read_message() : GraphNode))
+      (3, 2) => msg.neighbors.push((reader |> @lib.read_message() : GraphNode))
       (4, _) => msg.visited = reader |> @lib.read_bool() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -322,16 +334,19 @@ pub impl @lib.Write for GraphNode with fn write(self: GraphNode, writer : &@lib.
   writer |> @lib.write_string(self.id)
   if self.label is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   for item in self.neighbors {
     writer |> @lib.write_varint(26UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.visited is Some(v) {
     writer |> @lib.write_varint(32UL);
+
     writer |> @lib.write_bool(v)
 
   }
@@ -377,9 +392,9 @@ pub impl @lib.AsyncRead for GraphNode with fn read_with_limit(reader : @lib.Limi
     match (field_number, wire) {
       (1, _) => msg.id = reader |> @lib.async_read_string()
       (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.neighbors.push((reader |> @lib.async_read_message() : GraphNode))
+      (3, 2) => msg.neighbors.push((reader |> @lib.async_read_message() : GraphNode))
       (4, _) => msg.visited = reader |> @lib.async_read_bool() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -389,16 +404,19 @@ pub impl @lib.AsyncWrite for GraphNode with fn write(self: GraphNode, writer : &
   writer |> @lib.async_write_string(self.id)
   if self.label is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   for item in self.neighbors {
     writer |> @lib.async_write_varint(26UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.visited is Some(v) {
     writer |> @lib.async_write_varint(32UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
@@ -440,9 +458,9 @@ pub impl @lib.Read for NestedSelfRef_Inner with fn read_with_limit(reader : @lib
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.inner_name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.outer_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
-      (3, _) => msg.inner_ref = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (2, 2) => msg.outer_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
+      (3, 2) => msg.inner_ref = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -450,16 +468,19 @@ pub impl @lib.Read for NestedSelfRef_Inner with fn read_with_limit(reader : @lib
 pub impl @lib.Write for NestedSelfRef_Inner with fn write(self: NestedSelfRef_Inner, writer : &@lib.Writer) -> Unit raise {
   if self.inner_name is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.outer_ref is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.inner_ref is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -500,9 +521,9 @@ pub impl @lib.AsyncRead for NestedSelfRef_Inner with fn read_with_limit(reader :
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.inner_name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.outer_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
-      (3, _) => msg.inner_ref = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (2, 2) => msg.outer_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
+      (3, 2) => msg.inner_ref = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -510,16 +531,19 @@ pub impl @lib.AsyncRead for NestedSelfRef_Inner with fn read_with_limit(reader :
 pub impl @lib.AsyncWrite for NestedSelfRef_Inner with fn write(self: NestedSelfRef_Inner, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.inner_name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.outer_ref is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.inner_ref is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -559,9 +583,9 @@ pub impl @lib.Read for NestedSelfRef with fn read_with_limit(reader : @lib.Limit
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
-      (2, _) => msg.inner = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
-      (3, _) => msg.self_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (2, 2) => msg.inner = (reader |> @lib.read_message() : NestedSelfRef_Inner) |> Some
+      (3, 2) => msg.self_ref = (reader |> @lib.read_message() : NestedSelfRef) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -571,11 +595,13 @@ pub impl @lib.Write for NestedSelfRef with fn write(self: NestedSelfRef, writer 
   writer |> @lib.write_string(self.name)
   if self.inner is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.self_ref is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -615,9 +641,9 @@ pub impl @lib.AsyncRead for NestedSelfRef with fn read_with_limit(reader : @lib.
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
-      (2, _) => msg.inner = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
-      (3, _) => msg.self_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (2, 2) => msg.inner = (reader |> @lib.async_read_message() : NestedSelfRef_Inner) |> Some
+      (3, 2) => msg.self_ref = (reader |> @lib.async_read_message() : NestedSelfRef) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -627,11 +653,13 @@ pub impl @lib.AsyncWrite for NestedSelfRef with fn write(self: NestedSelfRef, wr
   writer |> @lib.async_write_string(self.name)
   if self.inner is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.self_ref is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -684,10 +712,10 @@ pub impl @lib.Read for Organization with fn read_with_limit(reader : @lib.Limite
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.description = reader |> @lib.read_string() |> Some
-      (3, _) => msg.parent_org = (reader |> @lib.read_message() : Organization) |> Some
-      (4, _) => msg.sub_orgs.push((reader |> @lib.read_message() : Organization))
-      (5, _) => msg.employees.push((reader |> @lib.read_message() : Employee))
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.parent_org = (reader |> @lib.read_message() : Organization) |> Some
+      (4, 2) => msg.sub_orgs.push((reader |> @lib.read_message() : Organization))
+      (5, 2) => msg.employees.push((reader |> @lib.read_message() : Employee))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -697,21 +725,25 @@ pub impl @lib.Write for Organization with fn write(self: Organization, writer : 
   writer |> @lib.write_string(self.name)
   if self.description is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.parent_org is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.sub_orgs {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.employees {
     writer |> @lib.write_varint(42UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -762,10 +794,10 @@ pub impl @lib.AsyncRead for Organization with fn read_with_limit(reader : @lib.L
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.description = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.parent_org = (reader |> @lib.async_read_message() : Organization) |> Some
-      (4, _) => msg.sub_orgs.push((reader |> @lib.async_read_message() : Organization))
-      (5, _) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.parent_org = (reader |> @lib.async_read_message() : Organization) |> Some
+      (4, 2) => msg.sub_orgs.push((reader |> @lib.async_read_message() : Organization))
+      (5, 2) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -775,21 +807,25 @@ pub impl @lib.AsyncWrite for Organization with fn write(self: Organization, writ
   writer |> @lib.async_write_string(self.name)
   if self.description is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.parent_org is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.sub_orgs {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.employees {
     writer |> @lib.async_write_varint(42UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -840,10 +876,10 @@ pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedRea
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string()
       (2, _) => msg.id = reader |> @lib.read_string()
-      (3, _) => msg.organization = (reader |> @lib.read_message() : Organization) |> Some
-      (4, _) => msg.manager = (reader |> @lib.read_message() : Employee) |> Some
-      (5, _) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.organization = (reader |> @lib.read_message() : Organization) |> Some
+      (4, 2) => msg.manager = (reader |> @lib.read_message() : Employee) |> Some
+      (5, 2) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -855,16 +891,19 @@ pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Wr
   writer |> @lib.write_string(self.id)
   if self.organization is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.manager is Some(v) {
     writer |> @lib.write_varint(34UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.subordinates {
     writer |> @lib.write_varint(42UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -914,10 +953,10 @@ pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.Limit
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string()
       (2, _) => msg.id = reader |> @lib.async_read_string()
-      (3, _) => msg.organization = (reader |> @lib.async_read_message() : Organization) |> Some
-      (4, _) => msg.manager = (reader |> @lib.async_read_message() : Employee) |> Some
-      (5, _) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.organization = (reader |> @lib.async_read_message() : Organization) |> Some
+      (4, 2) => msg.manager = (reader |> @lib.async_read_message() : Employee) |> Some
+      (5, 2) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -929,16 +968,19 @@ pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@l
   writer |> @lib.async_write_string(self.id)
   if self.organization is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.manager is Some(v) {
     writer |> @lib.async_write_varint(34UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.subordinates {
     writer |> @lib.async_write_varint(42UL)
+
     writer |> @lib.async_write_message(item)
 
   }

--- a/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
+++ b/test/snapshots/test_case7/__snapshot/src/test_case7/top.mbt
@@ -59,27 +59,19 @@ pub impl @lib.Write for TreeNode with fn write(self: TreeNode, writer : &@lib.Wr
   writer |> @lib.write_string(self.name)
   if self.value is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.parent is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.children {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.sibling is Some(v) {
     writer |> @lib.write_varint(42UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for TreeNode with fn to_json(self) {
@@ -141,27 +133,19 @@ pub impl @lib.AsyncWrite for TreeNode with fn write(self: TreeNode, writer : &@l
   writer |> @lib.async_write_string(self.name)
   if self.value is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.parent is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.children {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.sibling is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct ListNode {
@@ -211,15 +195,11 @@ pub impl @lib.Write for ListNode with fn write(self: ListNode, writer : &@lib.Wr
   writer |> @lib.write_string(self.data)
   if self.next is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.prev is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for ListNode with fn to_json(self) {
@@ -269,15 +249,11 @@ pub impl @lib.AsyncWrite for ListNode with fn write(self: ListNode, writer : &@l
   writer |> @lib.async_write_string(self.data)
   if self.next is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.prev is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct GraphNode {
@@ -334,21 +310,15 @@ pub impl @lib.Write for GraphNode with fn write(self: GraphNode, writer : &@lib.
   writer |> @lib.write_string(self.id)
   if self.label is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   for item in self.neighbors {
     writer |> @lib.write_varint(26UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.visited is Some(v) {
     writer |> @lib.write_varint(32UL);
-
     writer |> @lib.write_bool(v)
-
   }
 }
 pub impl ToJson for GraphNode with fn to_json(self) {
@@ -404,21 +374,15 @@ pub impl @lib.AsyncWrite for GraphNode with fn write(self: GraphNode, writer : &
   writer |> @lib.async_write_string(self.id)
   if self.label is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   for item in self.neighbors {
     writer |> @lib.async_write_varint(26UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.visited is Some(v) {
     writer |> @lib.async_write_varint(32UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
 }
 pub(all) struct NestedSelfRef_Inner {
@@ -468,21 +432,15 @@ pub impl @lib.Read for NestedSelfRef_Inner with fn read_with_limit(reader : @lib
 pub impl @lib.Write for NestedSelfRef_Inner with fn write(self: NestedSelfRef_Inner, writer : &@lib.Writer) -> Unit raise {
   if self.inner_name is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.outer_ref is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.inner_ref is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for NestedSelfRef_Inner with fn to_json(self) {
@@ -531,21 +489,15 @@ pub impl @lib.AsyncRead for NestedSelfRef_Inner with fn read_with_limit(reader :
 pub impl @lib.AsyncWrite for NestedSelfRef_Inner with fn write(self: NestedSelfRef_Inner, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.inner_name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.outer_ref is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.inner_ref is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct NestedSelfRef {
@@ -595,15 +547,11 @@ pub impl @lib.Write for NestedSelfRef with fn write(self: NestedSelfRef, writer 
   writer |> @lib.write_string(self.name)
   if self.inner is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.self_ref is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for NestedSelfRef with fn to_json(self) {
@@ -653,15 +601,11 @@ pub impl @lib.AsyncWrite for NestedSelfRef with fn write(self: NestedSelfRef, wr
   writer |> @lib.async_write_string(self.name)
   if self.inner is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.self_ref is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct Organization {
@@ -725,27 +669,19 @@ pub impl @lib.Write for Organization with fn write(self: Organization, writer : 
   writer |> @lib.write_string(self.name)
   if self.description is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.parent_org is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.sub_orgs {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.employees {
     writer |> @lib.write_varint(42UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for Organization with fn to_json(self) {
@@ -807,27 +743,19 @@ pub impl @lib.AsyncWrite for Organization with fn write(self: Organization, writ
   writer |> @lib.async_write_string(self.name)
   if self.description is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.parent_org is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.sub_orgs {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.employees {
     writer |> @lib.async_write_varint(42UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct Employee {
@@ -891,21 +819,15 @@ pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Wr
   writer |> @lib.write_string(self.id)
   if self.organization is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.manager is Some(v) {
     writer |> @lib.write_varint(34UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.subordinates {
     writer |> @lib.write_varint(42UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for Employee with fn to_json(self) {
@@ -968,20 +890,14 @@ pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@l
   writer |> @lib.async_write_string(self.id)
   if self.organization is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.manager is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.subordinates {
     writer |> @lib.async_write_varint(42UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }

--- a/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
+++ b/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
@@ -59,21 +59,15 @@ pub impl @lib.Write for User with fn write(self: User, writer : &@lib.Writer) ->
   writer |> @lib.write_string(self.name)
   if self.email is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_string(v)
-
   }
   for item in self.orders {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.friends {
     writer |> @lib.write_varint(42UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for User with fn to_json(self) {
@@ -136,21 +130,15 @@ pub impl @lib.AsyncWrite for User with fn write(self: User, writer : &@lib.Async
   writer |> @lib.async_write_string(self.name)
   if self.email is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   for item in self.orders {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.friends {
     writer |> @lib.async_write_varint(42UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct Order {
@@ -214,21 +202,15 @@ pub impl @lib.Write for Order with fn write(self: Order, writer : &@lib.Writer) 
   writer |> @lib.write_string(self.product_name)
   if self.amount is Some(v) {
     writer |> @lib.write_varint(25UL);
-
     writer |> @lib.write_double(v)
-
   }
   if self.customer is Some(v) {
     writer |> @lib.write_varint(34UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.related_orders {
     writer |> @lib.write_varint(42UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for Order with fn to_json(self) {
@@ -291,21 +273,15 @@ pub impl @lib.AsyncWrite for Order with fn write(self: Order, writer : &@lib.Asy
   writer |> @lib.async_write_string(self.product_name)
   if self.amount is Some(v) {
     writer |> @lib.async_write_varint(25UL);
-
     writer |> @lib.async_write_double(v)
-
   }
   if self.customer is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.related_orders {
     writer |> @lib.async_write_varint(42UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct Department {
@@ -369,21 +345,15 @@ pub impl @lib.Write for Department with fn write(self: Department, writer : &@li
   writer |> @lib.write_string(self.name)
   for item in self.employees {
     writer |> @lib.write_varint(26UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.projects {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.parent_dept is Some(v) {
     writer |> @lib.write_varint(42UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for Department with fn to_json(self) {
@@ -446,21 +416,15 @@ pub impl @lib.AsyncWrite for Department with fn write(self: Department, writer :
   writer |> @lib.async_write_string(self.name)
   for item in self.employees {
     writer |> @lib.async_write_varint(26UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.projects {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.parent_dept is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct Employee {
@@ -531,27 +495,19 @@ pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Wr
   writer |> @lib.write_string(self.name)
   if self.department is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.projects {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.supervisor is Some(v) {
     writer |> @lib.write_varint(42UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.subordinates {
     writer |> @lib.write_varint(50UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for Employee with fn to_json(self) {
@@ -620,27 +576,19 @@ pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@l
   writer |> @lib.async_write_string(self.name)
   if self.department is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.projects {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.supervisor is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.subordinates {
     writer |> @lib.async_write_varint(50UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct Project {
@@ -718,33 +666,23 @@ pub impl @lib.Write for Project with fn write(self: Project, writer : &@lib.Writ
   writer |> @lib.write_string(self.title)
   if self.description is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.department is Some(v) {
     writer |> @lib.write_varint(34UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.members {
     writer |> @lib.write_varint(42UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.dependencies {
     writer |> @lib.write_varint(50UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.dependents {
     writer |> @lib.write_varint(58UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for Project with fn to_json(self) {
@@ -819,33 +757,23 @@ pub impl @lib.AsyncWrite for Project with fn write(self: Project, writer : &@lib
   writer |> @lib.async_write_string(self.title)
   if self.description is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.department is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.members {
     writer |> @lib.async_write_varint(42UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.dependencies {
     writer |> @lib.async_write_varint(50UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.dependents {
     writer |> @lib.async_write_varint(58UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct Node_Connection {
@@ -909,27 +837,19 @@ pub impl @lib.Write for Node_Connection with fn write(self: Node_Connection, wri
   writer |> @lib.write_string(self.connection_id)
   if self.type_ is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.source is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.target is Some(v) {
     writer |> @lib.write_varint(34UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.weight is Some(v) {
     writer |> @lib.write_varint(42UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for Node_Connection with fn to_json(self) {
@@ -991,27 +911,19 @@ pub impl @lib.AsyncWrite for Node_Connection with fn write(self: Node_Connection
   writer |> @lib.async_write_string(self.connection_id)
   if self.type_ is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.source is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.target is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.weight is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct Node {
@@ -1068,21 +980,15 @@ pub impl @lib.Write for Node with fn write(self: Node, writer : &@lib.Writer) ->
   writer |> @lib.write_string(self.id)
   if self.data is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   for item in self.connections {
     writer |> @lib.write_varint(26UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.neighbors {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for Node with fn to_json(self) {
@@ -1138,21 +1044,15 @@ pub impl @lib.AsyncWrite for Node with fn write(self: Node, writer : &@lib.Async
   writer |> @lib.async_write_string(self.id)
   if self.data is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   for item in self.connections {
     writer |> @lib.async_write_varint(26UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.neighbors {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct Weight {
@@ -1209,21 +1109,15 @@ pub impl @lib.Write for Weight with fn write(self: Weight, writer : &@lib.Writer
   writer |> @lib.write_double(self.value)
   if self.unit is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.connection is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.related_nodes {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for Weight with fn to_json(self) {
@@ -1279,21 +1173,15 @@ pub impl @lib.AsyncWrite for Weight with fn write(self: Weight, writer : &@lib.A
   writer |> @lib.async_write_double(self.value)
   if self.unit is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.connection is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.related_nodes {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct Graph {
@@ -1350,21 +1238,15 @@ pub impl @lib.Write for Graph with fn write(self: Graph, writer : &@lib.Writer) 
   writer |> @lib.write_string(self.graph_id)
   if self.name is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   for item in self.vertices {
     writer |> @lib.write_varint(26UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.edges {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for Graph with fn to_json(self) {
@@ -1420,21 +1302,15 @@ pub impl @lib.AsyncWrite for Graph with fn write(self: Graph, writer : &@lib.Asy
   writer |> @lib.async_write_string(self.graph_id)
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   for item in self.vertices {
     writer |> @lib.async_write_varint(26UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.edges {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct Vertex {
@@ -1505,33 +1381,23 @@ pub impl @lib.Write for Vertex with fn write(self: Vertex, writer : &@lib.Writer
   writer |> @lib.write_string(self.vertex_id)
   if self.label is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.graph is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.incoming_edges {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.outgoing_edges {
     writer |> @lib.write_varint(42UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.adjacent_vertices {
     writer |> @lib.write_varint(50UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for Vertex with fn to_json(self) {
@@ -1599,33 +1465,23 @@ pub impl @lib.AsyncWrite for Vertex with fn write(self: Vertex, writer : &@lib.A
   writer |> @lib.async_write_string(self.vertex_id)
   if self.label is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.graph is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.incoming_edges {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.outgoing_edges {
     writer |> @lib.async_write_varint(42UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.adjacent_vertices {
     writer |> @lib.async_write_varint(50UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct Edge {
@@ -1696,33 +1552,23 @@ pub impl @lib.Write for Edge with fn write(self: Edge, writer : &@lib.Writer) ->
   writer |> @lib.write_string(self.edge_id)
   if self.weight is Some(v) {
     writer |> @lib.write_varint(17UL);
-
     writer |> @lib.write_double(v)
-
   }
   if self.graph is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.source_vertex is Some(v) {
     writer |> @lib.write_varint(34UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.target_vertex is Some(v) {
     writer |> @lib.write_varint(42UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.parallel_edges {
     writer |> @lib.write_varint(50UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for Edge with fn to_json(self) {
@@ -1790,32 +1636,22 @@ pub impl @lib.AsyncWrite for Edge with fn write(self: Edge, writer : &@lib.Async
   writer |> @lib.async_write_string(self.edge_id)
   if self.weight is Some(v) {
     writer |> @lib.async_write_varint(17UL);
-
     writer |> @lib.async_write_double(v)
-
   }
   if self.graph is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.source_vertex is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.target_vertex is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.parallel_edges {
     writer |> @lib.async_write_varint(50UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }

--- a/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
+++ b/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
@@ -45,9 +45,9 @@ pub impl @lib.Read for User with fn read_with_limit(reader : @lib.LimitedReader[
       (1, _) => msg.user_id = reader |> @lib.read_string()
       (2, _) => msg.name = reader |> @lib.read_string()
       (3, _) => msg.email = reader |> @lib.read_string() |> Some
-      (4, _) => msg.orders.push((reader |> @lib.read_message() : Order))
-      (5, _) => msg.friends.push((reader |> @lib.read_message() : User))
-      _ => reader |> @lib.skip_message_field(wire)
+      (4, 2) => msg.orders.push((reader |> @lib.read_message() : Order))
+      (5, 2) => msg.friends.push((reader |> @lib.read_message() : User))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -59,16 +59,19 @@ pub impl @lib.Write for User with fn write(self: User, writer : &@lib.Writer) ->
   writer |> @lib.write_string(self.name)
   if self.email is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_string(v)
 
   }
   for item in self.orders {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.friends {
     writer |> @lib.write_varint(42UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -119,9 +122,9 @@ pub impl @lib.AsyncRead for User with fn read_with_limit(reader : @lib.LimitedRe
       (1, _) => msg.user_id = reader |> @lib.async_read_string()
       (2, _) => msg.name = reader |> @lib.async_read_string()
       (3, _) => msg.email = reader |> @lib.async_read_string() |> Some
-      (4, _) => msg.orders.push((reader |> @lib.async_read_message() : Order))
-      (5, _) => msg.friends.push((reader |> @lib.async_read_message() : User))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (4, 2) => msg.orders.push((reader |> @lib.async_read_message() : Order))
+      (5, 2) => msg.friends.push((reader |> @lib.async_read_message() : User))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -133,16 +136,19 @@ pub impl @lib.AsyncWrite for User with fn write(self: User, writer : &@lib.Async
   writer |> @lib.async_write_string(self.name)
   if self.email is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   for item in self.orders {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.friends {
     writer |> @lib.async_write_varint(42UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -194,9 +200,9 @@ pub impl @lib.Read for Order with fn read_with_limit(reader : @lib.LimitedReader
       (1, _) => msg.order_id = reader |> @lib.read_string()
       (2, _) => msg.product_name = reader |> @lib.read_string()
       (3, _) => msg.amount = reader |> @lib.read_double() |> Some
-      (4, _) => msg.customer = (reader |> @lib.read_message() : User) |> Some
-      (5, _) => msg.related_orders.push((reader |> @lib.read_message() : Order))
-      _ => reader |> @lib.skip_message_field(wire)
+      (4, 2) => msg.customer = (reader |> @lib.read_message() : User) |> Some
+      (5, 2) => msg.related_orders.push((reader |> @lib.read_message() : Order))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -208,16 +214,19 @@ pub impl @lib.Write for Order with fn write(self: Order, writer : &@lib.Writer) 
   writer |> @lib.write_string(self.product_name)
   if self.amount is Some(v) {
     writer |> @lib.write_varint(25UL);
+
     writer |> @lib.write_double(v)
 
   }
   if self.customer is Some(v) {
     writer |> @lib.write_varint(34UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.related_orders {
     writer |> @lib.write_varint(42UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -268,9 +277,9 @@ pub impl @lib.AsyncRead for Order with fn read_with_limit(reader : @lib.LimitedR
       (1, _) => msg.order_id = reader |> @lib.async_read_string()
       (2, _) => msg.product_name = reader |> @lib.async_read_string()
       (3, _) => msg.amount = reader |> @lib.async_read_double() |> Some
-      (4, _) => msg.customer = (reader |> @lib.async_read_message() : User) |> Some
-      (5, _) => msg.related_orders.push((reader |> @lib.async_read_message() : Order))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (4, 2) => msg.customer = (reader |> @lib.async_read_message() : User) |> Some
+      (5, 2) => msg.related_orders.push((reader |> @lib.async_read_message() : Order))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -282,16 +291,19 @@ pub impl @lib.AsyncWrite for Order with fn write(self: Order, writer : &@lib.Asy
   writer |> @lib.async_write_string(self.product_name)
   if self.amount is Some(v) {
     writer |> @lib.async_write_varint(25UL);
+
     writer |> @lib.async_write_double(v)
 
   }
   if self.customer is Some(v) {
     writer |> @lib.async_write_varint(34UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.related_orders {
     writer |> @lib.async_write_varint(42UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -342,10 +354,10 @@ pub impl @lib.Read for Department with fn read_with_limit(reader : @lib.LimitedR
     match (field_number, wire) {
       (1, _) => msg.dept_id = reader |> @lib.read_string()
       (2, _) => msg.name = reader |> @lib.read_string()
-      (3, _) => msg.employees.push((reader |> @lib.read_message() : Employee))
-      (4, _) => msg.projects.push((reader |> @lib.read_message() : Project))
-      (5, _) => msg.parent_dept = (reader |> @lib.read_message() : Department) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.employees.push((reader |> @lib.read_message() : Employee))
+      (4, 2) => msg.projects.push((reader |> @lib.read_message() : Project))
+      (5, 2) => msg.parent_dept = (reader |> @lib.read_message() : Department) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -357,16 +369,19 @@ pub impl @lib.Write for Department with fn write(self: Department, writer : &@li
   writer |> @lib.write_string(self.name)
   for item in self.employees {
     writer |> @lib.write_varint(26UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.projects {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.parent_dept is Some(v) {
     writer |> @lib.write_varint(42UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -416,10 +431,10 @@ pub impl @lib.AsyncRead for Department with fn read_with_limit(reader : @lib.Lim
     match (field_number, wire) {
       (1, _) => msg.dept_id = reader |> @lib.async_read_string()
       (2, _) => msg.name = reader |> @lib.async_read_string()
-      (3, _) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
-      (4, _) => msg.projects.push((reader |> @lib.async_read_message() : Project))
-      (5, _) => msg.parent_dept = (reader |> @lib.async_read_message() : Department) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
+      (4, 2) => msg.projects.push((reader |> @lib.async_read_message() : Project))
+      (5, 2) => msg.parent_dept = (reader |> @lib.async_read_message() : Department) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -431,16 +446,19 @@ pub impl @lib.AsyncWrite for Department with fn write(self: Department, writer :
   writer |> @lib.async_write_string(self.name)
   for item in self.employees {
     writer |> @lib.async_write_varint(26UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.projects {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.parent_dept is Some(v) {
     writer |> @lib.async_write_varint(42UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -497,11 +515,11 @@ pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedRea
     match (field_number, wire) {
       (1, _) => msg.emp_id = reader |> @lib.read_string()
       (2, _) => msg.name = reader |> @lib.read_string()
-      (3, _) => msg.department = (reader |> @lib.read_message() : Department) |> Some
-      (4, _) => msg.projects.push((reader |> @lib.read_message() : Project))
-      (5, _) => msg.supervisor = (reader |> @lib.read_message() : Employee) |> Some
-      (6, _) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.department = (reader |> @lib.read_message() : Department) |> Some
+      (4, 2) => msg.projects.push((reader |> @lib.read_message() : Project))
+      (5, 2) => msg.supervisor = (reader |> @lib.read_message() : Employee) |> Some
+      (6, 2) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -513,21 +531,25 @@ pub impl @lib.Write for Employee with fn write(self: Employee, writer : &@lib.Wr
   writer |> @lib.write_string(self.name)
   if self.department is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.projects {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.supervisor is Some(v) {
     writer |> @lib.write_varint(42UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.subordinates {
     writer |> @lib.write_varint(50UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -582,11 +604,11 @@ pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.Limit
     match (field_number, wire) {
       (1, _) => msg.emp_id = reader |> @lib.async_read_string()
       (2, _) => msg.name = reader |> @lib.async_read_string()
-      (3, _) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
-      (4, _) => msg.projects.push((reader |> @lib.async_read_message() : Project))
-      (5, _) => msg.supervisor = (reader |> @lib.async_read_message() : Employee) |> Some
-      (6, _) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
+      (4, 2) => msg.projects.push((reader |> @lib.async_read_message() : Project))
+      (5, 2) => msg.supervisor = (reader |> @lib.async_read_message() : Employee) |> Some
+      (6, 2) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -598,21 +620,25 @@ pub impl @lib.AsyncWrite for Employee with fn write(self: Employee, writer : &@l
   writer |> @lib.async_write_string(self.name)
   if self.department is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.projects {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.supervisor is Some(v) {
     writer |> @lib.async_write_varint(42UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.subordinates {
     writer |> @lib.async_write_varint(50UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -676,11 +702,11 @@ pub impl @lib.Read for Project with fn read_with_limit(reader : @lib.LimitedRead
       (1, _) => msg.project_id = reader |> @lib.read_string()
       (2, _) => msg.title = reader |> @lib.read_string()
       (3, _) => msg.description = reader |> @lib.read_string() |> Some
-      (4, _) => msg.department = (reader |> @lib.read_message() : Department) |> Some
-      (5, _) => msg.members.push((reader |> @lib.read_message() : Employee))
-      (6, _) => msg.dependencies.push((reader |> @lib.read_message() : Project))
-      (7, _) => msg.dependents.push((reader |> @lib.read_message() : Project))
-      _ => reader |> @lib.skip_message_field(wire)
+      (4, 2) => msg.department = (reader |> @lib.read_message() : Department) |> Some
+      (5, 2) => msg.members.push((reader |> @lib.read_message() : Employee))
+      (6, 2) => msg.dependencies.push((reader |> @lib.read_message() : Project))
+      (7, 2) => msg.dependents.push((reader |> @lib.read_message() : Project))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -692,26 +718,31 @@ pub impl @lib.Write for Project with fn write(self: Project, writer : &@lib.Writ
   writer |> @lib.write_string(self.title)
   if self.description is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.department is Some(v) {
     writer |> @lib.write_varint(34UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.members {
     writer |> @lib.write_varint(42UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.dependencies {
     writer |> @lib.write_varint(50UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.dependents {
     writer |> @lib.write_varint(58UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -772,11 +803,11 @@ pub impl @lib.AsyncRead for Project with fn read_with_limit(reader : @lib.Limite
       (1, _) => msg.project_id = reader |> @lib.async_read_string()
       (2, _) => msg.title = reader |> @lib.async_read_string()
       (3, _) => msg.description = reader |> @lib.async_read_string() |> Some
-      (4, _) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
-      (5, _) => msg.members.push((reader |> @lib.async_read_message() : Employee))
-      (6, _) => msg.dependencies.push((reader |> @lib.async_read_message() : Project))
-      (7, _) => msg.dependents.push((reader |> @lib.async_read_message() : Project))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (4, 2) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
+      (5, 2) => msg.members.push((reader |> @lib.async_read_message() : Employee))
+      (6, 2) => msg.dependencies.push((reader |> @lib.async_read_message() : Project))
+      (7, 2) => msg.dependents.push((reader |> @lib.async_read_message() : Project))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -788,26 +819,31 @@ pub impl @lib.AsyncWrite for Project with fn write(self: Project, writer : &@lib
   writer |> @lib.async_write_string(self.title)
   if self.description is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.department is Some(v) {
     writer |> @lib.async_write_varint(34UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.members {
     writer |> @lib.async_write_varint(42UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.dependencies {
     writer |> @lib.async_write_varint(50UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.dependents {
     writer |> @lib.async_write_varint(58UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -860,10 +896,10 @@ pub impl @lib.Read for Node_Connection with fn read_with_limit(reader : @lib.Lim
     match (field_number, wire) {
       (1, _) => msg.connection_id = reader |> @lib.read_string()
       (2, _) => msg.type_ = reader |> @lib.read_string() |> Some
-      (3, _) => msg.source = (reader |> @lib.read_message() : Node) |> Some
-      (4, _) => msg.target = (reader |> @lib.read_message() : Node) |> Some
-      (5, _) => msg.weight = (reader |> @lib.read_message() : Weight) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.source = (reader |> @lib.read_message() : Node) |> Some
+      (4, 2) => msg.target = (reader |> @lib.read_message() : Node) |> Some
+      (5, 2) => msg.weight = (reader |> @lib.read_message() : Weight) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -873,21 +909,25 @@ pub impl @lib.Write for Node_Connection with fn write(self: Node_Connection, wri
   writer |> @lib.write_string(self.connection_id)
   if self.type_ is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.source is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.target is Some(v) {
     writer |> @lib.write_varint(34UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.weight is Some(v) {
     writer |> @lib.write_varint(42UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -938,10 +978,10 @@ pub impl @lib.AsyncRead for Node_Connection with fn read_with_limit(reader : @li
     match (field_number, wire) {
       (1, _) => msg.connection_id = reader |> @lib.async_read_string()
       (2, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.source = (reader |> @lib.async_read_message() : Node) |> Some
-      (4, _) => msg.target = (reader |> @lib.async_read_message() : Node) |> Some
-      (5, _) => msg.weight = (reader |> @lib.async_read_message() : Weight) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.source = (reader |> @lib.async_read_message() : Node) |> Some
+      (4, 2) => msg.target = (reader |> @lib.async_read_message() : Node) |> Some
+      (5, 2) => msg.weight = (reader |> @lib.async_read_message() : Weight) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -951,21 +991,25 @@ pub impl @lib.AsyncWrite for Node_Connection with fn write(self: Node_Connection
   writer |> @lib.async_write_string(self.connection_id)
   if self.type_ is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.source is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.target is Some(v) {
     writer |> @lib.async_write_varint(34UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.weight is Some(v) {
     writer |> @lib.async_write_varint(42UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -1012,9 +1056,9 @@ pub impl @lib.Read for Node with fn read_with_limit(reader : @lib.LimitedReader[
     match (field_number, wire) {
       (1, _) => msg.id = reader |> @lib.read_string()
       (2, _) => msg.data = reader |> @lib.read_string() |> Some
-      (3, _) => msg.connections.push((reader |> @lib.read_message() : Node_Connection))
-      (4, _) => msg.neighbors.push((reader |> @lib.read_message() : Node))
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.connections.push((reader |> @lib.read_message() : Node_Connection))
+      (4, 2) => msg.neighbors.push((reader |> @lib.read_message() : Node))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1024,16 +1068,19 @@ pub impl @lib.Write for Node with fn write(self: Node, writer : &@lib.Writer) ->
   writer |> @lib.write_string(self.id)
   if self.data is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   for item in self.connections {
     writer |> @lib.write_varint(26UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.neighbors {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -1079,9 +1126,9 @@ pub impl @lib.AsyncRead for Node with fn read_with_limit(reader : @lib.LimitedRe
     match (field_number, wire) {
       (1, _) => msg.id = reader |> @lib.async_read_string()
       (2, _) => msg.data = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.connections.push((reader |> @lib.async_read_message() : Node_Connection))
-      (4, _) => msg.neighbors.push((reader |> @lib.async_read_message() : Node))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.connections.push((reader |> @lib.async_read_message() : Node_Connection))
+      (4, 2) => msg.neighbors.push((reader |> @lib.async_read_message() : Node))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1091,16 +1138,19 @@ pub impl @lib.AsyncWrite for Node with fn write(self: Node, writer : &@lib.Async
   writer |> @lib.async_write_string(self.id)
   if self.data is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   for item in self.connections {
     writer |> @lib.async_write_varint(26UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.neighbors {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -1147,9 +1197,9 @@ pub impl @lib.Read for Weight with fn read_with_limit(reader : @lib.LimitedReade
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.read_double()
       (2, _) => msg.unit = reader |> @lib.read_string() |> Some
-      (3, _) => msg.connection = (reader |> @lib.read_message() : Node_Connection) |> Some
-      (4, _) => msg.related_nodes.push((reader |> @lib.read_message() : Node))
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.connection = (reader |> @lib.read_message() : Node_Connection) |> Some
+      (4, 2) => msg.related_nodes.push((reader |> @lib.read_message() : Node))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1159,16 +1209,19 @@ pub impl @lib.Write for Weight with fn write(self: Weight, writer : &@lib.Writer
   writer |> @lib.write_double(self.value)
   if self.unit is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.connection is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.related_nodes {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -1214,9 +1267,9 @@ pub impl @lib.AsyncRead for Weight with fn read_with_limit(reader : @lib.Limited
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.async_read_double()
       (2, _) => msg.unit = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.connection = (reader |> @lib.async_read_message() : Node_Connection) |> Some
-      (4, _) => msg.related_nodes.push((reader |> @lib.async_read_message() : Node))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.connection = (reader |> @lib.async_read_message() : Node_Connection) |> Some
+      (4, 2) => msg.related_nodes.push((reader |> @lib.async_read_message() : Node))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1226,16 +1279,19 @@ pub impl @lib.AsyncWrite for Weight with fn write(self: Weight, writer : &@lib.A
   writer |> @lib.async_write_double(self.value)
   if self.unit is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.connection is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.related_nodes {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -1282,9 +1338,9 @@ pub impl @lib.Read for Graph with fn read_with_limit(reader : @lib.LimitedReader
     match (field_number, wire) {
       (1, _) => msg.graph_id = reader |> @lib.read_string()
       (2, _) => msg.name = reader |> @lib.read_string() |> Some
-      (3, _) => msg.vertices.push((reader |> @lib.read_message() : Vertex))
-      (4, _) => msg.edges.push((reader |> @lib.read_message() : Edge))
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.vertices.push((reader |> @lib.read_message() : Vertex))
+      (4, 2) => msg.edges.push((reader |> @lib.read_message() : Edge))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1294,16 +1350,19 @@ pub impl @lib.Write for Graph with fn write(self: Graph, writer : &@lib.Writer) 
   writer |> @lib.write_string(self.graph_id)
   if self.name is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   for item in self.vertices {
     writer |> @lib.write_varint(26UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.edges {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -1349,9 +1408,9 @@ pub impl @lib.AsyncRead for Graph with fn read_with_limit(reader : @lib.LimitedR
     match (field_number, wire) {
       (1, _) => msg.graph_id = reader |> @lib.async_read_string()
       (2, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.vertices.push((reader |> @lib.async_read_message() : Vertex))
-      (4, _) => msg.edges.push((reader |> @lib.async_read_message() : Edge))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.vertices.push((reader |> @lib.async_read_message() : Vertex))
+      (4, 2) => msg.edges.push((reader |> @lib.async_read_message() : Edge))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1361,16 +1420,19 @@ pub impl @lib.AsyncWrite for Graph with fn write(self: Graph, writer : &@lib.Asy
   writer |> @lib.async_write_string(self.graph_id)
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   for item in self.vertices {
     writer |> @lib.async_write_varint(26UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.edges {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -1429,11 +1491,11 @@ pub impl @lib.Read for Vertex with fn read_with_limit(reader : @lib.LimitedReade
     match (field_number, wire) {
       (1, _) => msg.vertex_id = reader |> @lib.read_string()
       (2, _) => msg.label = reader |> @lib.read_string() |> Some
-      (3, _) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
-      (4, _) => msg.incoming_edges.push((reader |> @lib.read_message() : Edge))
-      (5, _) => msg.outgoing_edges.push((reader |> @lib.read_message() : Edge))
-      (6, _) => msg.adjacent_vertices.push((reader |> @lib.read_message() : Vertex))
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
+      (4, 2) => msg.incoming_edges.push((reader |> @lib.read_message() : Edge))
+      (5, 2) => msg.outgoing_edges.push((reader |> @lib.read_message() : Edge))
+      (6, 2) => msg.adjacent_vertices.push((reader |> @lib.read_message() : Vertex))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1443,26 +1505,31 @@ pub impl @lib.Write for Vertex with fn write(self: Vertex, writer : &@lib.Writer
   writer |> @lib.write_string(self.vertex_id)
   if self.label is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.graph is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.incoming_edges {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.outgoing_edges {
     writer |> @lib.write_varint(42UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.adjacent_vertices {
     writer |> @lib.write_varint(50UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -1518,11 +1585,11 @@ pub impl @lib.AsyncRead for Vertex with fn read_with_limit(reader : @lib.Limited
     match (field_number, wire) {
       (1, _) => msg.vertex_id = reader |> @lib.async_read_string()
       (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
-      (3, _) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
-      (4, _) => msg.incoming_edges.push((reader |> @lib.async_read_message() : Edge))
-      (5, _) => msg.outgoing_edges.push((reader |> @lib.async_read_message() : Edge))
-      (6, _) => msg.adjacent_vertices.push((reader |> @lib.async_read_message() : Vertex))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
+      (4, 2) => msg.incoming_edges.push((reader |> @lib.async_read_message() : Edge))
+      (5, 2) => msg.outgoing_edges.push((reader |> @lib.async_read_message() : Edge))
+      (6, 2) => msg.adjacent_vertices.push((reader |> @lib.async_read_message() : Vertex))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1532,26 +1599,31 @@ pub impl @lib.AsyncWrite for Vertex with fn write(self: Vertex, writer : &@lib.A
   writer |> @lib.async_write_string(self.vertex_id)
   if self.label is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.graph is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.incoming_edges {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.outgoing_edges {
     writer |> @lib.async_write_varint(42UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.adjacent_vertices {
     writer |> @lib.async_write_varint(50UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -1610,11 +1682,11 @@ pub impl @lib.Read for Edge with fn read_with_limit(reader : @lib.LimitedReader[
     match (field_number, wire) {
       (1, _) => msg.edge_id = reader |> @lib.read_string()
       (2, _) => msg.weight = reader |> @lib.read_double() |> Some
-      (3, _) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
-      (4, _) => msg.source_vertex = (reader |> @lib.read_message() : Vertex) |> Some
-      (5, _) => msg.target_vertex = (reader |> @lib.read_message() : Vertex) |> Some
-      (6, _) => msg.parallel_edges.push((reader |> @lib.read_message() : Edge))
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
+      (4, 2) => msg.source_vertex = (reader |> @lib.read_message() : Vertex) |> Some
+      (5, 2) => msg.target_vertex = (reader |> @lib.read_message() : Vertex) |> Some
+      (6, 2) => msg.parallel_edges.push((reader |> @lib.read_message() : Edge))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1624,26 +1696,31 @@ pub impl @lib.Write for Edge with fn write(self: Edge, writer : &@lib.Writer) ->
   writer |> @lib.write_string(self.edge_id)
   if self.weight is Some(v) {
     writer |> @lib.write_varint(17UL);
+
     writer |> @lib.write_double(v)
 
   }
   if self.graph is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.source_vertex is Some(v) {
     writer |> @lib.write_varint(34UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.target_vertex is Some(v) {
     writer |> @lib.write_varint(42UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.parallel_edges {
     writer |> @lib.write_varint(50UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -1699,11 +1776,11 @@ pub impl @lib.AsyncRead for Edge with fn read_with_limit(reader : @lib.LimitedRe
     match (field_number, wire) {
       (1, _) => msg.edge_id = reader |> @lib.async_read_string()
       (2, _) => msg.weight = reader |> @lib.async_read_double() |> Some
-      (3, _) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
-      (4, _) => msg.source_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
-      (5, _) => msg.target_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
-      (6, _) => msg.parallel_edges.push((reader |> @lib.async_read_message() : Edge))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
+      (4, 2) => msg.source_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
+      (5, 2) => msg.target_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
+      (6, 2) => msg.parallel_edges.push((reader |> @lib.async_read_message() : Edge))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1713,26 +1790,31 @@ pub impl @lib.AsyncWrite for Edge with fn write(self: Edge, writer : &@lib.Async
   writer |> @lib.async_write_string(self.edge_id)
   if self.weight is Some(v) {
     writer |> @lib.async_write_varint(17UL);
+
     writer |> @lib.async_write_double(v)
 
   }
   if self.graph is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.source_vertex is Some(v) {
     writer |> @lib.async_write_varint(34UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.target_vertex is Some(v) {
     writer |> @lib.async_write_varint(42UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.parallel_edges {
     writer |> @lib.async_write_varint(50UL)
+
     writer |> @lib.async_write_message(item)
 
   }

--- a/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
+++ b/test/snapshots/test_case8/__snapshot/src/test_case8/top.mbt
@@ -45,8 +45,8 @@ pub impl @lib.Read for User with fn read_with_limit(reader : @lib.LimitedReader[
       (1, _) => msg.user_id = reader |> @lib.read_string()
       (2, _) => msg.name = reader |> @lib.read_string()
       (3, _) => msg.email = reader |> @lib.read_string() |> Some
-      (4, 2) => msg.orders.push((reader |> @lib.read_message() : Order))
-      (5, 2) => msg.friends.push((reader |> @lib.read_message() : User))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.orders.push((reader |> @lib.read_message() : Order))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.friends.push((reader |> @lib.read_message() : User))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -116,8 +116,8 @@ pub impl @lib.AsyncRead for User with fn read_with_limit(reader : @lib.LimitedRe
       (1, _) => msg.user_id = reader |> @lib.async_read_string()
       (2, _) => msg.name = reader |> @lib.async_read_string()
       (3, _) => msg.email = reader |> @lib.async_read_string() |> Some
-      (4, 2) => msg.orders.push((reader |> @lib.async_read_message() : Order))
-      (5, 2) => msg.friends.push((reader |> @lib.async_read_message() : User))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.orders.push((reader |> @lib.async_read_message() : Order))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.friends.push((reader |> @lib.async_read_message() : User))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -188,8 +188,8 @@ pub impl @lib.Read for Order with fn read_with_limit(reader : @lib.LimitedReader
       (1, _) => msg.order_id = reader |> @lib.read_string()
       (2, _) => msg.product_name = reader |> @lib.read_string()
       (3, _) => msg.amount = reader |> @lib.read_double() |> Some
-      (4, 2) => msg.customer = (reader |> @lib.read_message() : User) |> Some
-      (5, 2) => msg.related_orders.push((reader |> @lib.read_message() : Order))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.customer = (reader |> @lib.read_message() : User) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.related_orders.push((reader |> @lib.read_message() : Order))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -259,8 +259,8 @@ pub impl @lib.AsyncRead for Order with fn read_with_limit(reader : @lib.LimitedR
       (1, _) => msg.order_id = reader |> @lib.async_read_string()
       (2, _) => msg.product_name = reader |> @lib.async_read_string()
       (3, _) => msg.amount = reader |> @lib.async_read_double() |> Some
-      (4, 2) => msg.customer = (reader |> @lib.async_read_message() : User) |> Some
-      (5, 2) => msg.related_orders.push((reader |> @lib.async_read_message() : Order))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.customer = (reader |> @lib.async_read_message() : User) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.related_orders.push((reader |> @lib.async_read_message() : Order))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -330,9 +330,9 @@ pub impl @lib.Read for Department with fn read_with_limit(reader : @lib.LimitedR
     match (field_number, wire) {
       (1, _) => msg.dept_id = reader |> @lib.read_string()
       (2, _) => msg.name = reader |> @lib.read_string()
-      (3, 2) => msg.employees.push((reader |> @lib.read_message() : Employee))
-      (4, 2) => msg.projects.push((reader |> @lib.read_message() : Project))
-      (5, 2) => msg.parent_dept = (reader |> @lib.read_message() : Department) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.employees.push((reader |> @lib.read_message() : Employee))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.projects.push((reader |> @lib.read_message() : Project))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.parent_dept = (reader |> @lib.read_message() : Department) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -401,9 +401,9 @@ pub impl @lib.AsyncRead for Department with fn read_with_limit(reader : @lib.Lim
     match (field_number, wire) {
       (1, _) => msg.dept_id = reader |> @lib.async_read_string()
       (2, _) => msg.name = reader |> @lib.async_read_string()
-      (3, 2) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
-      (4, 2) => msg.projects.push((reader |> @lib.async_read_message() : Project))
-      (5, 2) => msg.parent_dept = (reader |> @lib.async_read_message() : Department) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.employees.push((reader |> @lib.async_read_message() : Employee))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.projects.push((reader |> @lib.async_read_message() : Project))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.parent_dept = (reader |> @lib.async_read_message() : Department) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -479,10 +479,10 @@ pub impl @lib.Read for Employee with fn read_with_limit(reader : @lib.LimitedRea
     match (field_number, wire) {
       (1, _) => msg.emp_id = reader |> @lib.read_string()
       (2, _) => msg.name = reader |> @lib.read_string()
-      (3, 2) => msg.department = (reader |> @lib.read_message() : Department) |> Some
-      (4, 2) => msg.projects.push((reader |> @lib.read_message() : Project))
-      (5, 2) => msg.supervisor = (reader |> @lib.read_message() : Employee) |> Some
-      (6, 2) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.department = (reader |> @lib.read_message() : Department) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.projects.push((reader |> @lib.read_message() : Project))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.supervisor = (reader |> @lib.read_message() : Employee) |> Some
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.subordinates.push((reader |> @lib.read_message() : Employee))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -560,10 +560,10 @@ pub impl @lib.AsyncRead for Employee with fn read_with_limit(reader : @lib.Limit
     match (field_number, wire) {
       (1, _) => msg.emp_id = reader |> @lib.async_read_string()
       (2, _) => msg.name = reader |> @lib.async_read_string()
-      (3, 2) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
-      (4, 2) => msg.projects.push((reader |> @lib.async_read_message() : Project))
-      (5, 2) => msg.supervisor = (reader |> @lib.async_read_message() : Employee) |> Some
-      (6, 2) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.projects.push((reader |> @lib.async_read_message() : Project))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.supervisor = (reader |> @lib.async_read_message() : Employee) |> Some
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.subordinates.push((reader |> @lib.async_read_message() : Employee))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -650,10 +650,10 @@ pub impl @lib.Read for Project with fn read_with_limit(reader : @lib.LimitedRead
       (1, _) => msg.project_id = reader |> @lib.read_string()
       (2, _) => msg.title = reader |> @lib.read_string()
       (3, _) => msg.description = reader |> @lib.read_string() |> Some
-      (4, 2) => msg.department = (reader |> @lib.read_message() : Department) |> Some
-      (5, 2) => msg.members.push((reader |> @lib.read_message() : Employee))
-      (6, 2) => msg.dependencies.push((reader |> @lib.read_message() : Project))
-      (7, 2) => msg.dependents.push((reader |> @lib.read_message() : Project))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.department = (reader |> @lib.read_message() : Department) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.members.push((reader |> @lib.read_message() : Employee))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.dependencies.push((reader |> @lib.read_message() : Project))
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.dependents.push((reader |> @lib.read_message() : Project))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -741,10 +741,10 @@ pub impl @lib.AsyncRead for Project with fn read_with_limit(reader : @lib.Limite
       (1, _) => msg.project_id = reader |> @lib.async_read_string()
       (2, _) => msg.title = reader |> @lib.async_read_string()
       (3, _) => msg.description = reader |> @lib.async_read_string() |> Some
-      (4, 2) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
-      (5, 2) => msg.members.push((reader |> @lib.async_read_message() : Employee))
-      (6, 2) => msg.dependencies.push((reader |> @lib.async_read_message() : Project))
-      (7, 2) => msg.dependents.push((reader |> @lib.async_read_message() : Project))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.department = (reader |> @lib.async_read_message() : Department) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.members.push((reader |> @lib.async_read_message() : Employee))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.dependencies.push((reader |> @lib.async_read_message() : Project))
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.dependents.push((reader |> @lib.async_read_message() : Project))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -824,9 +824,9 @@ pub impl @lib.Read for Node_Connection with fn read_with_limit(reader : @lib.Lim
     match (field_number, wire) {
       (1, _) => msg.connection_id = reader |> @lib.read_string()
       (2, _) => msg.type_ = reader |> @lib.read_string() |> Some
-      (3, 2) => msg.source = (reader |> @lib.read_message() : Node) |> Some
-      (4, 2) => msg.target = (reader |> @lib.read_message() : Node) |> Some
-      (5, 2) => msg.weight = (reader |> @lib.read_message() : Weight) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.source = (reader |> @lib.read_message() : Node) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.target = (reader |> @lib.read_message() : Node) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.weight = (reader |> @lib.read_message() : Weight) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -898,9 +898,9 @@ pub impl @lib.AsyncRead for Node_Connection with fn read_with_limit(reader : @li
     match (field_number, wire) {
       (1, _) => msg.connection_id = reader |> @lib.async_read_string()
       (2, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
-      (3, 2) => msg.source = (reader |> @lib.async_read_message() : Node) |> Some
-      (4, 2) => msg.target = (reader |> @lib.async_read_message() : Node) |> Some
-      (5, 2) => msg.weight = (reader |> @lib.async_read_message() : Weight) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.source = (reader |> @lib.async_read_message() : Node) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.target = (reader |> @lib.async_read_message() : Node) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.weight = (reader |> @lib.async_read_message() : Weight) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -968,8 +968,8 @@ pub impl @lib.Read for Node with fn read_with_limit(reader : @lib.LimitedReader[
     match (field_number, wire) {
       (1, _) => msg.id = reader |> @lib.read_string()
       (2, _) => msg.data = reader |> @lib.read_string() |> Some
-      (3, 2) => msg.connections.push((reader |> @lib.read_message() : Node_Connection))
-      (4, 2) => msg.neighbors.push((reader |> @lib.read_message() : Node))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.connections.push((reader |> @lib.read_message() : Node_Connection))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.neighbors.push((reader |> @lib.read_message() : Node))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1032,8 +1032,8 @@ pub impl @lib.AsyncRead for Node with fn read_with_limit(reader : @lib.LimitedRe
     match (field_number, wire) {
       (1, _) => msg.id = reader |> @lib.async_read_string()
       (2, _) => msg.data = reader |> @lib.async_read_string() |> Some
-      (3, 2) => msg.connections.push((reader |> @lib.async_read_message() : Node_Connection))
-      (4, 2) => msg.neighbors.push((reader |> @lib.async_read_message() : Node))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.connections.push((reader |> @lib.async_read_message() : Node_Connection))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.neighbors.push((reader |> @lib.async_read_message() : Node))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1097,8 +1097,8 @@ pub impl @lib.Read for Weight with fn read_with_limit(reader : @lib.LimitedReade
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.read_double()
       (2, _) => msg.unit = reader |> @lib.read_string() |> Some
-      (3, 2) => msg.connection = (reader |> @lib.read_message() : Node_Connection) |> Some
-      (4, 2) => msg.related_nodes.push((reader |> @lib.read_message() : Node))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.connection = (reader |> @lib.read_message() : Node_Connection) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.related_nodes.push((reader |> @lib.read_message() : Node))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1161,8 +1161,8 @@ pub impl @lib.AsyncRead for Weight with fn read_with_limit(reader : @lib.Limited
     match (field_number, wire) {
       (1, _) => msg.value = reader |> @lib.async_read_double()
       (2, _) => msg.unit = reader |> @lib.async_read_string() |> Some
-      (3, 2) => msg.connection = (reader |> @lib.async_read_message() : Node_Connection) |> Some
-      (4, 2) => msg.related_nodes.push((reader |> @lib.async_read_message() : Node))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.connection = (reader |> @lib.async_read_message() : Node_Connection) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.related_nodes.push((reader |> @lib.async_read_message() : Node))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1226,8 +1226,8 @@ pub impl @lib.Read for Graph with fn read_with_limit(reader : @lib.LimitedReader
     match (field_number, wire) {
       (1, _) => msg.graph_id = reader |> @lib.read_string()
       (2, _) => msg.name = reader |> @lib.read_string() |> Some
-      (3, 2) => msg.vertices.push((reader |> @lib.read_message() : Vertex))
-      (4, 2) => msg.edges.push((reader |> @lib.read_message() : Edge))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.vertices.push((reader |> @lib.read_message() : Vertex))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.edges.push((reader |> @lib.read_message() : Edge))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1290,8 +1290,8 @@ pub impl @lib.AsyncRead for Graph with fn read_with_limit(reader : @lib.LimitedR
     match (field_number, wire) {
       (1, _) => msg.graph_id = reader |> @lib.async_read_string()
       (2, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (3, 2) => msg.vertices.push((reader |> @lib.async_read_message() : Vertex))
-      (4, 2) => msg.edges.push((reader |> @lib.async_read_message() : Edge))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.vertices.push((reader |> @lib.async_read_message() : Vertex))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.edges.push((reader |> @lib.async_read_message() : Edge))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1367,10 +1367,10 @@ pub impl @lib.Read for Vertex with fn read_with_limit(reader : @lib.LimitedReade
     match (field_number, wire) {
       (1, _) => msg.vertex_id = reader |> @lib.read_string()
       (2, _) => msg.label = reader |> @lib.read_string() |> Some
-      (3, 2) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
-      (4, 2) => msg.incoming_edges.push((reader |> @lib.read_message() : Edge))
-      (5, 2) => msg.outgoing_edges.push((reader |> @lib.read_message() : Edge))
-      (6, 2) => msg.adjacent_vertices.push((reader |> @lib.read_message() : Vertex))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.incoming_edges.push((reader |> @lib.read_message() : Edge))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.outgoing_edges.push((reader |> @lib.read_message() : Edge))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.adjacent_vertices.push((reader |> @lib.read_message() : Vertex))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1451,10 +1451,10 @@ pub impl @lib.AsyncRead for Vertex with fn read_with_limit(reader : @lib.Limited
     match (field_number, wire) {
       (1, _) => msg.vertex_id = reader |> @lib.async_read_string()
       (2, _) => msg.label = reader |> @lib.async_read_string() |> Some
-      (3, 2) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
-      (4, 2) => msg.incoming_edges.push((reader |> @lib.async_read_message() : Edge))
-      (5, 2) => msg.outgoing_edges.push((reader |> @lib.async_read_message() : Edge))
-      (6, 2) => msg.adjacent_vertices.push((reader |> @lib.async_read_message() : Vertex))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.incoming_edges.push((reader |> @lib.async_read_message() : Edge))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.outgoing_edges.push((reader |> @lib.async_read_message() : Edge))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.adjacent_vertices.push((reader |> @lib.async_read_message() : Vertex))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1538,10 +1538,10 @@ pub impl @lib.Read for Edge with fn read_with_limit(reader : @lib.LimitedReader[
     match (field_number, wire) {
       (1, _) => msg.edge_id = reader |> @lib.read_string()
       (2, _) => msg.weight = reader |> @lib.read_double() |> Some
-      (3, 2) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
-      (4, 2) => msg.source_vertex = (reader |> @lib.read_message() : Vertex) |> Some
-      (5, 2) => msg.target_vertex = (reader |> @lib.read_message() : Vertex) |> Some
-      (6, 2) => msg.parallel_edges.push((reader |> @lib.read_message() : Edge))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.graph = (reader |> @lib.read_message() : Graph) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.source_vertex = (reader |> @lib.read_message() : Vertex) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.target_vertex = (reader |> @lib.read_message() : Vertex) |> Some
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.parallel_edges.push((reader |> @lib.read_message() : Edge))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1622,10 +1622,10 @@ pub impl @lib.AsyncRead for Edge with fn read_with_limit(reader : @lib.LimitedRe
     match (field_number, wire) {
       (1, _) => msg.edge_id = reader |> @lib.async_read_string()
       (2, _) => msg.weight = reader |> @lib.async_read_double() |> Some
-      (3, 2) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
-      (4, 2) => msg.source_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
-      (5, 2) => msg.target_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
-      (6, 2) => msg.parallel_edges.push((reader |> @lib.async_read_message() : Edge))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.graph = (reader |> @lib.async_read_message() : Graph) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.source_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.target_vertex = (reader |> @lib.async_read_message() : Vertex) |> Some
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.parallel_edges.push((reader |> @lib.async_read_message() : Edge))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -173,9 +173,7 @@ pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(reader : @lib.L
 pub impl @lib.Write for FileDescriptorSet with fn write(self: FileDescriptorSet, writer : &@lib.Writer) -> Unit raise {
   for item in self.file {
     writer |> @lib.write_varint(10UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for FileDescriptorSet with fn to_json(self) {
@@ -212,9 +210,7 @@ pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(reader : @
 pub impl @lib.AsyncWrite for FileDescriptorSet with fn write(self: FileDescriptorSet, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.file {
     writer |> @lib.async_write_varint(10UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct FileDescriptorProto {
@@ -343,87 +339,59 @@ pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(reader : @lib
 pub impl @lib.Write for FileDescriptorProto with fn write(self: FileDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.package_ is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   for item in self.dependency {
     writer |> @lib.write_varint(26UL)
-
     writer |> @lib.write_string(item)
-
   }
   for item in self.public_dependency {
     writer |> @lib.write_varint(80UL)
-
     writer |> @lib.write_int32(item)
-
   }
   for item in self.weak_dependency {
     writer |> @lib.write_varint(88UL)
-
     writer |> @lib.write_int32(item)
-
   }
   for item in self.option_dependency {
     writer |> @lib.write_varint(122UL)
-
     writer |> @lib.write_string(item)
-
   }
   for item in self.message_type {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.enum_type {
     writer |> @lib.write_varint(42UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.service {
     writer |> @lib.write_varint(50UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.extension {
     writer |> @lib.write_varint(58UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(66UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.source_code_info is Some(v) {
     writer |> @lib.write_varint(74UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.syntax is Some(v) {
     writer |> @lib.write_varint(98UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.edition is Some(v) {
     writer |> @lib.write_varint(112UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
 }
 pub impl ToJson for FileDescriptorProto with fn to_json(self) {
@@ -540,87 +508,59 @@ pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(reader :
 pub impl @lib.AsyncWrite for FileDescriptorProto with fn write(self: FileDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.package_ is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   for item in self.dependency {
     writer |> @lib.async_write_varint(26UL)
-
     writer |> @lib.async_write_string(item)
-
   }
   for item in self.public_dependency {
     writer |> @lib.async_write_varint(80UL)
-
     writer |> @lib.async_write_int32(item)
-
   }
   for item in self.weak_dependency {
     writer |> @lib.async_write_varint(88UL)
-
     writer |> @lib.async_write_int32(item)
-
   }
   for item in self.option_dependency {
     writer |> @lib.async_write_varint(122UL)
-
     writer |> @lib.async_write_string(item)
-
   }
   for item in self.message_type {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.enum_type {
     writer |> @lib.async_write_varint(42UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.service {
     writer |> @lib.async_write_varint(50UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.extension {
     writer |> @lib.async_write_varint(58UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(66UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.source_code_info is Some(v) {
     writer |> @lib.async_write_varint(74UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.syntax is Some(v) {
     writer |> @lib.async_write_varint(98UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.edition is Some(v) {
     writer |> @lib.async_write_varint(112UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
 }
 pub(all) struct DescriptorProto_ExtensionRange {
@@ -670,21 +610,15 @@ pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(re
 pub impl @lib.Write for DescriptorProto_ExtensionRange with fn write(self: DescriptorProto_ExtensionRange, writer : &@lib.Writer) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.write_varint(8UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.end is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for DescriptorProto_ExtensionRange with fn to_json(self) {
@@ -733,21 +667,15 @@ pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_lim
 pub impl @lib.AsyncWrite for DescriptorProto_ExtensionRange with fn write(self: DescriptorProto_ExtensionRange, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.async_write_varint(8UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.end is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct DescriptorProto_ReservedRange {
@@ -790,15 +718,11 @@ pub impl @lib.Read for DescriptorProto_ReservedRange with fn read_with_limit(rea
 pub impl @lib.Write for DescriptorProto_ReservedRange with fn write(self: DescriptorProto_ReservedRange, writer : &@lib.Writer) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.write_varint(8UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.end is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_int32(v)
-
   }
 }
 pub impl ToJson for DescriptorProto_ReservedRange with fn to_json(self) {
@@ -841,15 +765,11 @@ pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with fn read_with_limi
 pub impl @lib.AsyncWrite for DescriptorProto_ReservedRange with fn write(self: DescriptorProto_ReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.async_write_varint(8UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.end is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
 }
 pub(all) struct DescriptorProto {
@@ -955,69 +875,47 @@ pub impl @lib.Read for DescriptorProto with fn read_with_limit(reader : @lib.Lim
 pub impl @lib.Write for DescriptorProto with fn write(self: DescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   for item in self.field {
     writer |> @lib.write_varint(18UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.extension {
     writer |> @lib.write_varint(50UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.nested_type {
     writer |> @lib.write_varint(26UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.enum_type {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.extension_range {
     writer |> @lib.write_varint(42UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.oneof_decl {
     writer |> @lib.write_varint(66UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(58UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.reserved_range {
     writer |> @lib.write_varint(74UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.reserved_name {
     writer |> @lib.write_varint(82UL)
-
     writer |> @lib.write_string(item)
-
   }
   if self.visibility is Some(v) {
     writer |> @lib.write_varint(88UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
 }
 pub impl ToJson for DescriptorProto with fn to_json(self) {
@@ -1114,69 +1012,47 @@ pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(reader : @li
 pub impl @lib.AsyncWrite for DescriptorProto with fn write(self: DescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   for item in self.field {
     writer |> @lib.async_write_varint(18UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.extension {
     writer |> @lib.async_write_varint(50UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.nested_type {
     writer |> @lib.async_write_varint(26UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.enum_type {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.extension_range {
     writer |> @lib.async_write_varint(42UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.oneof_decl {
     writer |> @lib.async_write_varint(66UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(58UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.reserved_range {
     writer |> @lib.async_write_varint(74UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.reserved_name {
     writer |> @lib.async_write_varint(82UL)
-
     writer |> @lib.async_write_string(item)
-
   }
   if self.visibility is Some(v) {
     writer |> @lib.async_write_varint(88UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
 }
 pub(all) enum ExtensionRangeOptions_VerificationState {
@@ -1278,33 +1154,23 @@ pub impl @lib.Read for ExtensionRangeOptions_Declaration with fn read_with_limit
 pub impl @lib.Write for ExtensionRangeOptions_Declaration with fn write(self: ExtensionRangeOptions_Declaration, writer : &@lib.Writer) -> Unit raise {
   if self.number is Some(v) {
     writer |> @lib.write_varint(8UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.full_name is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.type_ is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.reserved is Some(v) {
     writer |> @lib.write_varint(40UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.repeated is Some(v) {
     writer |> @lib.write_varint(48UL);
-
     writer |> @lib.write_bool(v)
-
   }
 }
 pub impl ToJson for ExtensionRangeOptions_Declaration with fn to_json(self) {
@@ -1365,33 +1231,23 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with fn read_with_
 pub impl @lib.AsyncWrite for ExtensionRangeOptions_Declaration with fn write(self: ExtensionRangeOptions_Declaration, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.number is Some(v) {
     writer |> @lib.async_write_varint(8UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.full_name is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.type_ is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.reserved is Some(v) {
     writer |> @lib.async_write_varint(40UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.repeated is Some(v) {
     writer |> @lib.async_write_varint(48UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
 }
 pub(all) struct ExtensionRangeOptions {
@@ -1448,27 +1304,19 @@ pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(reader : @l
 pub impl @lib.Write for ExtensionRangeOptions with fn write(self: ExtensionRangeOptions, writer : &@lib.Writer) -> Unit raise {
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.declaration {
     writer |> @lib.write_varint(18UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(402UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.verification is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
 }
 pub impl ToJson for ExtensionRangeOptions with fn to_json(self) {
@@ -1523,27 +1371,19 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(reader
 pub impl @lib.AsyncWrite for ExtensionRangeOptions with fn write(self: ExtensionRangeOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.declaration {
     writer |> @lib.async_write_varint(18UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(402UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.verification is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
 }
 pub(all) enum FieldDescriptorProto_Type {
@@ -1827,69 +1667,47 @@ pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(reader : @li
 pub impl @lib.Write for FieldDescriptorProto with fn write(self: FieldDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.number is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.label is Some(v) {
     writer |> @lib.write_varint(32UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.type_ is Some(v) {
     writer |> @lib.write_varint(40UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.type_name is Some(v) {
     writer |> @lib.write_varint(50UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.extendee is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.default_value is Some(v) {
     writer |> @lib.write_varint(58UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.oneof_index is Some(v) {
     writer |> @lib.write_varint(72UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.json_name is Some(v) {
     writer |> @lib.write_varint(82UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(66UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.proto3_optional is Some(v) {
     writer |> @lib.write_varint(136UL);
-
     writer |> @lib.write_bool(v)
-
   }
 }
 pub impl ToJson for FieldDescriptorProto with fn to_json(self) {
@@ -1986,69 +1804,47 @@ pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(reader 
 pub impl @lib.AsyncWrite for FieldDescriptorProto with fn write(self: FieldDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.number is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.label is Some(v) {
     writer |> @lib.async_write_varint(32UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.type_ is Some(v) {
     writer |> @lib.async_write_varint(40UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.type_name is Some(v) {
     writer |> @lib.async_write_varint(50UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.extendee is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.default_value is Some(v) {
     writer |> @lib.async_write_varint(58UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.oneof_index is Some(v) {
     writer |> @lib.async_write_varint(72UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.json_name is Some(v) {
     writer |> @lib.async_write_varint(82UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(66UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.proto3_optional is Some(v) {
     writer |> @lib.async_write_varint(136UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
 }
 pub(all) struct OneofDescriptorProto {
@@ -2091,15 +1887,11 @@ pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(reader : @li
 pub impl @lib.Write for OneofDescriptorProto with fn write(self: OneofDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for OneofDescriptorProto with fn to_json(self) {
@@ -2142,15 +1934,11 @@ pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(reader 
 pub impl @lib.AsyncWrite for OneofDescriptorProto with fn write(self: OneofDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct EnumDescriptorProto_EnumReservedRange {
@@ -2193,15 +1981,11 @@ pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with fn read_with_l
 pub impl @lib.Write for EnumDescriptorProto_EnumReservedRange with fn write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.Writer) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.write_varint(8UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.end is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_int32(v)
-
   }
 }
 pub impl ToJson for EnumDescriptorProto_EnumReservedRange with fn to_json(self) {
@@ -2244,15 +2028,11 @@ pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with fn read_w
 pub impl @lib.AsyncWrite for EnumDescriptorProto_EnumReservedRange with fn write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.async_write_varint(8UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.end is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
 }
 pub(all) struct EnumDescriptorProto {
@@ -2323,39 +2103,27 @@ pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(reader : @lib
 pub impl @lib.Write for EnumDescriptorProto with fn write(self: EnumDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   for item in self.value {
     writer |> @lib.write_varint(18UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.reserved_range {
     writer |> @lib.write_varint(34UL)
-
     writer |> @lib.write_message(item)
-
   }
   for item in self.reserved_name {
     writer |> @lib.write_varint(42UL)
-
     writer |> @lib.write_string(item)
-
   }
   if self.visibility is Some(v) {
     writer |> @lib.write_varint(48UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
 }
 pub impl ToJson for EnumDescriptorProto with fn to_json(self) {
@@ -2422,39 +2190,27 @@ pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(reader :
 pub impl @lib.AsyncWrite for EnumDescriptorProto with fn write(self: EnumDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   for item in self.value {
     writer |> @lib.async_write_varint(18UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.reserved_range {
     writer |> @lib.async_write_varint(34UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   for item in self.reserved_name {
     writer |> @lib.async_write_varint(42UL)
-
     writer |> @lib.async_write_string(item)
-
   }
   if self.visibility is Some(v) {
     writer |> @lib.async_write_varint(48UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
 }
 pub(all) struct EnumValueDescriptorProto {
@@ -2504,21 +2260,15 @@ pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(reader :
 pub impl @lib.Write for EnumValueDescriptorProto with fn write(self: EnumValueDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.number is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for EnumValueDescriptorProto with fn to_json(self) {
@@ -2567,21 +2317,15 @@ pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(rea
 pub impl @lib.AsyncWrite for EnumValueDescriptorProto with fn write(self: EnumValueDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.number is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct ServiceDescriptorProto {
@@ -2631,21 +2375,15 @@ pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(reader : @
 pub impl @lib.Write for ServiceDescriptorProto with fn write(self: ServiceDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   for item in self.method_ {
     writer |> @lib.write_varint(18UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for ServiceDescriptorProto with fn to_json(self) {
@@ -2694,21 +2432,15 @@ pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(reade
 pub impl @lib.AsyncWrite for ServiceDescriptorProto with fn write(self: ServiceDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   for item in self.method_ {
     writer |> @lib.async_write_varint(18UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct MethodDescriptorProto {
@@ -2779,39 +2511,27 @@ pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(reader : @l
 pub impl @lib.Write for MethodDescriptorProto with fn write(self: MethodDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.input_type is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.output_type is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(34UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.client_streaming is Some(v) {
     writer |> @lib.write_varint(40UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.server_streaming is Some(v) {
     writer |> @lib.write_varint(48UL);
-
     writer |> @lib.write_bool(v)
-
   }
 }
 pub impl ToJson for MethodDescriptorProto with fn to_json(self) {
@@ -2878,39 +2598,27 @@ pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(reader
 pub impl @lib.AsyncWrite for MethodDescriptorProto with fn write(self: MethodDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.input_type is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.output_type is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.client_streaming is Some(v) {
     writer |> @lib.async_write_varint(40UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.server_streaming is Some(v) {
     writer |> @lib.async_write_varint(48UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
 }
 pub(all) enum FileOptions_OptimizeMode {
@@ -3130,129 +2838,87 @@ pub impl @lib.Read for FileOptions with fn read_with_limit(reader : @lib.Limited
 pub impl @lib.Write for FileOptions with fn write(self: FileOptions, writer : &@lib.Writer) -> Unit raise {
   if self.java_package is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.java_outer_classname is Some(v) {
     writer |> @lib.write_varint(66UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.java_multiple_files is Some(v) {
     writer |> @lib.write_varint(80UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.java_generate_equals_and_hash is Some(v) {
     writer |> @lib.write_varint(160UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.java_string_check_utf8 is Some(v) {
     writer |> @lib.write_varint(216UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.optimize_for is Some(v) {
     writer |> @lib.write_varint(72UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.go_package is Some(v) {
     writer |> @lib.write_varint(90UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.cc_generic_services is Some(v) {
     writer |> @lib.write_varint(128UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.java_generic_services is Some(v) {
     writer |> @lib.write_varint(136UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.py_generic_services is Some(v) {
     writer |> @lib.write_varint(144UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(184UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.cc_enable_arenas is Some(v) {
     writer |> @lib.write_varint(248UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.objc_class_prefix is Some(v) {
     writer |> @lib.write_varint(290UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.csharp_namespace is Some(v) {
     writer |> @lib.write_varint(298UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.swift_prefix is Some(v) {
     writer |> @lib.write_varint(314UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.php_class_prefix is Some(v) {
     writer |> @lib.write_varint(322UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.php_namespace is Some(v) {
     writer |> @lib.write_varint(330UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.php_metadata_namespace is Some(v) {
     writer |> @lib.write_varint(354UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.ruby_package is Some(v) {
     writer |> @lib.write_varint(362UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(402UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for FileOptions with fn to_json(self) {
@@ -3409,129 +3075,87 @@ pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(reader : @lib.Li
 pub impl @lib.AsyncWrite for FileOptions with fn write(self: FileOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.java_package is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.java_outer_classname is Some(v) {
     writer |> @lib.async_write_varint(66UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.java_multiple_files is Some(v) {
     writer |> @lib.async_write_varint(80UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.java_generate_equals_and_hash is Some(v) {
     writer |> @lib.async_write_varint(160UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.java_string_check_utf8 is Some(v) {
     writer |> @lib.async_write_varint(216UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.optimize_for is Some(v) {
     writer |> @lib.async_write_varint(72UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.go_package is Some(v) {
     writer |> @lib.async_write_varint(90UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.cc_generic_services is Some(v) {
     writer |> @lib.async_write_varint(128UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.java_generic_services is Some(v) {
     writer |> @lib.async_write_varint(136UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.py_generic_services is Some(v) {
     writer |> @lib.async_write_varint(144UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(184UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.cc_enable_arenas is Some(v) {
     writer |> @lib.async_write_varint(248UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.objc_class_prefix is Some(v) {
     writer |> @lib.async_write_varint(290UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.csharp_namespace is Some(v) {
     writer |> @lib.async_write_varint(298UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.swift_prefix is Some(v) {
     writer |> @lib.async_write_varint(314UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.php_class_prefix is Some(v) {
     writer |> @lib.async_write_varint(322UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.php_namespace is Some(v) {
     writer |> @lib.async_write_varint(330UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.php_metadata_namespace is Some(v) {
     writer |> @lib.async_write_varint(354UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.ruby_package is Some(v) {
     writer |> @lib.async_write_varint(362UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(402UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct MessageOptions {
@@ -3609,45 +3233,31 @@ pub impl @lib.Read for MessageOptions with fn read_with_limit(reader : @lib.Limi
 pub impl @lib.Write for MessageOptions with fn write(self: MessageOptions, writer : &@lib.Writer) -> Unit raise {
   if self.message_set_wire_format is Some(v) {
     writer |> @lib.write_varint(8UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.no_standard_descriptor_accessor is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.map_entry is Some(v) {
     writer |> @lib.write_varint(56UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
     writer |> @lib.write_varint(88UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(98UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for MessageOptions with fn to_json(self) {
@@ -3720,45 +3330,31 @@ pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(reader : @lib
 pub impl @lib.AsyncWrite for MessageOptions with fn write(self: MessageOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.message_set_wire_format is Some(v) {
     writer |> @lib.async_write_varint(8UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.no_standard_descriptor_accessor is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.map_entry is Some(v) {
     writer |> @lib.async_write_varint(56UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
     writer |> @lib.async_write_varint(88UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(98UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) enum FieldOptions_CType {
@@ -4019,15 +3615,11 @@ pub impl @lib.Read for FieldOptions_EditionDefault with fn read_with_limit(reade
 pub impl @lib.Write for FieldOptions_EditionDefault with fn write(self: FieldOptions_EditionDefault, writer : &@lib.Writer) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.value is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
 }
 pub impl ToJson for FieldOptions_EditionDefault with fn to_json(self) {
@@ -4070,15 +3662,11 @@ pub impl @lib.AsyncRead for FieldOptions_EditionDefault with fn read_with_limit(
 pub impl @lib.AsyncWrite for FieldOptions_EditionDefault with fn write(self: FieldOptions_EditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.value is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
 }
 pub(all) struct FieldOptions_FeatureSupport {
@@ -4135,27 +3723,19 @@ pub impl @lib.Read for FieldOptions_FeatureSupport with fn read_with_limit(reade
 pub impl @lib.Write for FieldOptions_FeatureSupport with fn write(self: FieldOptions_FeatureSupport, writer : &@lib.Writer) -> Unit raise {
   if self.edition_introduced is Some(v) {
     writer |> @lib.write_varint(8UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.edition_deprecated is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.deprecation_warning is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.edition_removed is Some(v) {
     writer |> @lib.write_varint(32UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
 }
 pub impl ToJson for FieldOptions_FeatureSupport with fn to_json(self) {
@@ -4210,27 +3790,19 @@ pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with fn read_with_limit(
 pub impl @lib.AsyncWrite for FieldOptions_FeatureSupport with fn write(self: FieldOptions_FeatureSupport, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.edition_introduced is Some(v) {
     writer |> @lib.async_write_varint(8UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.edition_deprecated is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.deprecation_warning is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.edition_removed is Some(v) {
     writer |> @lib.async_write_varint(32UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
 }
 pub(all) struct FieldOptions {
@@ -4358,87 +3930,59 @@ pub impl @lib.Read for FieldOptions with fn read_with_limit(reader : @lib.Limite
 pub impl @lib.Write for FieldOptions with fn write(self: FieldOptions, writer : &@lib.Writer) -> Unit raise {
   if self.ctype is Some(v) {
     writer |> @lib.write_varint(8UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.packed is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.jstype is Some(v) {
     writer |> @lib.write_varint(48UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.lazy_ is Some(v) {
     writer |> @lib.write_varint(40UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.unverified_lazy is Some(v) {
     writer |> @lib.write_varint(120UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.weak is Some(v) {
     writer |> @lib.write_varint(80UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.debug_redact is Some(v) {
     writer |> @lib.write_varint(128UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.retention is Some(v) {
     writer |> @lib.write_varint(136UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   for item in self.targets {
     writer |> @lib.write_varint(152UL)
-
     writer |> @lib.write_enum(item.to_enum())
-
   }
   for item in self.edition_defaults {
     writer |> @lib.write_varint(162UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(170UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.feature_support is Some(v) {
     writer |> @lib.write_varint(178UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for FieldOptions with fn to_json(self) {
@@ -4554,87 +4098,59 @@ pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(reader : @lib.L
 pub impl @lib.AsyncWrite for FieldOptions with fn write(self: FieldOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.ctype is Some(v) {
     writer |> @lib.async_write_varint(8UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.packed is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.jstype is Some(v) {
     writer |> @lib.async_write_varint(48UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.lazy_ is Some(v) {
     writer |> @lib.async_write_varint(40UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.unverified_lazy is Some(v) {
     writer |> @lib.async_write_varint(120UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.weak is Some(v) {
     writer |> @lib.async_write_varint(80UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.debug_redact is Some(v) {
     writer |> @lib.async_write_varint(128UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.retention is Some(v) {
     writer |> @lib.async_write_varint(136UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   for item in self.targets {
     writer |> @lib.async_write_varint(152UL)
-
     writer |> @lib.async_write_enum(item.to_enum())
-
   }
   for item in self.edition_defaults {
     writer |> @lib.async_write_varint(162UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(170UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.feature_support is Some(v) {
     writer |> @lib.async_write_varint(178UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct OneofOptions {
@@ -4677,15 +4193,11 @@ pub impl @lib.Read for OneofOptions with fn read_with_limit(reader : @lib.Limite
 pub impl @lib.Write for OneofOptions with fn write(self: OneofOptions, writer : &@lib.Writer) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.write_varint(10UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for OneofOptions with fn to_json(self) {
@@ -4728,15 +4240,11 @@ pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(reader : @lib.L
 pub impl @lib.AsyncWrite for OneofOptions with fn write(self: OneofOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(10UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct EnumOptions {
@@ -4800,33 +4308,23 @@ pub impl @lib.Read for EnumOptions with fn read_with_limit(reader : @lib.Limited
 pub impl @lib.Write for EnumOptions with fn write(self: EnumOptions, writer : &@lib.Writer) -> Unit raise {
   if self.allow_alias is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
     writer |> @lib.write_varint(48UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(58UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for EnumOptions with fn to_json(self) {
@@ -4887,33 +4385,23 @@ pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(reader : @lib.Li
 pub impl @lib.AsyncWrite for EnumOptions with fn write(self: EnumOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.allow_alias is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
     writer |> @lib.async_write_varint(48UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(58UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct EnumValueOptions {
@@ -4977,33 +4465,23 @@ pub impl @lib.Read for EnumValueOptions with fn read_with_limit(reader : @lib.Li
 pub impl @lib.Write for EnumValueOptions with fn write(self: EnumValueOptions, writer : &@lib.Writer) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(8UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.debug_redact is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.feature_support is Some(v) {
     writer |> @lib.write_varint(34UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for EnumValueOptions with fn to_json(self) {
@@ -5064,33 +4542,23 @@ pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(reader : @l
 pub impl @lib.AsyncWrite for EnumValueOptions with fn write(self: EnumValueOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(8UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.debug_redact is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.feature_support is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct ServiceOptions {
@@ -5140,21 +4608,15 @@ pub impl @lib.Read for ServiceOptions with fn read_with_limit(reader : @lib.Limi
 pub impl @lib.Write for ServiceOptions with fn write(self: ServiceOptions, writer : &@lib.Writer) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.write_varint(274UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(264UL);
-
     writer |> @lib.write_bool(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for ServiceOptions with fn to_json(self) {
@@ -5203,21 +4665,15 @@ pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(reader : @lib
 pub impl @lib.AsyncWrite for ServiceOptions with fn write(self: ServiceOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(274UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(264UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) enum MethodOptions_IdempotencyLevel {
@@ -5318,27 +4774,19 @@ pub impl @lib.Read for MethodOptions with fn read_with_limit(reader : @lib.Limit
 pub impl @lib.Write for MethodOptions with fn write(self: MethodOptions, writer : &@lib.Writer) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(264UL);
-
     writer |> @lib.write_bool(v)
-
   }
   if self.idempotency_level is Some(v) {
     writer |> @lib.write_varint(272UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(282UL);
-
     writer |> @lib.write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for MethodOptions with fn to_json(self) {
@@ -5393,27 +4841,19 @@ pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(reader : @lib.
 pub impl @lib.AsyncWrite for MethodOptions with fn write(self: MethodOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(264UL);
-
     writer |> @lib.async_write_bool(v)
-
   }
   if self.idempotency_level is Some(v) {
     writer |> @lib.async_write_varint(272UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(282UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) struct UninterpretedOption_NamePart {
@@ -5571,45 +5011,31 @@ pub impl @lib.Read for UninterpretedOption with fn read_with_limit(reader : @lib
 pub impl @lib.Write for UninterpretedOption with fn write(self: UninterpretedOption, writer : &@lib.Writer) -> Unit raise {
   for item in self.name {
     writer |> @lib.write_varint(18UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.identifier_value is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.positive_int_value is Some(v) {
     writer |> @lib.write_varint(32UL);
-
     writer |> @lib.write_uint64(v)
-
   }
   if self.negative_int_value is Some(v) {
     writer |> @lib.write_varint(40UL);
-
     writer |> @lib.write_int64(v)
-
   }
   if self.double_value is Some(v) {
     writer |> @lib.write_varint(49UL);
-
     writer |> @lib.write_double(v)
-
   }
   if self.string_value is Some(v) {
     writer |> @lib.write_varint(58UL);
-
     writer |> @lib.write_bytes(v)
-
   }
   if self.aggregate_value is Some(v) {
     writer |> @lib.write_varint(66UL);
-
     writer |> @lib.write_string(v)
-
   }
 }
 pub impl ToJson for UninterpretedOption with fn to_json(self) {
@@ -5682,45 +5108,31 @@ pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(reader :
 pub impl @lib.AsyncWrite for UninterpretedOption with fn write(self: UninterpretedOption, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.name {
     writer |> @lib.async_write_varint(18UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.identifier_value is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.positive_int_value is Some(v) {
     writer |> @lib.async_write_varint(32UL);
-
     writer |> @lib.async_write_uint64(v)
-
   }
   if self.negative_int_value is Some(v) {
     writer |> @lib.async_write_varint(40UL);
-
     writer |> @lib.async_write_int64(v)
-
   }
   if self.double_value is Some(v) {
     writer |> @lib.async_write_varint(49UL);
-
     writer |> @lib.async_write_double(v)
-
   }
   if self.string_value is Some(v) {
     writer |> @lib.async_write_varint(58UL);
-
     writer |> @lib.async_write_bytes(v)
-
   }
   if self.aggregate_value is Some(v) {
     writer |> @lib.async_write_varint(66UL);
-
     writer |> @lib.async_write_string(v)
-
   }
 }
 pub(all) enum FeatureSet_FieldPresence {
@@ -6204,51 +5616,35 @@ pub impl @lib.Read for FeatureSet with fn read_with_limit(reader : @lib.LimitedR
 pub impl @lib.Write for FeatureSet with fn write(self: FeatureSet, writer : &@lib.Writer) -> Unit raise {
   if self.field_presence is Some(v) {
     writer |> @lib.write_varint(8UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.enum_type is Some(v) {
     writer |> @lib.write_varint(16UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.repeated_field_encoding is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.utf8_validation is Some(v) {
     writer |> @lib.write_varint(32UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.message_encoding is Some(v) {
     writer |> @lib.write_varint(40UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.json_format is Some(v) {
     writer |> @lib.write_varint(48UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.enforce_naming_style is Some(v) {
     writer |> @lib.write_varint(56UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.default_symbol_visibility is Some(v) {
     writer |> @lib.write_varint(64UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
 }
 pub impl ToJson for FeatureSet with fn to_json(self) {
@@ -6327,51 +5723,35 @@ pub impl @lib.AsyncRead for FeatureSet with fn read_with_limit(reader : @lib.Lim
 pub impl @lib.AsyncWrite for FeatureSet with fn write(self: FeatureSet, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.field_presence is Some(v) {
     writer |> @lib.async_write_varint(8UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.enum_type is Some(v) {
     writer |> @lib.async_write_varint(16UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.repeated_field_encoding is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.utf8_validation is Some(v) {
     writer |> @lib.async_write_varint(32UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.message_encoding is Some(v) {
     writer |> @lib.async_write_varint(40UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.json_format is Some(v) {
     writer |> @lib.async_write_varint(48UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.enforce_naming_style is Some(v) {
     writer |> @lib.async_write_varint(56UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.default_symbol_visibility is Some(v) {
     writer |> @lib.async_write_varint(64UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
 }
 pub(all) struct FeatureSetDefaults_FeatureSetEditionDefault {
@@ -6421,21 +5801,15 @@ pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_
 pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with fn write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.Writer) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.overridable_features is Some(v) {
     writer |> @lib.write_varint(34UL);
-
     writer |> @lib.write_message(v)
-
   }
   if self.fixed_features is Some(v) {
     writer |> @lib.write_varint(42UL);
-
     writer |> @lib.write_message(v)
-
   }
 }
 pub impl ToJson for FeatureSetDefaults_FeatureSetEditionDefault with fn to_json(self) {
@@ -6484,21 +5858,15 @@ pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn 
 pub impl @lib.AsyncWrite for FeatureSetDefaults_FeatureSetEditionDefault with fn write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.overridable_features is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-
     writer |> @lib.async_write_message(v)
-
   }
   if self.fixed_features is Some(v) {
     writer |> @lib.async_write_varint(42UL);
-
     writer |> @lib.async_write_message(v)
-
   }
 }
 pub(all) struct FeatureSetDefaults {
@@ -6548,21 +5916,15 @@ pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(reader : @lib.
 pub impl @lib.Write for FeatureSetDefaults with fn write(self: FeatureSetDefaults, writer : &@lib.Writer) -> Unit raise {
   for item in self.defaults {
     writer |> @lib.write_varint(10UL)
-
     writer |> @lib.write_message(item)
-
   }
   if self.minimum_edition is Some(v) {
     writer |> @lib.write_varint(32UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
   if self.maximum_edition is Some(v) {
     writer |> @lib.write_varint(40UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
 }
 pub impl ToJson for FeatureSetDefaults with fn to_json(self) {
@@ -6611,21 +5973,15 @@ pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(reader : 
 pub impl @lib.AsyncWrite for FeatureSetDefaults with fn write(self: FeatureSetDefaults, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.defaults {
     writer |> @lib.async_write_varint(10UL)
-
     writer |> @lib.async_write_message(item)
-
   }
   if self.minimum_edition is Some(v) {
     writer |> @lib.async_write_varint(32UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
   if self.maximum_edition is Some(v) {
     writer |> @lib.async_write_varint(40UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
 }
 pub(all) struct SourceCodeInfo_Location {
@@ -6695,7 +6051,6 @@ pub impl @lib.Write for SourceCodeInfo_Location with fn write(self: SourceCodeIn
     writer |> @lib.write_uint32(size)
     for item in self.path {
         writer |> @lib.write_int32(item)
-
     }
   }
   if !self.span.is_empty() {
@@ -6704,26 +6059,19 @@ pub impl @lib.Write for SourceCodeInfo_Location with fn write(self: SourceCodeIn
     writer |> @lib.write_uint32(size)
     for item in self.span {
         writer |> @lib.write_int32(item)
-
     }
   }
   if self.leading_comments is Some(v) {
     writer |> @lib.write_varint(26UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.trailing_comments is Some(v) {
     writer |> @lib.write_varint(34UL);
-
     writer |> @lib.write_string(v)
-
   }
   for item in self.leading_detached_comments {
     writer |> @lib.write_varint(50UL)
-
     writer |> @lib.write_string(item)
-
   }
 }
 pub impl ToJson for SourceCodeInfo_Location with fn to_json(self) {
@@ -6790,7 +6138,6 @@ pub impl @lib.AsyncWrite for SourceCodeInfo_Location with fn write(self: SourceC
     writer |> @lib.async_write_uint32(size)
     for item in self.path {
         writer |> @lib.async_write_int32(item)
-
     }
   }
   if !self.span.is_empty() {
@@ -6799,26 +6146,19 @@ pub impl @lib.AsyncWrite for SourceCodeInfo_Location with fn write(self: SourceC
     writer |> @lib.async_write_uint32(size)
     for item in self.span {
         writer |> @lib.async_write_int32(item)
-
     }
   }
   if self.leading_comments is Some(v) {
     writer |> @lib.async_write_varint(26UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.trailing_comments is Some(v) {
     writer |> @lib.async_write_varint(34UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   for item in self.leading_detached_comments {
     writer |> @lib.async_write_varint(50UL)
-
     writer |> @lib.async_write_string(item)
-
   }
 }
 pub(all) struct SourceCodeInfo {
@@ -6854,9 +6194,7 @@ pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(reader : @lib.Limi
 pub impl @lib.Write for SourceCodeInfo with fn write(self: SourceCodeInfo, writer : &@lib.Writer) -> Unit raise {
   for item in self.location {
     writer |> @lib.write_varint(10UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for SourceCodeInfo with fn to_json(self) {
@@ -6893,9 +6231,7 @@ pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(reader : @lib
 pub impl @lib.AsyncWrite for SourceCodeInfo with fn write(self: SourceCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.location {
     writer |> @lib.async_write_varint(10UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }
 pub(all) enum GeneratedCodeInfo_Annotation_Semantic {
@@ -7008,32 +6344,23 @@ pub impl @lib.Write for GeneratedCodeInfo_Annotation with fn write(self: Generat
     writer |> @lib.write_uint32(size)
     for item in self.path {
         writer |> @lib.write_int32(item)
-
     }
   }
   if self.source_file is Some(v) {
     writer |> @lib.write_varint(18UL);
-
     writer |> @lib.write_string(v)
-
   }
   if self.begin is Some(v) {
     writer |> @lib.write_varint(24UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.end is Some(v) {
     writer |> @lib.write_varint(32UL);
-
     writer |> @lib.write_int32(v)
-
   }
   if self.semantic is Some(v) {
     writer |> @lib.write_varint(40UL);
-
     writer |> @lib.write_enum(v.to_enum())
-
   }
 }
 pub impl ToJson for GeneratedCodeInfo_Annotation with fn to_json(self) {
@@ -7099,32 +6426,23 @@ pub impl @lib.AsyncWrite for GeneratedCodeInfo_Annotation with fn write(self: Ge
     writer |> @lib.async_write_uint32(size)
     for item in self.path {
         writer |> @lib.async_write_int32(item)
-
     }
   }
   if self.source_file is Some(v) {
     writer |> @lib.async_write_varint(18UL);
-
     writer |> @lib.async_write_string(v)
-
   }
   if self.begin is Some(v) {
     writer |> @lib.async_write_varint(24UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.end is Some(v) {
     writer |> @lib.async_write_varint(32UL);
-
     writer |> @lib.async_write_int32(v)
-
   }
   if self.semantic is Some(v) {
     writer |> @lib.async_write_varint(40UL);
-
     writer |> @lib.async_write_enum(v.to_enum())
-
   }
 }
 pub(all) struct GeneratedCodeInfo {
@@ -7160,9 +6478,7 @@ pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(reader : @lib.L
 pub impl @lib.Write for GeneratedCodeInfo with fn write(self: GeneratedCodeInfo, writer : &@lib.Writer) -> Unit raise {
   for item in self.annotation {
     writer |> @lib.write_varint(10UL)
-
     writer |> @lib.write_message(item)
-
   }
 }
 pub impl ToJson for GeneratedCodeInfo with fn to_json(self) {
@@ -7199,8 +6515,6 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(reader : @
 pub impl @lib.AsyncWrite for GeneratedCodeInfo with fn write(self: GeneratedCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.annotation {
     writer |> @lib.async_write_varint(10UL)
-
     writer |> @lib.async_write_message(item)
-
   }
 }

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -164,7 +164,7 @@ pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(reader : @lib.L
   let msg = FileDescriptorSet::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -201,7 +201,7 @@ pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(reader : @
   let msg = FileDescriptorSet::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.file.push((reader |> @lib.async_read_message() : FileDescriptorProto))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.file.push((reader |> @lib.async_read_message() : FileDescriptorProto))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -318,17 +318,17 @@ pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(reader : @lib
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.package_ = reader |> @lib.read_string() |> Some
       (3, _) => msg.dependency.push(reader |> @lib.read_string())
-      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (10, 0) => msg.public_dependency.push(reader |> @lib.read_int32())
-      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
+      (10, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.public_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (10, @lib.WIRE_TYPE_VARINT) => msg.public_dependency.push(reader |> @lib.read_int32())
+      (11, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.weak_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (11, @lib.WIRE_TYPE_VARINT) => msg.weak_dependency.push(reader |> @lib.read_int32())
       (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
-      (4, 2) => msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
-      (5, 2) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
-      (6, 2) => msg.service.push((reader |> @lib.read_message() : ServiceDescriptorProto))
-      (7, 2) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
-      (8, 2) => msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
-      (9, 2) => msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.service.push((reader |> @lib.read_message() : ServiceDescriptorProto))
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
+      (9, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo) |> Some
       (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
       (14, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -487,17 +487,17 @@ pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(reader :
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.package_ = reader |> @lib.async_read_string() |> Some
       (3, _) => msg.dependency.push(reader |> @lib.async_read_string())
-      (10, 2) => { msg.public_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (10, 0) => msg.public_dependency.push(reader |> @lib.async_read_int32())
-      (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
+      (10, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.public_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (10, @lib.WIRE_TYPE_VARINT) => msg.public_dependency.push(reader |> @lib.async_read_int32())
+      (11, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.weak_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (11, @lib.WIRE_TYPE_VARINT) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
       (15, _) => msg.option_dependency.push(reader |> @lib.async_read_string())
-      (4, 2) => msg.message_type.push((reader |> @lib.async_read_message() : DescriptorProto))
-      (5, 2) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
-      (6, 2) => msg.service.push((reader |> @lib.async_read_message() : ServiceDescriptorProto))
-      (7, 2) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-      (8, 2) => msg.options = (reader |> @lib.async_read_message() : FileOptions) |> Some
-      (9, 2) => msg.source_code_info = (reader |> @lib.async_read_message() : SourceCodeInfo) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.message_type.push((reader |> @lib.async_read_message() : DescriptorProto))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.service.push((reader |> @lib.async_read_message() : ServiceDescriptorProto))
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.async_read_message() : FileOptions) |> Some
+      (9, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.source_code_info = (reader |> @lib.async_read_message() : SourceCodeInfo) |> Some
       (12, _) => msg.syntax = reader |> @lib.async_read_string() |> Some
       (14, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -601,7 +601,7 @@ pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(re
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-      (3, 2) => msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -658,7 +658,7 @@ pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_lim
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-      (3, 2) => msg.options = (reader |> @lib.async_read_message() : ExtensionRangeOptions) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.async_read_message() : ExtensionRangeOptions) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -857,14 +857,14 @@ pub impl @lib.Read for DescriptorProto with fn read_with_limit(reader : @lib.Lim
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, 2) => msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
-      (6, 2) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
-      (3, 2) => msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto))
-      (4, 2) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
-      (5, 2) => msg.extension_range.push((reader |> @lib.read_message() : DescriptorProto_ExtensionRange))
-      (8, 2) => msg.oneof_decl.push((reader |> @lib.read_message() : OneofDescriptorProto))
-      (7, 2) => msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
-      (9, 2) => msg.reserved_range.push((reader |> @lib.read_message() : DescriptorProto_ReservedRange))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.extension_range.push((reader |> @lib.read_message() : DescriptorProto_ExtensionRange))
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.oneof_decl.push((reader |> @lib.read_message() : OneofDescriptorProto))
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
+      (9, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.reserved_range.push((reader |> @lib.read_message() : DescriptorProto_ReservedRange))
       (10, _) => msg.reserved_name.push(reader |> @lib.read_string())
       (11, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -994,14 +994,14 @@ pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(reader : @li
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, 2) => msg.field.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-      (6, 2) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-      (3, 2) => msg.nested_type.push((reader |> @lib.async_read_message() : DescriptorProto))
-      (4, 2) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
-      (5, 2) => msg.extension_range.push((reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange))
-      (8, 2) => msg.oneof_decl.push((reader |> @lib.async_read_message() : OneofDescriptorProto))
-      (7, 2) => msg.options = (reader |> @lib.async_read_message() : MessageOptions) |> Some
-      (9, 2) => msg.reserved_range.push((reader |> @lib.async_read_message() : DescriptorProto_ReservedRange))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.field.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+      (6, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.nested_type.push((reader |> @lib.async_read_message() : DescriptorProto))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.extension_range.push((reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange))
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.oneof_decl.push((reader |> @lib.async_read_message() : OneofDescriptorProto))
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.async_read_message() : MessageOptions) |> Some
+      (9, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.reserved_range.push((reader |> @lib.async_read_message() : DescriptorProto_ReservedRange))
       (10, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
       (11, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -1292,9 +1292,9 @@ pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(reader : @l
   let msg = ExtensionRangeOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-      (2, 2) => msg.declaration.push((reader |> @lib.read_message() : ExtensionRangeOptions_Declaration))
-      (50, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.declaration.push((reader |> @lib.read_message() : ExtensionRangeOptions_Declaration))
+      (50, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (3, _) => msg.verification = reader |> @lib.read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
@@ -1359,9 +1359,9 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(reader
   let msg = ExtensionRangeOptions::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-      (2, 2) => msg.declaration.push((reader |> @lib.async_read_message() : ExtensionRangeOptions_Declaration))
-      (50, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.declaration.push((reader |> @lib.async_read_message() : ExtensionRangeOptions_Declaration))
+      (50, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
       (3, _) => msg.verification = reader |> @lib.async_read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
@@ -1657,7 +1657,7 @@ pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(reader : @li
       (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
       (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
       (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
-      (8, 2) => msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
       (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
@@ -1794,7 +1794,7 @@ pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(reader 
       (7, _) => msg.default_value = reader |> @lib.async_read_string() |> Some
       (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
       (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
-      (8, 2) => msg.options = (reader |> @lib.async_read_message() : FieldOptions) |> Some
+      (8, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.async_read_message() : FieldOptions) |> Some
       (17, _) => msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
@@ -1878,7 +1878,7 @@ pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(reader : @li
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, 2) => msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -1925,7 +1925,7 @@ pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(reader 
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, 2) => msg.options = (reader |> @lib.async_read_message() : OneofOptions) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.async_read_message() : OneofOptions) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -2090,9 +2090,9 @@ pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(reader : @lib
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, 2) => msg.value.push((reader |> @lib.read_message() : EnumValueDescriptorProto))
-      (3, 2) => msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
-      (4, 2) => msg.reserved_range.push((reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.value.push((reader |> @lib.read_message() : EnumValueDescriptorProto))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.reserved_range.push((reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange))
       (5, _) => msg.reserved_name.push(reader |> @lib.read_string())
       (6, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -2177,9 +2177,9 @@ pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(reader :
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, 2) => msg.value.push((reader |> @lib.async_read_message() : EnumValueDescriptorProto))
-      (3, 2) => msg.options = (reader |> @lib.async_read_message() : EnumOptions) |> Some
-      (4, 2) => msg.reserved_range.push((reader |> @lib.async_read_message() : EnumDescriptorProto_EnumReservedRange))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.value.push((reader |> @lib.async_read_message() : EnumValueDescriptorProto))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.async_read_message() : EnumOptions) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.reserved_range.push((reader |> @lib.async_read_message() : EnumDescriptorProto_EnumReservedRange))
       (5, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
       (6, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -2251,7 +2251,7 @@ pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(reader :
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.number = reader |> @lib.read_int32() |> Some
-      (3, 2) => msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -2308,7 +2308,7 @@ pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(rea
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-      (3, 2) => msg.options = (reader |> @lib.async_read_message() : EnumValueOptions) |> Some
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.async_read_message() : EnumValueOptions) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -2365,8 +2365,8 @@ pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(reader : @
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, 2) => msg.method_.push((reader |> @lib.read_message() : MethodDescriptorProto))
-      (3, 2) => msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.method_.push((reader |> @lib.read_message() : MethodDescriptorProto))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -2422,8 +2422,8 @@ pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(reade
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, 2) => msg.method_.push((reader |> @lib.async_read_message() : MethodDescriptorProto))
-      (3, 2) => msg.options = (reader |> @lib.async_read_message() : ServiceOptions) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.method_.push((reader |> @lib.async_read_message() : MethodDescriptorProto))
+      (3, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.async_read_message() : ServiceOptions) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -2500,7 +2500,7 @@ pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(reader : @l
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
       (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
-      (4, 2) => msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
       (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
       (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -2587,7 +2587,7 @@ pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(reader
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
       (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
-      (4, 2) => msg.options = (reader |> @lib.async_read_message() : MethodOptions) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.options = (reader |> @lib.async_read_message() : MethodOptions) |> Some
       (5, _) => msg.client_streaming = reader |> @lib.async_read_bool() |> Some
       (6, _) => msg.server_streaming = reader |> @lib.async_read_bool() |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -2828,8 +2828,8 @@ pub impl @lib.Read for FileOptions with fn read_with_limit(reader : @lib.Limited
       (41, _) => msg.php_namespace = reader |> @lib.read_string() |> Some
       (44, _) => msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
       (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
-      (50, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      (50, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -3065,8 +3065,8 @@ pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(reader : @lib.Li
       (41, _) => msg.php_namespace = reader |> @lib.async_read_string() |> Some
       (44, _) => msg.php_metadata_namespace = reader |> @lib.async_read_string() |> Some
       (45, _) => msg.ruby_package = reader |> @lib.async_read_string() |> Some
-      (50, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      (50, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -3223,8 +3223,8 @@ pub impl @lib.Read for MessageOptions with fn read_with_limit(reader : @lib.Limi
       (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
       (7, _) => msg.map_entry = reader |> @lib.read_bool() |> Some
       (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
-      (12, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      (12, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -3320,8 +3320,8 @@ pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(reader : @lib
       (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
       (7, _) => msg.map_entry = reader |> @lib.async_read_bool() |> Some
       (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
-      (12, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      (12, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -3916,12 +3916,12 @@ pub impl @lib.Read for FieldOptions with fn read_with_limit(reader : @lib.Limite
       (10, _) => msg.weak = reader |> @lib.read_bool() |> Some
       (16, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
       (17, _) => msg.retention = reader |> @lib.read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
-      (19, 2) => { let packed = reader |> @lib.read_packed(@lib.read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
-      (19, 0) => msg.targets.push(reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum)
-      (20, 2) => msg.edition_defaults.push((reader |> @lib.read_message() : FieldOptions_EditionDefault))
-      (21, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (22, 2) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      (19, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { let packed = reader |> @lib.read_packed(@lib.read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
+      (19, @lib.WIRE_TYPE_VARINT) => msg.targets.push(reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum)
+      (20, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.edition_defaults.push((reader |> @lib.read_message() : FieldOptions_EditionDefault))
+      (21, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (22, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4084,12 +4084,12 @@ pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(reader : @lib.L
       (10, _) => msg.weak = reader |> @lib.async_read_bool() |> Some
       (16, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
       (17, _) => msg.retention = reader |> @lib.async_read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
-      (19, 2) => { let packed = reader |> @lib.async_read_packed(@lib.async_read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
-      (19, 0) => msg.targets.push(reader |> @lib.async_read_enum() |> FieldOptions_OptionTargetType::from_enum)
-      (20, 2) => msg.edition_defaults.push((reader |> @lib.async_read_message() : FieldOptions_EditionDefault))
-      (21, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (22, 2) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      (19, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { let packed = reader |> @lib.async_read_packed(@lib.async_read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
+      (19, @lib.WIRE_TYPE_VARINT) => msg.targets.push(reader |> @lib.async_read_enum() |> FieldOptions_OptionTargetType::from_enum)
+      (20, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.edition_defaults.push((reader |> @lib.async_read_message() : FieldOptions_EditionDefault))
+      (21, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (22, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4183,8 +4183,8 @@ pub impl @lib.Read for OneofOptions with fn read_with_limit(reader : @lib.Limite
   let msg = OneofOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4230,8 +4230,8 @@ pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(reader : @lib.L
   let msg = OneofOptions::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4298,8 +4298,8 @@ pub impl @lib.Read for EnumOptions with fn read_with_limit(reader : @lib.Limited
       (2, _) => msg.allow_alias = reader |> @lib.read_bool() |> Some
       (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
       (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
-      (7, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4375,8 +4375,8 @@ pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(reader : @lib.Li
       (2, _) => msg.allow_alias = reader |> @lib.async_read_bool() |> Some
       (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
       (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
-      (7, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      (7, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4453,10 +4453,10 @@ pub impl @lib.Read for EnumValueOptions with fn read_with_limit(reader : @lib.Li
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (2, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-      (4, 2) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4530,10 +4530,10 @@ pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(reader : @l
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (2, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
       (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-      (4, 2) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4597,9 +4597,9 @@ pub impl @lib.Read for ServiceOptions with fn read_with_limit(reader : @lib.Limi
   let msg = ServiceOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (34, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (34, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4654,9 +4654,9 @@ pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(reader : @lib
   let msg = ServiceOptions::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (34, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (34, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
       (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4764,8 +4764,8 @@ pub impl @lib.Read for MethodOptions with fn read_with_limit(reader : @lib.Limit
     match (field_number, wire) {
       (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
       (34, _) => msg.idempotency_level = reader |> @lib.read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
-      (35, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      (35, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4831,8 +4831,8 @@ pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(reader : @lib.
     match (field_number, wire) {
       (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
       (34, _) => msg.idempotency_level = reader |> @lib.async_read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
-      (35, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      (35, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -4996,7 +4996,7 @@ pub impl @lib.Read for UninterpretedOption with fn read_with_limit(reader : @lib
   let msg = UninterpretedOption::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (2, 2) => msg.name.push((reader |> @lib.read_message() : UninterpretedOption_NamePart))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.name.push((reader |> @lib.read_message() : UninterpretedOption_NamePart))
       (3, _) => msg.identifier_value = reader |> @lib.read_string() |> Some
       (4, _) => msg.positive_int_value = reader |> @lib.read_uint64() |> Some
       (5, _) => msg.negative_int_value = reader |> @lib.read_int64() |> Some
@@ -5093,7 +5093,7 @@ pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(reader :
   let msg = UninterpretedOption::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (2, 2) => msg.name.push((reader |> @lib.async_read_message() : UninterpretedOption_NamePart))
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.name.push((reader |> @lib.async_read_message() : UninterpretedOption_NamePart))
       (3, _) => msg.identifier_value = reader |> @lib.async_read_string() |> Some
       (4, _) => msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some
       (5, _) => msg.negative_int_value = reader |> @lib.async_read_int64() |> Some
@@ -5791,8 +5791,8 @@ pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (3, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      (4, 2) => msg.overridable_features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (5, 2) => msg.fixed_features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.overridable_features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.fixed_features = (reader |> @lib.read_message() : FeatureSet) |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -5848,8 +5848,8 @@ pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn 
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (3, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-      (4, 2) => msg.overridable_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (5, 2) => msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (4, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.overridable_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (5, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -5905,7 +5905,7 @@ pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(reader : @lib.
   let msg = FeatureSetDefaults::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.defaults.push((reader |> @lib.read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.defaults.push((reader |> @lib.read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
       (4, _) => msg.minimum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
       (5, _) => msg.maximum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
@@ -5962,7 +5962,7 @@ pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(reader : 
   let msg = FeatureSetDefaults::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.defaults.push((reader |> @lib.async_read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.defaults.push((reader |> @lib.async_read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
       (4, _) => msg.minimum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
       (5, _) => msg.maximum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
@@ -6032,10 +6032,10 @@ pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(reader : 
   let msg = SourceCodeInfo_Location::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (1, 0) => msg.path.push(reader |> @lib.read_int32())
-      (2, 2) => { msg.span.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (2, 0) => msg.span.push(reader |> @lib.read_int32())
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (1, @lib.WIRE_TYPE_VARINT) => msg.path.push(reader |> @lib.read_int32())
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.span.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (2, @lib.WIRE_TYPE_VARINT) => msg.span.push(reader |> @lib.read_int32())
       (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
       (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
       (6, _) => msg.leading_detached_comments.push(reader |> @lib.read_string())
@@ -6119,10 +6119,10 @@ pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(read
   let msg = SourceCodeInfo_Location::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
-      (2, 2) => { msg.span.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (2, 0) => msg.span.push(reader |> @lib.async_read_int32())
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (1, @lib.WIRE_TYPE_VARINT) => msg.path.push(reader |> @lib.async_read_int32())
+      (2, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.span.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (2, @lib.WIRE_TYPE_VARINT) => msg.span.push(reader |> @lib.async_read_int32())
       (3, _) => msg.leading_comments = reader |> @lib.async_read_string() |> Some
       (4, _) => msg.trailing_comments = reader |> @lib.async_read_string() |> Some
       (6, _) => msg.leading_detached_comments.push(reader |> @lib.async_read_string())
@@ -6185,7 +6185,7 @@ pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(reader : @lib.Limi
   let msg = SourceCodeInfo::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.location.push((reader |> @lib.read_message() : SourceCodeInfo_Location))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.location.push((reader |> @lib.read_message() : SourceCodeInfo_Location))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -6222,7 +6222,7 @@ pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(reader : @lib
   let msg = SourceCodeInfo::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.location.push((reader |> @lib.async_read_message() : SourceCodeInfo_Location))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.location.push((reader |> @lib.async_read_message() : SourceCodeInfo_Location))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
@@ -6326,8 +6326,8 @@ pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(read
   let msg = GeneratedCodeInfo_Annotation::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
-      (1, 0) => msg.path.push(reader |> @lib.read_int32())
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.path.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
+      (1, @lib.WIRE_TYPE_VARINT) => msg.path.push(reader |> @lib.read_int32())
       (2, _) => msg.source_file = reader |> @lib.read_string() |> Some
       (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
       (4, _) => msg.end = reader |> @lib.read_int32() |> Some
@@ -6408,8 +6408,8 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit
   let msg = GeneratedCodeInfo_Annotation::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
-      (1, 0) => msg.path.push(reader |> @lib.async_read_int32())
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => { msg.path.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
+      (1, @lib.WIRE_TYPE_VARINT) => msg.path.push(reader |> @lib.async_read_int32())
       (2, _) => msg.source_file = reader |> @lib.async_read_string() |> Some
       (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
       (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
@@ -6469,7 +6469,7 @@ pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(reader : @lib.L
   let msg = GeneratedCodeInfo::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.annotation.push((reader |> @lib.read_message() : GeneratedCodeInfo_Annotation))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.annotation.push((reader |> @lib.read_message() : GeneratedCodeInfo_Annotation))
       _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
@@ -6506,7 +6506,7 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(reader : @
   let msg = GeneratedCodeInfo::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, 2) => msg.annotation.push((reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation))
+      (1, @lib.WIRE_TYPE_LENGTH_DELIMITED) => msg.annotation.push((reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation))
       _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }

--- a/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
+++ b/test/snapshots/test_case9/__snapshot/src/google/protobuf/top.mbt
@@ -164,8 +164,8 @@ pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(reader : @lib.L
   let msg = FileDescriptorSet::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
-      _ => reader |> @lib.skip_message_field(wire)
+      (1, 2) => msg.file.push((reader |> @lib.read_message() : FileDescriptorProto))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -173,6 +173,7 @@ pub impl @lib.Read for FileDescriptorSet with fn read_with_limit(reader : @lib.L
 pub impl @lib.Write for FileDescriptorSet with fn write(self: FileDescriptorSet, writer : &@lib.Writer) -> Unit raise {
   for item in self.file {
     writer |> @lib.write_varint(10UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -202,8 +203,8 @@ pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(reader : @
   let msg = FileDescriptorSet::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.file.push((reader |> @lib.async_read_message() : FileDescriptorProto))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (1, 2) => msg.file.push((reader |> @lib.async_read_message() : FileDescriptorProto))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -211,6 +212,7 @@ pub impl @lib.AsyncRead for FileDescriptorSet with fn read_with_limit(reader : @
 pub impl @lib.AsyncWrite for FileDescriptorSet with fn write(self: FileDescriptorSet, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.file {
     writer |> @lib.async_write_varint(10UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -325,15 +327,15 @@ pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(reader : @lib
       (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.read_packed(@lib.read_int32, None)).iter()) }
       (11, 0) => msg.weak_dependency.push(reader |> @lib.read_int32())
       (15, _) => msg.option_dependency.push(reader |> @lib.read_string())
-      (4, _) => msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
-      (5, _) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
-      (6, _) => msg.service.push((reader |> @lib.read_message() : ServiceDescriptorProto))
-      (7, _) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
-      (8, _) => msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
-      (9, _) => msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo) |> Some
+      (4, 2) => msg.message_type.push((reader |> @lib.read_message() : DescriptorProto))
+      (5, 2) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
+      (6, 2) => msg.service.push((reader |> @lib.read_message() : ServiceDescriptorProto))
+      (7, 2) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
+      (8, 2) => msg.options = (reader |> @lib.read_message() : FileOptions) |> Some
+      (9, 2) => msg.source_code_info = (reader |> @lib.read_message() : SourceCodeInfo) |> Some
       (12, _) => msg.syntax = reader |> @lib.read_string() |> Some
       (14, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -341,71 +343,85 @@ pub impl @lib.Read for FileDescriptorProto with fn read_with_limit(reader : @lib
 pub impl @lib.Write for FileDescriptorProto with fn write(self: FileDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.package_ is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   for item in self.dependency {
     writer |> @lib.write_varint(26UL)
+
     writer |> @lib.write_string(item)
 
   }
   for item in self.public_dependency {
     writer |> @lib.write_varint(80UL)
+
     writer |> @lib.write_int32(item)
 
   }
   for item in self.weak_dependency {
     writer |> @lib.write_varint(88UL)
+
     writer |> @lib.write_int32(item)
 
   }
   for item in self.option_dependency {
     writer |> @lib.write_varint(122UL)
+
     writer |> @lib.write_string(item)
 
   }
   for item in self.message_type {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.enum_type {
     writer |> @lib.write_varint(42UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.service {
     writer |> @lib.write_varint(50UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.extension {
     writer |> @lib.write_varint(58UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(66UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.source_code_info is Some(v) {
     writer |> @lib.write_varint(74UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.syntax is Some(v) {
     writer |> @lib.write_varint(98UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.edition is Some(v) {
     writer |> @lib.write_varint(112UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
@@ -508,15 +524,15 @@ pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(reader :
       (11, 2) => { msg.weak_dependency.push_iter((reader |> @lib.async_read_packed(@lib.async_read_int32, None)).iter()) }
       (11, 0) => msg.weak_dependency.push(reader |> @lib.async_read_int32())
       (15, _) => msg.option_dependency.push(reader |> @lib.async_read_string())
-      (4, _) => msg.message_type.push((reader |> @lib.async_read_message() : DescriptorProto))
-      (5, _) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
-      (6, _) => msg.service.push((reader |> @lib.async_read_message() : ServiceDescriptorProto))
-      (7, _) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-      (8, _) => msg.options = (reader |> @lib.async_read_message() : FileOptions) |> Some
-      (9, _) => msg.source_code_info = (reader |> @lib.async_read_message() : SourceCodeInfo) |> Some
+      (4, 2) => msg.message_type.push((reader |> @lib.async_read_message() : DescriptorProto))
+      (5, 2) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
+      (6, 2) => msg.service.push((reader |> @lib.async_read_message() : ServiceDescriptorProto))
+      (7, 2) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+      (8, 2) => msg.options = (reader |> @lib.async_read_message() : FileOptions) |> Some
+      (9, 2) => msg.source_code_info = (reader |> @lib.async_read_message() : SourceCodeInfo) |> Some
       (12, _) => msg.syntax = reader |> @lib.async_read_string() |> Some
       (14, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -524,71 +540,85 @@ pub impl @lib.AsyncRead for FileDescriptorProto with fn read_with_limit(reader :
 pub impl @lib.AsyncWrite for FileDescriptorProto with fn write(self: FileDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.package_ is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   for item in self.dependency {
     writer |> @lib.async_write_varint(26UL)
+
     writer |> @lib.async_write_string(item)
 
   }
   for item in self.public_dependency {
     writer |> @lib.async_write_varint(80UL)
+
     writer |> @lib.async_write_int32(item)
 
   }
   for item in self.weak_dependency {
     writer |> @lib.async_write_varint(88UL)
+
     writer |> @lib.async_write_int32(item)
 
   }
   for item in self.option_dependency {
     writer |> @lib.async_write_varint(122UL)
+
     writer |> @lib.async_write_string(item)
 
   }
   for item in self.message_type {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.enum_type {
     writer |> @lib.async_write_varint(42UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.service {
     writer |> @lib.async_write_varint(50UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.extension {
     writer |> @lib.async_write_varint(58UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(66UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.source_code_info is Some(v) {
     writer |> @lib.async_write_varint(74UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.syntax is Some(v) {
     writer |> @lib.async_write_varint(98UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.edition is Some(v) {
     writer |> @lib.async_write_varint(112UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
@@ -631,8 +661,8 @@ pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(re
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-      (3, _) => msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.options = (reader |> @lib.read_message() : ExtensionRangeOptions) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -640,16 +670,19 @@ pub impl @lib.Read for DescriptorProto_ExtensionRange with fn read_with_limit(re
 pub impl @lib.Write for DescriptorProto_ExtensionRange with fn write(self: DescriptorProto_ExtensionRange, writer : &@lib.Writer) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.write_varint(8UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.end is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -691,8 +724,8 @@ pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_lim
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-      (3, _) => msg.options = (reader |> @lib.async_read_message() : ExtensionRangeOptions) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.options = (reader |> @lib.async_read_message() : ExtensionRangeOptions) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -700,16 +733,19 @@ pub impl @lib.AsyncRead for DescriptorProto_ExtensionRange with fn read_with_lim
 pub impl @lib.AsyncWrite for DescriptorProto_ExtensionRange with fn write(self: DescriptorProto_ExtensionRange, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.async_write_varint(8UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.end is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -746,7 +782,7 @@ pub impl @lib.Read for DescriptorProto_ReservedRange with fn read_with_limit(rea
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -754,11 +790,13 @@ pub impl @lib.Read for DescriptorProto_ReservedRange with fn read_with_limit(rea
 pub impl @lib.Write for DescriptorProto_ReservedRange with fn write(self: DescriptorProto_ReservedRange, writer : &@lib.Writer) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.write_varint(8UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.end is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_int32(v)
 
   }
@@ -795,7 +833,7 @@ pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with fn read_with_limi
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -803,11 +841,13 @@ pub impl @lib.AsyncRead for DescriptorProto_ReservedRange with fn read_with_limi
 pub impl @lib.AsyncWrite for DescriptorProto_ReservedRange with fn write(self: DescriptorProto_ReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.async_write_varint(8UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.end is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
@@ -897,17 +937,17 @@ pub impl @lib.Read for DescriptorProto with fn read_with_limit(reader : @lib.Lim
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
-      (6, _) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
-      (3, _) => msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto))
-      (4, _) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
-      (5, _) => msg.extension_range.push((reader |> @lib.read_message() : DescriptorProto_ExtensionRange))
-      (8, _) => msg.oneof_decl.push((reader |> @lib.read_message() : OneofDescriptorProto))
-      (7, _) => msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
-      (9, _) => msg.reserved_range.push((reader |> @lib.read_message() : DescriptorProto_ReservedRange))
+      (2, 2) => msg.field.push((reader |> @lib.read_message() : FieldDescriptorProto))
+      (6, 2) => msg.extension.push((reader |> @lib.read_message() : FieldDescriptorProto))
+      (3, 2) => msg.nested_type.push((reader |> @lib.read_message() : DescriptorProto))
+      (4, 2) => msg.enum_type.push((reader |> @lib.read_message() : EnumDescriptorProto))
+      (5, 2) => msg.extension_range.push((reader |> @lib.read_message() : DescriptorProto_ExtensionRange))
+      (8, 2) => msg.oneof_decl.push((reader |> @lib.read_message() : OneofDescriptorProto))
+      (7, 2) => msg.options = (reader |> @lib.read_message() : MessageOptions) |> Some
+      (9, 2) => msg.reserved_range.push((reader |> @lib.read_message() : DescriptorProto_ReservedRange))
       (10, _) => msg.reserved_name.push(reader |> @lib.read_string())
       (11, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -915,56 +955,67 @@ pub impl @lib.Read for DescriptorProto with fn read_with_limit(reader : @lib.Lim
 pub impl @lib.Write for DescriptorProto with fn write(self: DescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   for item in self.field {
     writer |> @lib.write_varint(18UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.extension {
     writer |> @lib.write_varint(50UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.nested_type {
     writer |> @lib.write_varint(26UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.enum_type {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.extension_range {
     writer |> @lib.write_varint(42UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.oneof_decl {
     writer |> @lib.write_varint(66UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(58UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.reserved_range {
     writer |> @lib.write_varint(74UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.reserved_name {
     writer |> @lib.write_varint(82UL)
+
     writer |> @lib.write_string(item)
 
   }
   if self.visibility is Some(v) {
     writer |> @lib.write_varint(88UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
@@ -1045,17 +1096,17 @@ pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(reader : @li
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.field.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-      (6, _) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
-      (3, _) => msg.nested_type.push((reader |> @lib.async_read_message() : DescriptorProto))
-      (4, _) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
-      (5, _) => msg.extension_range.push((reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange))
-      (8, _) => msg.oneof_decl.push((reader |> @lib.async_read_message() : OneofDescriptorProto))
-      (7, _) => msg.options = (reader |> @lib.async_read_message() : MessageOptions) |> Some
-      (9, _) => msg.reserved_range.push((reader |> @lib.async_read_message() : DescriptorProto_ReservedRange))
+      (2, 2) => msg.field.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+      (6, 2) => msg.extension.push((reader |> @lib.async_read_message() : FieldDescriptorProto))
+      (3, 2) => msg.nested_type.push((reader |> @lib.async_read_message() : DescriptorProto))
+      (4, 2) => msg.enum_type.push((reader |> @lib.async_read_message() : EnumDescriptorProto))
+      (5, 2) => msg.extension_range.push((reader |> @lib.async_read_message() : DescriptorProto_ExtensionRange))
+      (8, 2) => msg.oneof_decl.push((reader |> @lib.async_read_message() : OneofDescriptorProto))
+      (7, 2) => msg.options = (reader |> @lib.async_read_message() : MessageOptions) |> Some
+      (9, 2) => msg.reserved_range.push((reader |> @lib.async_read_message() : DescriptorProto_ReservedRange))
       (10, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
       (11, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1063,56 +1114,67 @@ pub impl @lib.AsyncRead for DescriptorProto with fn read_with_limit(reader : @li
 pub impl @lib.AsyncWrite for DescriptorProto with fn write(self: DescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   for item in self.field {
     writer |> @lib.async_write_varint(18UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.extension {
     writer |> @lib.async_write_varint(50UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.nested_type {
     writer |> @lib.async_write_varint(26UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.enum_type {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.extension_range {
     writer |> @lib.async_write_varint(42UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.oneof_decl {
     writer |> @lib.async_write_varint(66UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(58UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.reserved_range {
     writer |> @lib.async_write_varint(74UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.reserved_name {
     writer |> @lib.async_write_varint(82UL)
+
     writer |> @lib.async_write_string(item)
 
   }
   if self.visibility is Some(v) {
     writer |> @lib.async_write_varint(88UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
@@ -1208,7 +1270,7 @@ pub impl @lib.Read for ExtensionRangeOptions_Declaration with fn read_with_limit
       (3, _) => msg.type_ = reader |> @lib.read_string() |> Some
       (5, _) => msg.reserved = reader |> @lib.read_bool() |> Some
       (6, _) => msg.repeated = reader |> @lib.read_bool() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1216,26 +1278,31 @@ pub impl @lib.Read for ExtensionRangeOptions_Declaration with fn read_with_limit
 pub impl @lib.Write for ExtensionRangeOptions_Declaration with fn write(self: ExtensionRangeOptions_Declaration, writer : &@lib.Writer) -> Unit raise {
   if self.number is Some(v) {
     writer |> @lib.write_varint(8UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.full_name is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.type_ is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.reserved is Some(v) {
     writer |> @lib.write_varint(40UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.repeated is Some(v) {
     writer |> @lib.write_varint(48UL);
+
     writer |> @lib.write_bool(v)
 
   }
@@ -1290,7 +1357,7 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with fn read_with_
       (3, _) => msg.type_ = reader |> @lib.async_read_string() |> Some
       (5, _) => msg.reserved = reader |> @lib.async_read_bool() |> Some
       (6, _) => msg.repeated = reader |> @lib.async_read_bool() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1298,26 +1365,31 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions_Declaration with fn read_with_
 pub impl @lib.AsyncWrite for ExtensionRangeOptions_Declaration with fn write(self: ExtensionRangeOptions_Declaration, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.number is Some(v) {
     writer |> @lib.async_write_varint(8UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.full_name is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.type_ is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.reserved is Some(v) {
     writer |> @lib.async_write_varint(40UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.repeated is Some(v) {
     writer |> @lib.async_write_varint(48UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
@@ -1364,11 +1436,11 @@ pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(reader : @l
   let msg = ExtensionRangeOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-      (2, _) => msg.declaration.push((reader |> @lib.read_message() : ExtensionRangeOptions_Declaration))
-      (50, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      (2, 2) => msg.declaration.push((reader |> @lib.read_message() : ExtensionRangeOptions_Declaration))
+      (50, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (3, _) => msg.verification = reader |> @lib.read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1376,21 +1448,25 @@ pub impl @lib.Read for ExtensionRangeOptions with fn read_with_limit(reader : @l
 pub impl @lib.Write for ExtensionRangeOptions with fn write(self: ExtensionRangeOptions, writer : &@lib.Writer) -> Unit raise {
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.declaration {
     writer |> @lib.write_varint(18UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(402UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.verification is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
@@ -1435,11 +1511,11 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(reader
   let msg = ExtensionRangeOptions::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-      (2, _) => msg.declaration.push((reader |> @lib.async_read_message() : ExtensionRangeOptions_Declaration))
-      (50, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      (2, 2) => msg.declaration.push((reader |> @lib.async_read_message() : ExtensionRangeOptions_Declaration))
+      (50, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
       (3, _) => msg.verification = reader |> @lib.async_read_enum() |> ExtensionRangeOptions_VerificationState::from_enum |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1447,21 +1523,25 @@ pub impl @lib.AsyncRead for ExtensionRangeOptions with fn read_with_limit(reader
 pub impl @lib.AsyncWrite for ExtensionRangeOptions with fn write(self: ExtensionRangeOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.declaration {
     writer |> @lib.async_write_varint(18UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(402UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.verification is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
@@ -1737,9 +1817,9 @@ pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(reader : @li
       (7, _) => msg.default_value = reader |> @lib.read_string() |> Some
       (9, _) => msg.oneof_index = reader |> @lib.read_int32() |> Some
       (10, _) => msg.json_name = reader |> @lib.read_string() |> Some
-      (8, _) => msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
+      (8, 2) => msg.options = (reader |> @lib.read_message() : FieldOptions) |> Some
       (17, _) => msg.proto3_optional = reader |> @lib.read_bool() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1747,56 +1827,67 @@ pub impl @lib.Read for FieldDescriptorProto with fn read_with_limit(reader : @li
 pub impl @lib.Write for FieldDescriptorProto with fn write(self: FieldDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.number is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.label is Some(v) {
     writer |> @lib.write_varint(32UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.type_ is Some(v) {
     writer |> @lib.write_varint(40UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.type_name is Some(v) {
     writer |> @lib.write_varint(50UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.extendee is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.default_value is Some(v) {
     writer |> @lib.write_varint(58UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.oneof_index is Some(v) {
     writer |> @lib.write_varint(72UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.json_name is Some(v) {
     writer |> @lib.write_varint(82UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(66UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.proto3_optional is Some(v) {
     writer |> @lib.write_varint(136UL);
+
     writer |> @lib.write_bool(v)
 
   }
@@ -1885,9 +1976,9 @@ pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(reader 
       (7, _) => msg.default_value = reader |> @lib.async_read_string() |> Some
       (9, _) => msg.oneof_index = reader |> @lib.async_read_int32() |> Some
       (10, _) => msg.json_name = reader |> @lib.async_read_string() |> Some
-      (8, _) => msg.options = (reader |> @lib.async_read_message() : FieldOptions) |> Some
+      (8, 2) => msg.options = (reader |> @lib.async_read_message() : FieldOptions) |> Some
       (17, _) => msg.proto3_optional = reader |> @lib.async_read_bool() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1895,56 +1986,67 @@ pub impl @lib.AsyncRead for FieldDescriptorProto with fn read_with_limit(reader 
 pub impl @lib.AsyncWrite for FieldDescriptorProto with fn write(self: FieldDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.number is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.label is Some(v) {
     writer |> @lib.async_write_varint(32UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.type_ is Some(v) {
     writer |> @lib.async_write_varint(40UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.type_name is Some(v) {
     writer |> @lib.async_write_varint(50UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.extendee is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.default_value is Some(v) {
     writer |> @lib.async_write_varint(58UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.oneof_index is Some(v) {
     writer |> @lib.async_write_varint(72UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.json_name is Some(v) {
     writer |> @lib.async_write_varint(82UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(66UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.proto3_optional is Some(v) {
     writer |> @lib.async_write_varint(136UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
@@ -1980,8 +2082,8 @@ pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(reader : @li
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (2, 2) => msg.options = (reader |> @lib.read_message() : OneofOptions) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -1989,11 +2091,13 @@ pub impl @lib.Read for OneofDescriptorProto with fn read_with_limit(reader : @li
 pub impl @lib.Write for OneofDescriptorProto with fn write(self: OneofDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -2029,8 +2133,8 @@ pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(reader 
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.options = (reader |> @lib.async_read_message() : OneofOptions) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (2, 2) => msg.options = (reader |> @lib.async_read_message() : OneofOptions) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2038,11 +2142,13 @@ pub impl @lib.AsyncRead for OneofDescriptorProto with fn read_with_limit(reader 
 pub impl @lib.AsyncWrite for OneofDescriptorProto with fn write(self: OneofDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -2079,7 +2185,7 @@ pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with fn read_with_l
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.read_int32() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2087,11 +2193,13 @@ pub impl @lib.Read for EnumDescriptorProto_EnumReservedRange with fn read_with_l
 pub impl @lib.Write for EnumDescriptorProto_EnumReservedRange with fn write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.Writer) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.write_varint(8UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.end is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_int32(v)
 
   }
@@ -2128,7 +2236,7 @@ pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with fn read_w
     match (field_number, wire) {
       (1, _) => msg.start = reader |> @lib.async_read_int32() |> Some
       (2, _) => msg.end = reader |> @lib.async_read_int32() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2136,11 +2244,13 @@ pub impl @lib.AsyncRead for EnumDescriptorProto_EnumReservedRange with fn read_w
 pub impl @lib.AsyncWrite for EnumDescriptorProto_EnumReservedRange with fn write(self: EnumDescriptorProto_EnumReservedRange, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.start is Some(v) {
     writer |> @lib.async_write_varint(8UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.end is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
@@ -2200,12 +2310,12 @@ pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(reader : @lib
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.value.push((reader |> @lib.read_message() : EnumValueDescriptorProto))
-      (3, _) => msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
-      (4, _) => msg.reserved_range.push((reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange))
+      (2, 2) => msg.value.push((reader |> @lib.read_message() : EnumValueDescriptorProto))
+      (3, 2) => msg.options = (reader |> @lib.read_message() : EnumOptions) |> Some
+      (4, 2) => msg.reserved_range.push((reader |> @lib.read_message() : EnumDescriptorProto_EnumReservedRange))
       (5, _) => msg.reserved_name.push(reader |> @lib.read_string())
       (6, _) => msg.visibility = reader |> @lib.read_enum() |> SymbolVisibility::from_enum |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2213,31 +2323,37 @@ pub impl @lib.Read for EnumDescriptorProto with fn read_with_limit(reader : @lib
 pub impl @lib.Write for EnumDescriptorProto with fn write(self: EnumDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   for item in self.value {
     writer |> @lib.write_varint(18UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.reserved_range {
     writer |> @lib.write_varint(34UL)
+
     writer |> @lib.write_message(item)
 
   }
   for item in self.reserved_name {
     writer |> @lib.write_varint(42UL)
+
     writer |> @lib.write_string(item)
 
   }
   if self.visibility is Some(v) {
     writer |> @lib.write_varint(48UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
@@ -2293,12 +2409,12 @@ pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(reader :
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.value.push((reader |> @lib.async_read_message() : EnumValueDescriptorProto))
-      (3, _) => msg.options = (reader |> @lib.async_read_message() : EnumOptions) |> Some
-      (4, _) => msg.reserved_range.push((reader |> @lib.async_read_message() : EnumDescriptorProto_EnumReservedRange))
+      (2, 2) => msg.value.push((reader |> @lib.async_read_message() : EnumValueDescriptorProto))
+      (3, 2) => msg.options = (reader |> @lib.async_read_message() : EnumOptions) |> Some
+      (4, 2) => msg.reserved_range.push((reader |> @lib.async_read_message() : EnumDescriptorProto_EnumReservedRange))
       (5, _) => msg.reserved_name.push(reader |> @lib.async_read_string())
       (6, _) => msg.visibility = reader |> @lib.async_read_enum() |> SymbolVisibility::from_enum |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2306,31 +2422,37 @@ pub impl @lib.AsyncRead for EnumDescriptorProto with fn read_with_limit(reader :
 pub impl @lib.AsyncWrite for EnumDescriptorProto with fn write(self: EnumDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   for item in self.value {
     writer |> @lib.async_write_varint(18UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.reserved_range {
     writer |> @lib.async_write_varint(34UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   for item in self.reserved_name {
     writer |> @lib.async_write_varint(42UL)
+
     writer |> @lib.async_write_string(item)
 
   }
   if self.visibility is Some(v) {
     writer |> @lib.async_write_varint(48UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
@@ -2373,8 +2495,8 @@ pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(reader :
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.number = reader |> @lib.read_int32() |> Some
-      (3, _) => msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (3, 2) => msg.options = (reader |> @lib.read_message() : EnumValueOptions) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2382,16 +2504,19 @@ pub impl @lib.Read for EnumValueDescriptorProto with fn read_with_limit(reader :
 pub impl @lib.Write for EnumValueDescriptorProto with fn write(self: EnumValueDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.number is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -2433,8 +2558,8 @@ pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(rea
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.number = reader |> @lib.async_read_int32() |> Some
-      (3, _) => msg.options = (reader |> @lib.async_read_message() : EnumValueOptions) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (3, 2) => msg.options = (reader |> @lib.async_read_message() : EnumValueOptions) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2442,16 +2567,19 @@ pub impl @lib.AsyncRead for EnumValueDescriptorProto with fn read_with_limit(rea
 pub impl @lib.AsyncWrite for EnumValueDescriptorProto with fn write(self: EnumValueDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.number is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -2493,9 +2621,9 @@ pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(reader : @
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
-      (2, _) => msg.method_.push((reader |> @lib.read_message() : MethodDescriptorProto))
-      (3, _) => msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (2, 2) => msg.method_.push((reader |> @lib.read_message() : MethodDescriptorProto))
+      (3, 2) => msg.options = (reader |> @lib.read_message() : ServiceOptions) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2503,16 +2631,19 @@ pub impl @lib.Read for ServiceDescriptorProto with fn read_with_limit(reader : @
 pub impl @lib.Write for ServiceDescriptorProto with fn write(self: ServiceDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   for item in self.method_ {
     writer |> @lib.write_varint(18UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -2553,9 +2684,9 @@ pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(reade
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
-      (2, _) => msg.method_.push((reader |> @lib.async_read_message() : MethodDescriptorProto))
-      (3, _) => msg.options = (reader |> @lib.async_read_message() : ServiceOptions) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (2, 2) => msg.method_.push((reader |> @lib.async_read_message() : MethodDescriptorProto))
+      (3, 2) => msg.options = (reader |> @lib.async_read_message() : ServiceOptions) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2563,16 +2694,19 @@ pub impl @lib.AsyncRead for ServiceDescriptorProto with fn read_with_limit(reade
 pub impl @lib.AsyncWrite for ServiceDescriptorProto with fn write(self: ServiceDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   for item in self.method_ {
     writer |> @lib.async_write_varint(18UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -2634,10 +2768,10 @@ pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(reader : @l
       (1, _) => msg.name = reader |> @lib.read_string() |> Some
       (2, _) => msg.input_type = reader |> @lib.read_string() |> Some
       (3, _) => msg.output_type = reader |> @lib.read_string() |> Some
-      (4, _) => msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
+      (4, 2) => msg.options = (reader |> @lib.read_message() : MethodOptions) |> Some
       (5, _) => msg.client_streaming = reader |> @lib.read_bool() |> Some
       (6, _) => msg.server_streaming = reader |> @lib.read_bool() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2645,31 +2779,37 @@ pub impl @lib.Read for MethodDescriptorProto with fn read_with_limit(reader : @l
 pub impl @lib.Write for MethodDescriptorProto with fn write(self: MethodDescriptorProto, writer : &@lib.Writer) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.input_type is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.output_type is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.options is Some(v) {
     writer |> @lib.write_varint(34UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.client_streaming is Some(v) {
     writer |> @lib.write_varint(40UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.server_streaming is Some(v) {
     writer |> @lib.write_varint(48UL);
+
     writer |> @lib.write_bool(v)
 
   }
@@ -2727,10 +2867,10 @@ pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(reader
       (1, _) => msg.name = reader |> @lib.async_read_string() |> Some
       (2, _) => msg.input_type = reader |> @lib.async_read_string() |> Some
       (3, _) => msg.output_type = reader |> @lib.async_read_string() |> Some
-      (4, _) => msg.options = (reader |> @lib.async_read_message() : MethodOptions) |> Some
+      (4, 2) => msg.options = (reader |> @lib.async_read_message() : MethodOptions) |> Some
       (5, _) => msg.client_streaming = reader |> @lib.async_read_bool() |> Some
       (6, _) => msg.server_streaming = reader |> @lib.async_read_bool() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2738,31 +2878,37 @@ pub impl @lib.AsyncRead for MethodDescriptorProto with fn read_with_limit(reader
 pub impl @lib.AsyncWrite for MethodDescriptorProto with fn write(self: MethodDescriptorProto, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.name is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.input_type is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.output_type is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.options is Some(v) {
     writer |> @lib.async_write_varint(34UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.client_streaming is Some(v) {
     writer |> @lib.async_write_varint(40UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.server_streaming is Some(v) {
     writer |> @lib.async_write_varint(48UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
@@ -2974,9 +3120,9 @@ pub impl @lib.Read for FileOptions with fn read_with_limit(reader : @lib.Limited
       (41, _) => msg.php_namespace = reader |> @lib.read_string() |> Some
       (44, _) => msg.php_metadata_namespace = reader |> @lib.read_string() |> Some
       (45, _) => msg.ruby_package = reader |> @lib.read_string() |> Some
-      (50, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-      _ => reader |> @lib.skip_message_field(wire)
+      (50, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -2984,106 +3130,127 @@ pub impl @lib.Read for FileOptions with fn read_with_limit(reader : @lib.Limited
 pub impl @lib.Write for FileOptions with fn write(self: FileOptions, writer : &@lib.Writer) -> Unit raise {
   if self.java_package is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.java_outer_classname is Some(v) {
     writer |> @lib.write_varint(66UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.java_multiple_files is Some(v) {
     writer |> @lib.write_varint(80UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.java_generate_equals_and_hash is Some(v) {
     writer |> @lib.write_varint(160UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.java_string_check_utf8 is Some(v) {
     writer |> @lib.write_varint(216UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.optimize_for is Some(v) {
     writer |> @lib.write_varint(72UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.go_package is Some(v) {
     writer |> @lib.write_varint(90UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.cc_generic_services is Some(v) {
     writer |> @lib.write_varint(128UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.java_generic_services is Some(v) {
     writer |> @lib.write_varint(136UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.py_generic_services is Some(v) {
     writer |> @lib.write_varint(144UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(184UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.cc_enable_arenas is Some(v) {
     writer |> @lib.write_varint(248UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.objc_class_prefix is Some(v) {
     writer |> @lib.write_varint(290UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.csharp_namespace is Some(v) {
     writer |> @lib.write_varint(298UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.swift_prefix is Some(v) {
     writer |> @lib.write_varint(314UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.php_class_prefix is Some(v) {
     writer |> @lib.write_varint(322UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.php_namespace is Some(v) {
     writer |> @lib.write_varint(330UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.php_metadata_namespace is Some(v) {
     writer |> @lib.write_varint(354UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.ruby_package is Some(v) {
     writer |> @lib.write_varint(362UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(402UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -3232,9 +3399,9 @@ pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(reader : @lib.Li
       (41, _) => msg.php_namespace = reader |> @lib.async_read_string() |> Some
       (44, _) => msg.php_metadata_namespace = reader |> @lib.async_read_string() |> Some
       (45, _) => msg.ruby_package = reader |> @lib.async_read_string() |> Some
-      (50, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (50, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3242,106 +3409,127 @@ pub impl @lib.AsyncRead for FileOptions with fn read_with_limit(reader : @lib.Li
 pub impl @lib.AsyncWrite for FileOptions with fn write(self: FileOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.java_package is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.java_outer_classname is Some(v) {
     writer |> @lib.async_write_varint(66UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.java_multiple_files is Some(v) {
     writer |> @lib.async_write_varint(80UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.java_generate_equals_and_hash is Some(v) {
     writer |> @lib.async_write_varint(160UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.java_string_check_utf8 is Some(v) {
     writer |> @lib.async_write_varint(216UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.optimize_for is Some(v) {
     writer |> @lib.async_write_varint(72UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.go_package is Some(v) {
     writer |> @lib.async_write_varint(90UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.cc_generic_services is Some(v) {
     writer |> @lib.async_write_varint(128UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.java_generic_services is Some(v) {
     writer |> @lib.async_write_varint(136UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.py_generic_services is Some(v) {
     writer |> @lib.async_write_varint(144UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(184UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.cc_enable_arenas is Some(v) {
     writer |> @lib.async_write_varint(248UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.objc_class_prefix is Some(v) {
     writer |> @lib.async_write_varint(290UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.csharp_namespace is Some(v) {
     writer |> @lib.async_write_varint(298UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.swift_prefix is Some(v) {
     writer |> @lib.async_write_varint(314UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.php_class_prefix is Some(v) {
     writer |> @lib.async_write_varint(322UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.php_namespace is Some(v) {
     writer |> @lib.async_write_varint(330UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.php_metadata_namespace is Some(v) {
     writer |> @lib.async_write_varint(354UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.ruby_package is Some(v) {
     writer |> @lib.async_write_varint(362UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(402UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -3411,9 +3599,9 @@ pub impl @lib.Read for MessageOptions with fn read_with_limit(reader : @lib.Limi
       (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
       (7, _) => msg.map_entry = reader |> @lib.read_bool() |> Some
       (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
-      (12, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-      _ => reader |> @lib.skip_message_field(wire)
+      (12, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3421,36 +3609,43 @@ pub impl @lib.Read for MessageOptions with fn read_with_limit(reader : @lib.Limi
 pub impl @lib.Write for MessageOptions with fn write(self: MessageOptions, writer : &@lib.Writer) -> Unit raise {
   if self.message_set_wire_format is Some(v) {
     writer |> @lib.write_varint(8UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.no_standard_descriptor_accessor is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.map_entry is Some(v) {
     writer |> @lib.write_varint(56UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
     writer |> @lib.write_varint(88UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(98UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -3515,9 +3710,9 @@ pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(reader : @lib
       (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
       (7, _) => msg.map_entry = reader |> @lib.async_read_bool() |> Some
       (11, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
-      (12, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (12, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3525,36 +3720,43 @@ pub impl @lib.AsyncRead for MessageOptions with fn read_with_limit(reader : @lib
 pub impl @lib.AsyncWrite for MessageOptions with fn write(self: MessageOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.message_set_wire_format is Some(v) {
     writer |> @lib.async_write_varint(8UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.no_standard_descriptor_accessor is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.map_entry is Some(v) {
     writer |> @lib.async_write_varint(56UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
     writer |> @lib.async_write_varint(88UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(98UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -3809,7 +4011,7 @@ pub impl @lib.Read for FieldOptions_EditionDefault with fn read_with_limit(reade
     match (field_number, wire) {
       (3, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
       (2, _) => msg.value = reader |> @lib.read_string() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3817,11 +4019,13 @@ pub impl @lib.Read for FieldOptions_EditionDefault with fn read_with_limit(reade
 pub impl @lib.Write for FieldOptions_EditionDefault with fn write(self: FieldOptions_EditionDefault, writer : &@lib.Writer) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.value is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
@@ -3858,7 +4062,7 @@ pub impl @lib.AsyncRead for FieldOptions_EditionDefault with fn read_with_limit(
     match (field_number, wire) {
       (3, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
       (2, _) => msg.value = reader |> @lib.async_read_string() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3866,11 +4070,13 @@ pub impl @lib.AsyncRead for FieldOptions_EditionDefault with fn read_with_limit(
 pub impl @lib.AsyncWrite for FieldOptions_EditionDefault with fn write(self: FieldOptions_EditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.value is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
@@ -3921,7 +4127,7 @@ pub impl @lib.Read for FieldOptions_FeatureSupport with fn read_with_limit(reade
       (2, _) => msg.edition_deprecated = reader |> @lib.read_enum() |> Edition::from_enum |> Some
       (3, _) => msg.deprecation_warning = reader |> @lib.read_string() |> Some
       (4, _) => msg.edition_removed = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -3929,21 +4135,25 @@ pub impl @lib.Read for FieldOptions_FeatureSupport with fn read_with_limit(reade
 pub impl @lib.Write for FieldOptions_FeatureSupport with fn write(self: FieldOptions_FeatureSupport, writer : &@lib.Writer) -> Unit raise {
   if self.edition_introduced is Some(v) {
     writer |> @lib.write_varint(8UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.edition_deprecated is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.deprecation_warning is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.edition_removed is Some(v) {
     writer |> @lib.write_varint(32UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
@@ -3992,7 +4202,7 @@ pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with fn read_with_limit(
       (2, _) => msg.edition_deprecated = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
       (3, _) => msg.deprecation_warning = reader |> @lib.async_read_string() |> Some
       (4, _) => msg.edition_removed = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4000,21 +4210,25 @@ pub impl @lib.AsyncRead for FieldOptions_FeatureSupport with fn read_with_limit(
 pub impl @lib.AsyncWrite for FieldOptions_FeatureSupport with fn write(self: FieldOptions_FeatureSupport, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.edition_introduced is Some(v) {
     writer |> @lib.async_write_varint(8UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.edition_deprecated is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.deprecation_warning is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.edition_removed is Some(v) {
     writer |> @lib.async_write_varint(32UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
@@ -4132,11 +4346,11 @@ pub impl @lib.Read for FieldOptions with fn read_with_limit(reader : @lib.Limite
       (17, _) => msg.retention = reader |> @lib.read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
       (19, 2) => { let packed = reader |> @lib.read_packed(@lib.read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
       (19, 0) => msg.targets.push(reader |> @lib.read_enum() |> FieldOptions_OptionTargetType::from_enum)
-      (20, _) => msg.edition_defaults.push((reader |> @lib.read_message() : FieldOptions_EditionDefault))
-      (21, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (22, _) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-      _ => reader |> @lib.skip_message_field(wire)
+      (20, 2) => msg.edition_defaults.push((reader |> @lib.read_message() : FieldOptions_EditionDefault))
+      (21, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (22, 2) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4144,71 +4358,85 @@ pub impl @lib.Read for FieldOptions with fn read_with_limit(reader : @lib.Limite
 pub impl @lib.Write for FieldOptions with fn write(self: FieldOptions, writer : &@lib.Writer) -> Unit raise {
   if self.ctype is Some(v) {
     writer |> @lib.write_varint(8UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.packed is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.jstype is Some(v) {
     writer |> @lib.write_varint(48UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.lazy_ is Some(v) {
     writer |> @lib.write_varint(40UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.unverified_lazy is Some(v) {
     writer |> @lib.write_varint(120UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.weak is Some(v) {
     writer |> @lib.write_varint(80UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.debug_redact is Some(v) {
     writer |> @lib.write_varint(128UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.retention is Some(v) {
     writer |> @lib.write_varint(136UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   for item in self.targets {
     writer |> @lib.write_varint(152UL)
+
     writer |> @lib.write_enum(item.to_enum())
 
   }
   for item in self.edition_defaults {
     writer |> @lib.write_varint(162UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(170UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.feature_support is Some(v) {
     writer |> @lib.write_varint(178UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -4314,11 +4542,11 @@ pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(reader : @lib.L
       (17, _) => msg.retention = reader |> @lib.async_read_enum() |> FieldOptions_OptionRetention::from_enum |> Some
       (19, 2) => { let packed = reader |> @lib.async_read_packed(@lib.async_read_enum, None); for item in packed { msg.targets.push(FieldOptions_OptionTargetType::from_enum(item)) } }
       (19, 0) => msg.targets.push(reader |> @lib.async_read_enum() |> FieldOptions_OptionTargetType::from_enum)
-      (20, _) => msg.edition_defaults.push((reader |> @lib.async_read_message() : FieldOptions_EditionDefault))
-      (21, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (22, _) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (20, 2) => msg.edition_defaults.push((reader |> @lib.async_read_message() : FieldOptions_EditionDefault))
+      (21, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (22, 2) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4326,71 +4554,85 @@ pub impl @lib.AsyncRead for FieldOptions with fn read_with_limit(reader : @lib.L
 pub impl @lib.AsyncWrite for FieldOptions with fn write(self: FieldOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.ctype is Some(v) {
     writer |> @lib.async_write_varint(8UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.packed is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.jstype is Some(v) {
     writer |> @lib.async_write_varint(48UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.lazy_ is Some(v) {
     writer |> @lib.async_write_varint(40UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.unverified_lazy is Some(v) {
     writer |> @lib.async_write_varint(120UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.weak is Some(v) {
     writer |> @lib.async_write_varint(80UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.debug_redact is Some(v) {
     writer |> @lib.async_write_varint(128UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.retention is Some(v) {
     writer |> @lib.async_write_varint(136UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   for item in self.targets {
     writer |> @lib.async_write_varint(152UL)
+
     writer |> @lib.async_write_enum(item.to_enum())
 
   }
   for item in self.edition_defaults {
     writer |> @lib.async_write_varint(162UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(170UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.feature_support is Some(v) {
     writer |> @lib.async_write_varint(178UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -4425,9 +4667,9 @@ pub impl @lib.Read for OneofOptions with fn read_with_limit(reader : @lib.Limite
   let msg = OneofOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-      _ => reader |> @lib.skip_message_field(wire)
+      (1, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4435,11 +4677,13 @@ pub impl @lib.Read for OneofOptions with fn read_with_limit(reader : @lib.Limite
 pub impl @lib.Write for OneofOptions with fn write(self: OneofOptions, writer : &@lib.Writer) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.write_varint(10UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -4474,9 +4718,9 @@ pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(reader : @lib.L
   let msg = OneofOptions::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (1, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4484,11 +4728,13 @@ pub impl @lib.AsyncRead for OneofOptions with fn read_with_limit(reader : @lib.L
 pub impl @lib.AsyncWrite for OneofOptions with fn write(self: OneofOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(10UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -4544,9 +4790,9 @@ pub impl @lib.Read for EnumOptions with fn read_with_limit(reader : @lib.Limited
       (2, _) => msg.allow_alias = reader |> @lib.read_bool() |> Some
       (3, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
       (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.read_bool() |> Some
-      (7, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-      _ => reader |> @lib.skip_message_field(wire)
+      (7, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4554,26 +4800,31 @@ pub impl @lib.Read for EnumOptions with fn read_with_limit(reader : @lib.Limited
 pub impl @lib.Write for EnumOptions with fn write(self: EnumOptions, writer : &@lib.Writer) -> Unit raise {
   if self.allow_alias is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
     writer |> @lib.write_varint(48UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(58UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -4626,9 +4877,9 @@ pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(reader : @lib.Li
       (2, _) => msg.allow_alias = reader |> @lib.async_read_bool() |> Some
       (3, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
       (6, _) => msg.deprecated_legacy_json_field_conflicts = reader |> @lib.async_read_bool() |> Some
-      (7, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (7, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4636,26 +4887,31 @@ pub impl @lib.AsyncRead for EnumOptions with fn read_with_limit(reader : @lib.Li
 pub impl @lib.AsyncWrite for EnumOptions with fn write(self: EnumOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.allow_alias is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.deprecated_legacy_json_field_conflicts is Some(v) {
     writer |> @lib.async_write_varint(48UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(58UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -4709,11 +4965,11 @@ pub impl @lib.Read for EnumValueOptions with fn read_with_limit(reader : @lib.Li
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (2, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (2, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (3, _) => msg.debug_redact = reader |> @lib.read_bool() |> Some
-      (4, _) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-      _ => reader |> @lib.skip_message_field(wire)
+      (4, 2) => msg.feature_support = (reader |> @lib.read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4721,26 +4977,31 @@ pub impl @lib.Read for EnumValueOptions with fn read_with_limit(reader : @lib.Li
 pub impl @lib.Write for EnumValueOptions with fn write(self: EnumValueOptions, writer : &@lib.Writer) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(8UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.debug_redact is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.feature_support is Some(v) {
     writer |> @lib.write_varint(34UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -4791,11 +5052,11 @@ pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(reader : @l
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (1, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (2, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (2, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
       (3, _) => msg.debug_redact = reader |> @lib.async_read_bool() |> Some
-      (4, _) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (4, 2) => msg.feature_support = (reader |> @lib.async_read_message() : FieldOptions_FeatureSupport) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4803,26 +5064,31 @@ pub impl @lib.AsyncRead for EnumValueOptions with fn read_with_limit(reader : @l
 pub impl @lib.AsyncWrite for EnumValueOptions with fn write(self: EnumValueOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(8UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.debug_redact is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.feature_support is Some(v) {
     writer |> @lib.async_write_varint(34UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -4863,10 +5129,10 @@ pub impl @lib.Read for ServiceOptions with fn read_with_limit(reader : @lib.Limi
   let msg = ServiceOptions::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (34, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (34, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
       (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-      _ => reader |> @lib.skip_message_field(wire)
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4874,16 +5140,19 @@ pub impl @lib.Read for ServiceOptions with fn read_with_limit(reader : @lib.Limi
 pub impl @lib.Write for ServiceOptions with fn write(self: ServiceOptions, writer : &@lib.Writer) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.write_varint(274UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(264UL);
+
     writer |> @lib.write_bool(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -4923,10 +5192,10 @@ pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(reader : @lib
   let msg = ServiceOptions::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (34, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (34, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
       (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -4934,16 +5203,19 @@ pub impl @lib.AsyncRead for ServiceOptions with fn read_with_limit(reader : @lib
 pub impl @lib.AsyncWrite for ServiceOptions with fn write(self: ServiceOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(274UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(264UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -5036,9 +5308,9 @@ pub impl @lib.Read for MethodOptions with fn read_with_limit(reader : @lib.Limit
     match (field_number, wire) {
       (33, _) => msg.deprecated = reader |> @lib.read_bool() |> Some
       (34, _) => msg.idempotency_level = reader |> @lib.read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
-      (35, _) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
-      _ => reader |> @lib.skip_message_field(wire)
+      (35, 2) => msg.features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.read_message() : UninterpretedOption))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5046,21 +5318,25 @@ pub impl @lib.Read for MethodOptions with fn read_with_limit(reader : @lib.Limit
 pub impl @lib.Write for MethodOptions with fn write(self: MethodOptions, writer : &@lib.Writer) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.write_varint(264UL);
+
     writer |> @lib.write_bool(v)
 
   }
   if self.idempotency_level is Some(v) {
     writer |> @lib.write_varint(272UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.features is Some(v) {
     writer |> @lib.write_varint(282UL);
+
     writer |> @lib.write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.write_varint(7994UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -5107,9 +5383,9 @@ pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(reader : @lib.
     match (field_number, wire) {
       (33, _) => msg.deprecated = reader |> @lib.async_read_bool() |> Some
       (34, _) => msg.idempotency_level = reader |> @lib.async_read_enum() |> MethodOptions_IdempotencyLevel::from_enum |> Some
-      (35, _) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (999, _) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (35, 2) => msg.features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (999, 2) => msg.uninterpreted_option.push((reader |> @lib.async_read_message() : UninterpretedOption))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5117,21 +5393,25 @@ pub impl @lib.AsyncRead for MethodOptions with fn read_with_limit(reader : @lib.
 pub impl @lib.AsyncWrite for MethodOptions with fn write(self: MethodOptions, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.deprecated is Some(v) {
     writer |> @lib.async_write_varint(264UL);
+
     writer |> @lib.async_write_bool(v)
 
   }
   if self.idempotency_level is Some(v) {
     writer |> @lib.async_write_varint(272UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.features is Some(v) {
     writer |> @lib.async_write_varint(282UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   for item in self.uninterpreted_option {
     writer |> @lib.async_write_varint(7994UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -5164,7 +5444,7 @@ pub impl @lib.Read for UninterpretedOption_NamePart with fn read_with_limit(read
     match (field_number, wire) {
       (1, _) => msg.name_part = reader |> @lib.read_string()
       (2, _) => msg.is_extension = reader |> @lib.read_bool()
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5205,7 +5485,7 @@ pub impl @lib.AsyncRead for UninterpretedOption_NamePart with fn read_with_limit
     match (field_number, wire) {
       (1, _) => msg.name_part = reader |> @lib.async_read_string()
       (2, _) => msg.is_extension = reader |> @lib.async_read_bool()
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5276,14 +5556,14 @@ pub impl @lib.Read for UninterpretedOption with fn read_with_limit(reader : @lib
   let msg = UninterpretedOption::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (2, _) => msg.name.push((reader |> @lib.read_message() : UninterpretedOption_NamePart))
+      (2, 2) => msg.name.push((reader |> @lib.read_message() : UninterpretedOption_NamePart))
       (3, _) => msg.identifier_value = reader |> @lib.read_string() |> Some
       (4, _) => msg.positive_int_value = reader |> @lib.read_uint64() |> Some
       (5, _) => msg.negative_int_value = reader |> @lib.read_int64() |> Some
       (6, _) => msg.double_value = reader |> @lib.read_double() |> Some
       (7, _) => msg.string_value = reader |> @lib.read_bytes() |> Some
       (8, _) => msg.aggregate_value = reader |> @lib.read_string() |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5291,36 +5571,43 @@ pub impl @lib.Read for UninterpretedOption with fn read_with_limit(reader : @lib
 pub impl @lib.Write for UninterpretedOption with fn write(self: UninterpretedOption, writer : &@lib.Writer) -> Unit raise {
   for item in self.name {
     writer |> @lib.write_varint(18UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.identifier_value is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.positive_int_value is Some(v) {
     writer |> @lib.write_varint(32UL);
+
     writer |> @lib.write_uint64(v)
 
   }
   if self.negative_int_value is Some(v) {
     writer |> @lib.write_varint(40UL);
+
     writer |> @lib.write_int64(v)
 
   }
   if self.double_value is Some(v) {
     writer |> @lib.write_varint(49UL);
+
     writer |> @lib.write_double(v)
 
   }
   if self.string_value is Some(v) {
     writer |> @lib.write_varint(58UL);
+
     writer |> @lib.write_bytes(v)
 
   }
   if self.aggregate_value is Some(v) {
     writer |> @lib.write_varint(66UL);
+
     writer |> @lib.write_string(v)
 
   }
@@ -5380,14 +5667,14 @@ pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(reader :
   let msg = UninterpretedOption::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (2, _) => msg.name.push((reader |> @lib.async_read_message() : UninterpretedOption_NamePart))
+      (2, 2) => msg.name.push((reader |> @lib.async_read_message() : UninterpretedOption_NamePart))
       (3, _) => msg.identifier_value = reader |> @lib.async_read_string() |> Some
       (4, _) => msg.positive_int_value = reader |> @lib.async_read_uint64() |> Some
       (5, _) => msg.negative_int_value = reader |> @lib.async_read_int64() |> Some
       (6, _) => msg.double_value = reader |> @lib.async_read_double() |> Some
       (7, _) => msg.string_value = reader |> @lib.async_read_bytes() |> Some
       (8, _) => msg.aggregate_value = reader |> @lib.async_read_string() |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5395,36 +5682,43 @@ pub impl @lib.AsyncRead for UninterpretedOption with fn read_with_limit(reader :
 pub impl @lib.AsyncWrite for UninterpretedOption with fn write(self: UninterpretedOption, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.name {
     writer |> @lib.async_write_varint(18UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.identifier_value is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.positive_int_value is Some(v) {
     writer |> @lib.async_write_varint(32UL);
+
     writer |> @lib.async_write_uint64(v)
 
   }
   if self.negative_int_value is Some(v) {
     writer |> @lib.async_write_varint(40UL);
+
     writer |> @lib.async_write_int64(v)
 
   }
   if self.double_value is Some(v) {
     writer |> @lib.async_write_varint(49UL);
+
     writer |> @lib.async_write_double(v)
 
   }
   if self.string_value is Some(v) {
     writer |> @lib.async_write_varint(58UL);
+
     writer |> @lib.async_write_bytes(v)
 
   }
   if self.aggregate_value is Some(v) {
     writer |> @lib.async_write_varint(66UL);
+
     writer |> @lib.async_write_string(v)
 
   }
@@ -5902,7 +6196,7 @@ pub impl @lib.Read for FeatureSet with fn read_with_limit(reader : @lib.LimitedR
       (6, _) => msg.json_format = reader |> @lib.read_enum() |> FeatureSet_JsonFormat::from_enum |> Some
       (7, _) => msg.enforce_naming_style = reader |> @lib.read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some
       (8, _) => msg.default_symbol_visibility = reader |> @lib.read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -5910,41 +6204,49 @@ pub impl @lib.Read for FeatureSet with fn read_with_limit(reader : @lib.LimitedR
 pub impl @lib.Write for FeatureSet with fn write(self: FeatureSet, writer : &@lib.Writer) -> Unit raise {
   if self.field_presence is Some(v) {
     writer |> @lib.write_varint(8UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.enum_type is Some(v) {
     writer |> @lib.write_varint(16UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.repeated_field_encoding is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.utf8_validation is Some(v) {
     writer |> @lib.write_varint(32UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.message_encoding is Some(v) {
     writer |> @lib.write_varint(40UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.json_format is Some(v) {
     writer |> @lib.write_varint(48UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.enforce_naming_style is Some(v) {
     writer |> @lib.write_varint(56UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.default_symbol_visibility is Some(v) {
     writer |> @lib.write_varint(64UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
@@ -6017,7 +6319,7 @@ pub impl @lib.AsyncRead for FeatureSet with fn read_with_limit(reader : @lib.Lim
       (6, _) => msg.json_format = reader |> @lib.async_read_enum() |> FeatureSet_JsonFormat::from_enum |> Some
       (7, _) => msg.enforce_naming_style = reader |> @lib.async_read_enum() |> FeatureSet_EnforceNamingStyle::from_enum |> Some
       (8, _) => msg.default_symbol_visibility = reader |> @lib.async_read_enum() |> FeatureSet_VisibilityFeature_DefaultSymbolVisibility::from_enum |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6025,41 +6327,49 @@ pub impl @lib.AsyncRead for FeatureSet with fn read_with_limit(reader : @lib.Lim
 pub impl @lib.AsyncWrite for FeatureSet with fn write(self: FeatureSet, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.field_presence is Some(v) {
     writer |> @lib.async_write_varint(8UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.enum_type is Some(v) {
     writer |> @lib.async_write_varint(16UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.repeated_field_encoding is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.utf8_validation is Some(v) {
     writer |> @lib.async_write_varint(32UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.message_encoding is Some(v) {
     writer |> @lib.async_write_varint(40UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.json_format is Some(v) {
     writer |> @lib.async_write_varint(48UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.enforce_naming_style is Some(v) {
     writer |> @lib.async_write_varint(56UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.default_symbol_visibility is Some(v) {
     writer |> @lib.async_write_varint(64UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
@@ -6101,9 +6411,9 @@ pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (3, _) => msg.edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      (4, _) => msg.overridable_features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      (5, _) => msg.fixed_features = (reader |> @lib.read_message() : FeatureSet) |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      (4, 2) => msg.overridable_features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      (5, 2) => msg.fixed_features = (reader |> @lib.read_message() : FeatureSet) |> Some
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6111,16 +6421,19 @@ pub impl @lib.Read for FeatureSetDefaults_FeatureSetEditionDefault with fn read_
 pub impl @lib.Write for FeatureSetDefaults_FeatureSetEditionDefault with fn write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.Writer) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.overridable_features is Some(v) {
     writer |> @lib.write_varint(34UL);
+
     writer |> @lib.write_message(v)
 
   }
   if self.fixed_features is Some(v) {
     writer |> @lib.write_varint(42UL);
+
     writer |> @lib.write_message(v)
 
   }
@@ -6161,9 +6474,9 @@ pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn 
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
       (3, _) => msg.edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-      (4, _) => msg.overridable_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      (5, _) => msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (4, 2) => msg.overridable_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      (5, 2) => msg.fixed_features = (reader |> @lib.async_read_message() : FeatureSet) |> Some
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6171,16 +6484,19 @@ pub impl @lib.AsyncRead for FeatureSetDefaults_FeatureSetEditionDefault with fn 
 pub impl @lib.AsyncWrite for FeatureSetDefaults_FeatureSetEditionDefault with fn write(self: FeatureSetDefaults_FeatureSetEditionDefault, writer : &@lib.AsyncWriter) -> Unit raise {
   if self.edition is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.overridable_features is Some(v) {
     writer |> @lib.async_write_varint(34UL);
+
     writer |> @lib.async_write_message(v)
 
   }
   if self.fixed_features is Some(v) {
     writer |> @lib.async_write_varint(42UL);
+
     writer |> @lib.async_write_message(v)
 
   }
@@ -6221,10 +6537,10 @@ pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(reader : @lib.
   let msg = FeatureSetDefaults::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.defaults.push((reader |> @lib.read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
+      (1, 2) => msg.defaults.push((reader |> @lib.read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
       (4, _) => msg.minimum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
       (5, _) => msg.maximum_edition = reader |> @lib.read_enum() |> Edition::from_enum |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6232,16 +6548,19 @@ pub impl @lib.Read for FeatureSetDefaults with fn read_with_limit(reader : @lib.
 pub impl @lib.Write for FeatureSetDefaults with fn write(self: FeatureSetDefaults, writer : &@lib.Writer) -> Unit raise {
   for item in self.defaults {
     writer |> @lib.write_varint(10UL)
+
     writer |> @lib.write_message(item)
 
   }
   if self.minimum_edition is Some(v) {
     writer |> @lib.write_varint(32UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
   if self.maximum_edition is Some(v) {
     writer |> @lib.write_varint(40UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
@@ -6281,10 +6600,10 @@ pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(reader : 
   let msg = FeatureSetDefaults::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.defaults.push((reader |> @lib.async_read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
+      (1, 2) => msg.defaults.push((reader |> @lib.async_read_message() : FeatureSetDefaults_FeatureSetEditionDefault))
       (4, _) => msg.minimum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
       (5, _) => msg.maximum_edition = reader |> @lib.async_read_enum() |> Edition::from_enum |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6292,16 +6611,19 @@ pub impl @lib.AsyncRead for FeatureSetDefaults with fn read_with_limit(reader : 
 pub impl @lib.AsyncWrite for FeatureSetDefaults with fn write(self: FeatureSetDefaults, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.defaults {
     writer |> @lib.async_write_varint(10UL)
+
     writer |> @lib.async_write_message(item)
 
   }
   if self.minimum_edition is Some(v) {
     writer |> @lib.async_write_varint(32UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
   if self.maximum_edition is Some(v) {
     writer |> @lib.async_write_varint(40UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
@@ -6361,7 +6683,7 @@ pub impl @lib.Read for SourceCodeInfo_Location with fn read_with_limit(reader : 
       (3, _) => msg.leading_comments = reader |> @lib.read_string() |> Some
       (4, _) => msg.trailing_comments = reader |> @lib.read_string() |> Some
       (6, _) => msg.leading_detached_comments.push(reader |> @lib.read_string())
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6387,16 +6709,19 @@ pub impl @lib.Write for SourceCodeInfo_Location with fn write(self: SourceCodeIn
   }
   if self.leading_comments is Some(v) {
     writer |> @lib.write_varint(26UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.trailing_comments is Some(v) {
     writer |> @lib.write_varint(34UL);
+
     writer |> @lib.write_string(v)
 
   }
   for item in self.leading_detached_comments {
     writer |> @lib.write_varint(50UL)
+
     writer |> @lib.write_string(item)
 
   }
@@ -6453,7 +6778,7 @@ pub impl @lib.AsyncRead for SourceCodeInfo_Location with fn read_with_limit(read
       (3, _) => msg.leading_comments = reader |> @lib.async_read_string() |> Some
       (4, _) => msg.trailing_comments = reader |> @lib.async_read_string() |> Some
       (6, _) => msg.leading_detached_comments.push(reader |> @lib.async_read_string())
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6479,16 +6804,19 @@ pub impl @lib.AsyncWrite for SourceCodeInfo_Location with fn write(self: SourceC
   }
   if self.leading_comments is Some(v) {
     writer |> @lib.async_write_varint(26UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.trailing_comments is Some(v) {
     writer |> @lib.async_write_varint(34UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   for item in self.leading_detached_comments {
     writer |> @lib.async_write_varint(50UL)
+
     writer |> @lib.async_write_string(item)
 
   }
@@ -6517,8 +6845,8 @@ pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(reader : @lib.Limi
   let msg = SourceCodeInfo::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.location.push((reader |> @lib.read_message() : SourceCodeInfo_Location))
-      _ => reader |> @lib.skip_message_field(wire)
+      (1, 2) => msg.location.push((reader |> @lib.read_message() : SourceCodeInfo_Location))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6526,6 +6854,7 @@ pub impl @lib.Read for SourceCodeInfo with fn read_with_limit(reader : @lib.Limi
 pub impl @lib.Write for SourceCodeInfo with fn write(self: SourceCodeInfo, writer : &@lib.Writer) -> Unit raise {
   for item in self.location {
     writer |> @lib.write_varint(10UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -6555,8 +6884,8 @@ pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(reader : @lib
   let msg = SourceCodeInfo::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.location.push((reader |> @lib.async_read_message() : SourceCodeInfo_Location))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (1, 2) => msg.location.push((reader |> @lib.async_read_message() : SourceCodeInfo_Location))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6564,6 +6893,7 @@ pub impl @lib.AsyncRead for SourceCodeInfo with fn read_with_limit(reader : @lib
 pub impl @lib.AsyncWrite for SourceCodeInfo with fn write(self: SourceCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.location {
     writer |> @lib.async_write_varint(10UL)
+
     writer |> @lib.async_write_message(item)
 
   }
@@ -6666,7 +6996,7 @@ pub impl @lib.Read for GeneratedCodeInfo_Annotation with fn read_with_limit(read
       (3, _) => msg.begin = reader |> @lib.read_int32() |> Some
       (4, _) => msg.end = reader |> @lib.read_int32() |> Some
       (5, _) => msg.semantic = reader |> @lib.read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
-      _ => reader |> @lib.skip_message_field(wire)
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6683,21 +7013,25 @@ pub impl @lib.Write for GeneratedCodeInfo_Annotation with fn write(self: Generat
   }
   if self.source_file is Some(v) {
     writer |> @lib.write_varint(18UL);
+
     writer |> @lib.write_string(v)
 
   }
   if self.begin is Some(v) {
     writer |> @lib.write_varint(24UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.end is Some(v) {
     writer |> @lib.write_varint(32UL);
+
     writer |> @lib.write_int32(v)
 
   }
   if self.semantic is Some(v) {
     writer |> @lib.write_varint(40UL);
+
     writer |> @lib.write_enum(v.to_enum())
 
   }
@@ -6753,7 +7087,7 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo_Annotation with fn read_with_limit
       (3, _) => msg.begin = reader |> @lib.async_read_int32() |> Some
       (4, _) => msg.end = reader |> @lib.async_read_int32() |> Some
       (5, _) => msg.semantic = reader |> @lib.async_read_enum() |> GeneratedCodeInfo_Annotation_Semantic::from_enum |> Some
-      _ => reader |> @lib.async_skip_message_field(wire)
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6770,21 +7104,25 @@ pub impl @lib.AsyncWrite for GeneratedCodeInfo_Annotation with fn write(self: Ge
   }
   if self.source_file is Some(v) {
     writer |> @lib.async_write_varint(18UL);
+
     writer |> @lib.async_write_string(v)
 
   }
   if self.begin is Some(v) {
     writer |> @lib.async_write_varint(24UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.end is Some(v) {
     writer |> @lib.async_write_varint(32UL);
+
     writer |> @lib.async_write_int32(v)
 
   }
   if self.semantic is Some(v) {
     writer |> @lib.async_write_varint(40UL);
+
     writer |> @lib.async_write_enum(v.to_enum())
 
   }
@@ -6813,8 +7151,8 @@ pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(reader : @lib.L
   let msg = GeneratedCodeInfo::default()
   while (reader |> @lib.read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.annotation.push((reader |> @lib.read_message() : GeneratedCodeInfo_Annotation))
-      _ => reader |> @lib.skip_message_field(wire)
+      (1, 2) => msg.annotation.push((reader |> @lib.read_message() : GeneratedCodeInfo_Annotation))
+      _ => reader |> @lib.skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6822,6 +7160,7 @@ pub impl @lib.Read for GeneratedCodeInfo with fn read_with_limit(reader : @lib.L
 pub impl @lib.Write for GeneratedCodeInfo with fn write(self: GeneratedCodeInfo, writer : &@lib.Writer) -> Unit raise {
   for item in self.annotation {
     writer |> @lib.write_varint(10UL)
+
     writer |> @lib.write_message(item)
 
   }
@@ -6851,8 +7190,8 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(reader : @
   let msg = GeneratedCodeInfo::default()
   while (reader |> @lib.async_read_next_message_field()) is Some((field_number, wire)) {
     match (field_number, wire) {
-      (1, _) => msg.annotation.push((reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation))
-      _ => reader |> @lib.async_skip_message_field(wire)
+      (1, 2) => msg.annotation.push((reader |> @lib.async_read_message() : GeneratedCodeInfo_Annotation))
+      _ => reader |> @lib.async_skip_message_field_by_number(field_number, wire)
     }
   }
   msg
@@ -6860,6 +7199,7 @@ pub impl @lib.AsyncRead for GeneratedCodeInfo with fn read_with_limit(reader : @
 pub impl @lib.AsyncWrite for GeneratedCodeInfo with fn write(self: GeneratedCodeInfo, writer : &@lib.AsyncWriter) -> Unit raise {
   for item in self.annotation {
     writer |> @lib.async_write_varint(10UL)
+
     writer |> @lib.async_write_message(item)
 
   }


### PR DESCRIPTION
## Why

Protobuf editions expose the legacy group wire format through `features.message_encoding = DELIMITED`, and proto2 schemas can still contain `group` fields represented as `TYPE_GROUP` descriptors. The generator needs to handle both forms to preserve wire compatibility instead of rejecting those descriptors or emitting length-prefixed message fields.

## What Changed

- Add a field-envelope shape so payload handling is separated from field framing decisions such as scalar, packed, length-delimited, and delimited/group wire envelopes.
- Add runtime helpers for delimited message read/write/size and field-number-aware unknown group skipping.
- Lower edition `message_encoding = DELIMITED` and proto2 `TYPE_GROUP` through the same delimited message envelope path.
- Keep `LimitedReader` opaque so parser state for group boundaries is not exposed as public record fields.
- Add generated-code harness cases for edition delimited message fields and proto2 groups, including repeated groups, unknown group skipping, and async codecs.

## Scope

This is compatibility support for existing protobuf wire/schema behavior. It does not add a separate user-facing group abstraction, does not implement unrelated edition features such as UTF-8 validation controls, and leaves issue 55 as a verification-only concern for this branch.